### PR TITLE
fix(apply-core): add canon-cli onboard to install manifest

### DIFF
--- a/commands/apply-core.md
+++ b/commands/apply-core.md
@@ -116,6 +116,7 @@ Files available:
 - `canon/cli/commands/balance.ts`
 - `canon/cli/commands/order.ts`
 - `canon/cli/commands/kill.ts`
+- `canon/cli/commands/onboard.ts`
 - `canon/cli/commands/help.ts`
 - `canon/skills/canon-cli.md`
 - `canon/skills/polymarket.md`
@@ -578,6 +579,7 @@ Write each source file to `~/.degacore/canon-cli/`:
 - `canon/cli/commands/balance.ts` -> `~/.degacore/canon-cli/commands/balance.ts`
 - `canon/cli/commands/order.ts` -> `~/.degacore/canon-cli/commands/order.ts`
 - `canon/cli/commands/kill.ts` -> `~/.degacore/canon-cli/commands/kill.ts`
+- `canon/cli/commands/onboard.ts` -> `~/.degacore/canon-cli/commands/onboard.ts`
 - `canon/cli/commands/help.ts` -> `~/.degacore/canon-cli/commands/help.ts`
 
 Write the agent discovery skills:


### PR DESCRIPTION
Oversight from #182: \`canon/cli/commands/onboard.ts\` was registered in \`canon-cli.ts\` but never added to the install manifest. A user re-running \`/apply-core\` would get the onboard router but not the handler, breaking at runtime.

## Changes

- \`commands/apply-core.md\`: add \`canon/cli/commands/onboard.ts\` to both:
  - \`## Source\` / Files available list
  - Step 4 file-copy mapping (\`-> ~/.degacore/canon-cli/commands/onboard.ts\`)

One-line fix, zero ambiguity. Tested by re-reading the manifest vs the actual repo layout.

## After merge

Users should re-run \`/apply-core\` to pull down:
- Updated \`canon-cli.md\` and new \`polymarket.md\` skills globally
- New \`onboard.ts\` handler
- Updated \`help.ts\` with the global skills-dir fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)