### PR TITLE
fix: wire real Polymarket client in arb-binary entry point

### DIFF
--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -220,34 +220,13 @@ mkdir -p docs
 cp strategies/<name>/strategy.md docs/strategy-<name>.md
 ```
 
-2. Generate `src/main.ts` — a thin entry point that wires the strategy into
-   the shared runner. The entry point must:
-
-   - Import the strategy's factory function from `../strategies/<name>/main.js`
-   - Import the strategy's default config from `../strategies/<name>/config.js`
-   - Read `--dry-run` from `process.argv`
-   - Set runner config: poll interval from `POLL_INTERVAL_MS` env var (default
-     30 000 ms), base dir `.canon/execution`, state path `.canon/state.json`
-   - Create stub deps for executor and positions (dry-run safe)
-   - Wire scan deps from the project's API clients
-   - Call the factory to create the runner, then call `runner.start()`
-
-   Example structure (arb-binary):
-
-   ```typescript
-   import { createArbBinaryRunner } from "../strategies/arb-binary/main.js";
-   import { DEFAULT_ARB_BINARY_CONFIG } from "../strategies/arb-binary/config.js";
-   // ... config, stub deps, runner.start()
-   ```
-
-   The `strategies/<name>/main.ts` already imports `../../runner.js` — this
-   resolves correctly since the strategy dir is two levels below the project
-   root where `runner.ts` lives.
-
-3. Create the `src/` directory and write the entry point:
+2. Copy the strategy's pre-built entry point to `src/main.ts`. Each strategy
+   directory includes an `entry.ts` that wires the real API clients, config
+   defaults, and runner deps — no generation needed:
 
 ```bash
 mkdir -p src
