### PR TITLE
fix: arb-binary runtime fixes + flow.json

### DIFF
--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -229,6 +229,12 @@ mkdir -p src
 cp strategies/<name>/entry.ts src/main.ts
 ```
 
+3. Copy the strategy's flow definition for the TUI pipeline diagram:
+
+```bash
+cp strategies/<name>/flow.json .canon/flow.json 2>/dev/null || true
+```
+
 4. Verify the entry point compiles:
 
 ```bash

--- a/canon/templates/package.json
+++ b/canon/templates/package.json
@@ -14,7 +14,8 @@
     "node": ">=22"
   },
   "dependencies": {
-    "pmxtjs": "2.22.1"
+    "pmxtjs": "2.22.1",
+    "pmxt-core": "2.22.1"
   },
   "devDependencies": {
     "oxlint": "1.60.0",

--- a/canon/templates/pnpm-lock.yaml
+++ b/canon/templates/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      pmxt-core:
+        specifier: 2.22.1
+        version: 2.22.1(@types/node@25.6.0)(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@6.0.6)
       pmxtjs:
         specifier: 2.22.1
         version: 2.22.1(@types/node@25.6.0)(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@6.0.6)
@@ -3805,7 +3808,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -3974,7 +3977,7 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 25.6.0
 
   '@types/ws@8.18.1':
     dependencies:

--- a/canon/templates/runner.ts
+++ b/canon/templates/runner.ts
@@ -4,6 +4,8 @@
  * and structured execution logging.
  */
 
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 import type { TradeSignal } from "./types/TradeSignal.js";
 import type { RiskInterface, Portfolio } from "./types/RiskInterface.js";
 import type { ExecutionLogEntry } from "./execution-log.js";
@@ -97,6 +99,31 @@ export function createRunner(
     process.stdout.write(`${tag} ${msg}\n`);
   }
 
+  const flowPath = join(
+    config.baseDir.replace(/\/execution$/, ""),
+    "flow.json",
+  );
+
+  function updateFlow(
+    active: string,
+    completed: string[],
+  ): void {
+    if (!existsSync(flowPath)) return;
+    try {
+      const flow = JSON.parse(readFileSync(flowPath, "utf-8")) as {
+        steps: string[];
+        labels: Record<string, string>;
+        active: string;
+        completed: string[];
+      };
+      flow.active = active;
+      flow.completed = completed;
+      writeFileSync(flowPath, JSON.stringify(flow, null, 2) + "\n");
+    } catch {
+      // flow.json missing or malformed — skip silently
+    }
+  }
+
   async function processSignal(
     signal: TradeSignal,
     portfolio: Portfolio,
@@ -144,6 +171,7 @@ export function createRunner(
       return;
     }
 
+    updateFlow("execute", ["scan", "signal", "risk"]);
     try {
       const result = await deps.executor.submit(submittable);
       deps.log(
@@ -170,14 +198,20 @@ export function createRunner(
 
   async function cycle(): Promise<void> {
     cycleCount++;
+    updateFlow("scan", []);
     out("SCAN", `Cycle ${String(cycleCount)}`);
 
     const portfolio = await deps.positions.reconcile();
+
+    updateFlow("signal", ["scan"]);
     const signals = await deps.strategy();
 
     for (const signal of signals) {
+      updateFlow("risk", ["scan", "signal"]);
       await processSignal(signal, portfolio);
     }
+
+    updateFlow("log", ["scan", "signal", "risk", "execute"]);
 
     if (signals.length === 0) {
       out(
@@ -185,6 +219,8 @@ export function createRunner(
         `Cycle ${String(cycleCount)} — 0 signals, no edges`,
       );
     }
+
+    updateFlow("", ["scan", "signal", "risk", "execute", "log"]);
   }
 
   function stop(): void {

--- a/canon/templates/strategies/arb-binary/config.ts
+++ b/canon/templates/strategies/arb-binary/config.ts
@@ -9,7 +9,7 @@ import type { ArbBinaryConfig } from "./signal.js";
 
 /** C2 production defaults for ARB-01 binary arbitrage. */
 export const DEFAULT_ARB_BINARY_CONFIG: ArbBinaryConfig = {
-  category: "NBA",
+  category: "NBA Champion",
   kellyFraction: 0.25,
   maxExposure: 0.08,
   hurdleRate: 0.015,

--- a/canon/templates/strategies/arb-binary/entry.ts
+++ b/canon/templates/strategies/arb-binary/entry.ts
@@ -33,16 +33,21 @@ const risk = createRiskChecker({
 
 const strategy = async () => {
   const markets = await polySearchMarkets(strategyConfig.category);
-  const marketData: MarketData[] = markets.map((m) => ({
-    conditionId: m.conditionId,
-    question: m.question,
-    category: strategyConfig.category,
-    yesAsk: m.yesPrice,
-    noAsk: m.noPrice,
-    yesTokenId: m.yesTokenId ?? "",
-    noTokenId: m.noTokenId ?? "",
-    estimatedSlippage: 0,
-  }));
+  const marketData: MarketData[] = [];
+  for (const m of markets) {
+    // Skip dead markets with no liquidity
+    if (m.yesPrice <= 0 || m.noPrice <= 0) continue;
+    marketData.push({
+      conditionId: m.conditionId,
+      question: m.question,
+      category: strategyConfig.category,
+      yesAsk: m.yesPrice,
+      noAsk: m.noPrice,
+      yesTokenId: m.yesTokenId ?? "",
+      noTokenId: m.noTokenId ?? "",
+      estimatedSlippage: 0,
+    });
+  }
   return detectSignals(marketData, strategyConfig);
 };
 

--- a/canon/templates/strategies/arb-binary/entry.ts
+++ b/canon/templates/strategies/arb-binary/entry.ts
@@ -1,35 +1,49 @@
 /**
  * ARB-01 Binary Arbitrage — Project Entry Point
  *
- * This file is copied to src/main.ts by canon-start when the user
- * selects the arb-binary strategy. It wires the real Polymarket
- * client into the strategy's scan layer.
+ * Wires the real Polymarket client into the arb-binary strategy.
+ * Uses search result prices directly for signal detection — same
+ * pattern as the nba-momentum template. No order book calls needed
+ * for dry-run scanning.
  */
 
-import { createArbBinaryRunner } from "../strategies/arb-binary/main.js";
+import { createRunner } from "../runner.js";
+import { appendEntry } from "../execution-log.js";
+import { searchMarkets as polySearchMarkets } from "../client-polymarket.js";
+import { detectSignals } from "../strategies/arb-binary/signal.js";
 import { DEFAULT_ARB_BINARY_CONFIG } from "../strategies/arb-binary/config.js";
-import {
-  searchMarkets as polySearchMarkets,
-  fetchOrderBook as polyFetchOrderBook,
-} from "../client-polymarket.js";
-import type { ArbBinaryRunnerConfig } from "../strategies/arb-binary/main.js";
-import type { ScanSearchResult } from "../strategies/arb-binary/scan.js";
+import { createRiskChecker } from "../strategies/arb-binary/risk.js";
+import type { MarketData } from "../strategies/arb-binary/signal.js";
 import type { ExecutorDeps, PositionDeps } from "../runner.js";
 import type { Portfolio } from "../types/RiskInterface.js";
+import type { ExecutionLogEntry } from "../execution-log.js";
 
 const dryRun = process.argv.includes("--dry-run");
 const pollIntervalMs =
   Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
 
-const config: ArbBinaryRunnerConfig = {
-  strategy: DEFAULT_ARB_BINARY_CONFIG,
-  runner: {
-    pollIntervalMs,
-    dryRun,
-    baseDir: ".canon/execution",
-    statePath: ".canon/state.json",
-  },
+const strategyConfig = DEFAULT_ARB_BINARY_CONFIG;
+
+const risk = createRiskChecker({
+  bankroll: strategyConfig.bankroll,
+  kellyFraction: strategyConfig.kellyFraction,
+  maxExposure: strategyConfig.maxExposure,
   maxConsecutiveLosses: 3,
+});
+
+const strategy = async () => {
+  const markets = await polySearchMarkets(strategyConfig.category);
+  const marketData: MarketData[] = markets.map((m) => ({
+    conditionId: m.conditionId,
+    question: m.question,
+    category: strategyConfig.category,
+    yesAsk: m.yesPrice,
+    noAsk: m.noPrice,
+    yesTokenId: m.yesTokenId ?? "",
+    noTokenId: m.noTokenId ?? "",
+    estimatedSlippage: 0,
+  }));
+  return detectSignals(marketData, strategyConfig);
 };
 
 const stubExecutor: ExecutorDeps = {
@@ -40,7 +54,7 @@ const stubExecutor: ExecutorDeps = {
 };
 
 const emptyPortfolio: Portfolio = {
-  total_value: config.strategy.bankroll,
+  total_value: strategyConfig.bankroll,
   positions: [],
   daily_pnl: 0,
 };
@@ -54,22 +68,17 @@ const stubPositions: PositionDeps = {
   },
 };
 
-const runner = createArbBinaryRunner(config, {
-  scan: {
-    async searchMarkets(query: string): Promise<ScanSearchResult[]> {
-      const markets = await polySearchMarkets(query);
-      return markets.map((m) => ({
-        conditionId: m.conditionId,
-        question: m.question,
-        yesTokenId: m.yesTokenId,
-        noTokenId: m.noTokenId,
-      }));
-    },
-    fetchOrderBook: polyFetchOrderBook,
+const runner = createRunner(
+  { pollIntervalMs, dryRun, baseDir: ".canon/execution", statePath: ".canon/state.json" },
+  {
+    strategy,
+    risk,
+    executor: stubExecutor,
+    positions: stubPositions,
+    log: (entry: ExecutionLogEntry) =>
+      appendEntry(".canon/execution", entry),
   },
-  executor: stubExecutor,
-  positions: stubPositions,
-});
+);
 
 process.stdout.write(
   `START ARB-01 scanner (${dryRun ? "dry-run" : "live"}) poll=${String(pollIntervalMs)}ms\n`,

--- a/canon/templates/strategies/arb-binary/flow.json
+++ b/canon/templates/strategies/arb-binary/flow.json
@@ -1,0 +1,12 @@
+{
+  "steps": ["scan", "signal", "risk", "execute", "log"],
+  "labels": {
+    "scan": "Scan Markets",
+    "signal": "Detect Signal",
+    "risk": "Risk Check",
+    "execute": "Execute",
+    "log": "Log"
+  },
+  "active": "",
+  "completed": []
+}


### PR DESCRIPTION
## Summary
- Filter dead markets with zero prices (was causing 598 false signals)
- Narrow default category from "NBA" (875 results) to "NBA Champion" (30)
- Add pmxt-core as direct dep for pnpm sidecar binary hoisting
- Add flow.json for TUI pipeline diagram with real-time step animation
- Remove .env blocker for auth-free strategies

## Test plan
- [ ] Fresh dir → `/canon-init` → `/canon-start` → arb-binary → cycles with 0 false signals
- [ ] `.canon/flow.json` updates active/completed during cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)