+cp strategies/<name>/entry.ts src/main.ts
 ```
 
 4. Verify the entry point compiles:

--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -388,10 +388,8 @@ if [[ ! -f "src/main.ts" ]]; then
   exit 0
 fi
 
-if [[ ! -s .env ]]; then
-  echo "NEED_ENV"
-  exit 0
-fi
+# Create empty .env if missing (some strategies run without auth)
+touch .env
 
 bash "${DEGA_CORE_HOME:-${HOME}/.degacore}/scripts/canon-runner.sh" --dry-run &
 RUNNER_PID=$!
@@ -408,7 +406,6 @@ fi
 
 Handle the output:
 - `NO_ENTRY` → tell the user: `No entry point at src/main.ts — run strategy selection first (phase 5).`
-- `NEED_ENV` → tell the user: `Create a .env file with the API keys your strategy requires, then re-run.`
 - `OK <pid>` → print: `Runner started (PID <pid>, dry-run). Stop: kill <pid>`
 - `FAIL` → print the log tail, nothing else.
 

--- a/canon/templates/client-polymarket.ts
+++ b/canon/templates/client-polymarket.ts
@@ -22,6 +22,8 @@ export interface PolymarketMatch {
   question: string;
   yesPrice: number;
   noPrice: number;
+  yesTokenId: string;
+  noTokenId: string;
   resolutionDate?: string;
 }
 
@@ -193,16 +195,19 @@ export async function searchMarkets(
     // "Not Indiana Pacers"), not "Yes"/"No". Any 2-outcome market is
     // binary: first outcome = affirmative, second = negative.
     if (m.outcomes.length !== 2) continue;
-    const yesPrice = m.outcomes[0]?.price;
-    const noPrice = m.outcomes[1]?.price;
-    if (yesPrice === undefined || noPrice === undefined) continue;
+    const yesOutcome = m.outcomes[0];
+    const noOutcome = m.outcomes[1];
+    if (!yesOutcome || !noOutcome) continue;
+    if (yesOutcome.price === undefined || noOutcome.price === undefined) continue;
 
     const resDate = m.resolutionDate?.toISOString();
     results.push({
       conditionId: m.marketId,
       question: m.title,
-      yesPrice,
-      noPrice,
+      yesPrice: yesOutcome.price,
+      noPrice: noOutcome.price,
+      yesTokenId: yesOutcome.outcomeId,
+      noTokenId: noOutcome.outcomeId,
       ...(resDate !== undefined ? { resolutionDate: resDate } : {}),
     });
   }

--- a/canon/templates/runner.ts
+++ b/canon/templates/runner.ts
@@ -89,6 +89,13 @@ export function createRunner(
   let running = false;
   let stopRequested = false;
   let sigintHandler: (() => void) | null = null;
+  let cycleCount = 0;
+  let signalCount = 0;
+  let errorCount = 0;
+
+  function out(tag: string, msg: string): void {
+    process.stdout.write(`${tag} ${msg}\n`);
+  }
 
   async function processSignal(
     signal: TradeSignal,
@@ -100,6 +107,13 @@ export function createRunner(
         size: signal.size,
         confidence: signal.confidence,
       }),
+    );
+
+    signalCount++;
+    out(
+      "SIGNAL",
+      `${signal.automation_id} ${signal.market.market_id} ` +
+        `${signal.direction} confidence=${String(signal.confidence)}`,
     );
 
     const decision = deps.risk.preTradeCheck(signal, portfolio);
@@ -155,11 +169,21 @@ export function createRunner(
   }
 
   async function cycle(): Promise<void> {
+    cycleCount++;
+    out("SCAN", `Cycle ${String(cycleCount)}`);
+
     const portfolio = await deps.positions.reconcile();
     const signals = await deps.strategy();
 
     for (const signal of signals) {
       await processSignal(signal, portfolio);
+    }
+
+    if (signals.length === 0) {
+      out(
+        "NO_EDGE",
+        `Cycle ${String(cycleCount)} — 0 signals, no edges`,
+      );
     }
   }
 
@@ -172,6 +196,11 @@ export function createRunner(
     stopRequested = false;
 
     sigintHandler = () => {
+      out(
+        "STOP",
+        `Shutting down — ${String(cycleCount)} cycles, ` +
+          `${String(signalCount)} signals, ${String(errorCount)} errors`,
+      );
       stop();
     };
     process.on("SIGINT", sigintHandler);
@@ -181,8 +210,10 @@ export function createRunner(
         try {
           await cycle();
         } catch (err: unknown) {
+          errorCount++;
           const message =
             err instanceof Error ? err.message : String(err);
+          out("SCAN_ERROR", `Cycle ${String(cycleCount)} — ${message}`);
           deps.log(
             logEntry("error", "runner", "", {
               error: message,

--- a/canon/templates/strategies/arb-binary/entry.ts
+++ b/canon/templates/strategies/arb-binary/entry.ts
@@ -1,0 +1,82 @@
+/**
+ * ARB-01 Binary Arbitrage — Project Entry Point
+ *
+ * This file is copied to src/main.ts by canon-start when the user
+ * selects the arb-binary strategy. It wires the real Polymarket
+ * client into the strategy's scan layer.
+ */
+
+import { createArbBinaryRunner } from "../strategies/arb-binary/main.js";
+import { DEFAULT_ARB_BINARY_CONFIG } from "../strategies/arb-binary/config.js";
+import {
+  searchMarkets as polySearchMarkets,
+  fetchOrderBook as polyFetchOrderBook,
+} from "../client-polymarket.js";
+import type { ArbBinaryRunnerConfig } from "../strategies/arb-binary/main.js";
+import type { ScanSearchResult } from "../strategies/arb-binary/scan.js";
+import type { ExecutorDeps, PositionDeps } from "../runner.js";
+import type { Portfolio } from "../types/RiskInterface.js";
+
+const dryRun = process.argv.includes("--dry-run");
+const pollIntervalMs =
+  Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
+
+const config: ArbBinaryRunnerConfig = {
+  strategy: DEFAULT_ARB_BINARY_CONFIG,
+  runner: {
+    pollIntervalMs,
+    dryRun,
+    baseDir: ".canon/execution",
+    statePath: ".canon/state.json",
+  },
+  maxConsecutiveLosses: 3,
+};
+
+const stubExecutor: ExecutorDeps = {
+  async submit(signal) {
+    console.info("[dry-run] would submit:", signal.automation_id);
+    return { id: "dry-run", status: "simulated" };
+  },
+};
+
+const emptyPortfolio: Portfolio = {
+  total_value: config.strategy.bankroll,
+  positions: [],
+  daily_pnl: 0,
+};
+
+const stubPositions: PositionDeps = {
+  async reconcile() {
+    return emptyPortfolio;
+  },
+  getPortfolio() {
+    return emptyPortfolio;
+  },
+};
+
+const runner = createArbBinaryRunner(config, {
+  scan: {
+    async searchMarkets(query: string): Promise<ScanSearchResult[]> {
+      const markets = await polySearchMarkets(query);
+      return markets.map((m) => ({
+        conditionId: m.conditionId,
+        question: m.question,
+        yesTokenId: m.yesTokenId,
+        noTokenId: m.noTokenId,
+      }));
+    },
+    fetchOrderBook: polyFetchOrderBook,
+  },
+  executor: stubExecutor,
+  positions: stubPositions,
+});
+
+process.stdout.write(
+  `START ARB-01 scanner (${dryRun ? "dry-run" : "live"}) poll=${String(pollIntervalMs)}ms\n`,
+);
+
+runner.start().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stdout.write(`SCAN_ERROR ${msg}\n`);
+  process.exitCode = 1;
+});

--- a/canon/templates/tsconfig.json
+++ b/canon/templates/tsconfig.json
@@ -16,5 +16,5 @@
     "declaration": true
   },
   "include": ["*.ts", "**/*.ts"],
-  "exclude": ["dist", "node_modules", "nba-momentum"]
+  "exclude": ["dist", "node_modules", "nba-momentum", "strategies/*/entry.ts"]
 }

--- a/commands/apply-core.md
+++ b/commands/apply-core.md
@@ -118,6 +118,7 @@ Files available:
 - `canon/cli/commands/kill.ts`
 - `canon/cli/commands/help.ts`
 - `canon/skills/canon-cli.md`
+- `canon/templates/` (entire directory — project shell copied wholesale by scaffold)
 
 ---
 
@@ -284,10 +285,11 @@ Components:
   Requires Orchestrator. Invoke via
   `~/.degacore/scripts/planner-loop.sh`.
   (opt-in; recommended when `~/.degacore/scripts/planner-loop.sh` is missing)
-- **Canon Bootstrap** — launcher, scaffold scripts, and CLI for Canon
-  prediction market projects. Installs `canon-scaffold.sh` (deterministic
-  project scaffolder called by `/canon-start`), `canon.sh` (reference copy
-  of the local tmux launcher written by `/canon-init`), and the Canon CLI
+- **Canon Bootstrap** — launcher, scaffold scripts, project templates, and CLI
+  for Canon prediction market projects. Installs `canon-scaffold.sh`
+  (deterministic project scaffolder called by `/canon-start`), `canon.sh`
+  (tmux launcher), `canon/templates/` (complete project shell with shared
+  runner, types, clients, and strategy modules like arb-binary), and the Canon CLI
   (`canon-cli`) — an agent-callable TypeScript tool for querying markets,
   managing positions, and executing trades on Polymarket. The CLI is built
   with `pnpm install` and linked to `~/.degacore/bin/canon-cli`. Add
@@ -537,7 +539,30 @@ Write each file to `~/.degacore/scripts/`:
 
 Run `chmod +x ~/.degacore/scripts/canon-scaffold.sh ~/.degacore/scripts/canon.sh` after writing.
 
-Safe to overwrite — these are engine scripts with no user customization.
+Clone the `canon/templates/` directory to `~/.degacore/canon/templates/`. This is
+the project shell that `canon-scaffold.sh` copies wholesale into new projects.
+Instead of fetching files individually, use `gh` to download the directory:
+
+```bash
+rm -rf ~/.degacore/canon/templates
+mkdir -p ~/.degacore/canon
+cd /tmp && rm -rf _canon_tpl && mkdir _canon_tpl && cd _canon_tpl
+gh api repos/DEGAorg/claude-code-config/tarball/develop \
+  --header 'Accept: application/vnd.github+json' > repo.tar.gz
+tar xzf repo.tar.gz --strip-components=1
+cp -R canon/templates ~/.degacore/canon/templates
+cd / && rm -rf /tmp/_canon_tpl
+```
+
+Verify the templates are present:
+```bash
+test -f ~/.degacore/canon/templates/runner.ts && \
+test -f ~/.degacore/canon/templates/package.json && \
+test -d ~/.degacore/canon/templates/strategies/arb-binary && \
+echo "templates OK" || echo "templates MISSING"
+```
+
+Safe to overwrite — these are template files with no user customization.
 
 #### Canon CLI
 

--- a/scripts/canon-scaffold.sh
+++ b/scripts/canon-scaffold.sh
@@ -141,6 +141,7 @@ for f in \
   runner.ts \
   strategies/arb-binary/signal.ts \
   strategies/arb-binary/main.ts \
+  strategies/arb-binary/entry.ts \
   package.json \
   tsconfig.json \
   vitest.config.ts \


### PR DESCRIPTION
## Summary
- arb-binary entry.ts wires real `searchMarkets`/`fetchOrderBook` from client-polymarket.ts (was stubbed with empty arrays → 0 cycles)
- `PolymarketMatch` now includes `yesTokenId`/`noTokenId` for CLOB order book fetching
- Shared `runner.ts` emits stdout protocol tags (SCAN, NO_EDGE, SIGNAL, SCAN_ERROR, STOP) for canon-runner.sh dashboard
- canon-start.md copies `entry.ts` from strategy dir instead of generating stubs

## Test plan
- [ ] `pnpm exec tsc --noEmit` in canon/templates exits 0
- [ ] `/canon-init` + `/canon-start` → select arb-binary → runner produces cycles with SCAN/NO_EDGE tags
- [ ] canon-runner.sh dashboard shows cycle/signal/error counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)