### PR TITLE
sync: promote ace-work to develop (canon-cli session work + ace-work default)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,12 +257,26 @@ Active work:
 
 ## Working Conventions
 
+### Operating mode (read first every session)
+
+**Read `docs/agent-operating-mode.md`.** It defines the defaults for any agent working here: decide-and-move on reversible actions, self-verify before shipping (tsc + tests + lint + live smoke), cite with links, keep PRs focused, log follow-ups to `docs/exec-plans/tech-debt.md`. These rules hold across all sessions — do not re-derive them and do not ask the user to re-confirm them. If a rule is wrong for a situation, say so and propose an update to that doc.
+
+### Canon TUI wiring
+
+The Canon TUI (`DEGAorg/conductor-view`, separate repo) is not auto-wired to this repo's knowledge. See `canon/docs/tui-wiring.md` for what the TUI must do to access `canon-cli` commands and installed skills, and what it must NOT duplicate.
+
 ### Commit and push — prohibited
 
-- **Never push directly to `main` or `master`** — use feature branches and PRs.
+- **Never push directly to the project's trunk** (`main` / `master`, or whatever `github.pr_target` resolves to in this repo) — always open a PR.
 - **Never force-push** — no `git push --force` or `git push -f`.
 - **Never run `git reset --hard`** — use `git reset --soft` or revert instead.
 - Hooks in `settings.json` block these patterns; do not attempt them.
+
+### PR target
+
+**Never hardcode `main`.** Resolve the PR target dynamically: `github.pr_target` from `dega-core.yaml` → `develop` if the remote has it → `main`. See `docs/agent-operating-mode.md` § "PR target resolution" for the exact shell recipe.
+
+In this repo, `github.pr_target` is currently `ace-work`: open PRs against `ace-work`; the user promotes to `main` on their own schedule. Do not override this.
 
 ### Plans vs references
 
@@ -287,9 +301,9 @@ Active work:
 
 ### Session start
 
-Check `docs/exec-plans/active/` for in-progress plans before starting new work.
-Each plan is a directory — read `active/<slug>/plan.md`, find the first unchecked
-`[ ]` in the Progress log, and continue from there.
+1. Read `docs/agent-operating-mode.md` — the defaults for how to work here.
+2. Check `docs/exec-plans/active/` for in-progress plans. Each plan is a directory — read `active/<slug>/plan.md`, find the first unchecked `[ ]` in the Progress log, and continue from there.
+3. If the session is picking up a specific task (a GitHub issue, a PR review, a user request), proceed directly; do not re-plan from scratch.
 
 ### Orchestrator
 

--- a/POLYMARKET_TEST_HANDOFF.md
+++ b/POLYMARKET_TEST_HANDOFF.md
@@ -1,0 +1,118 @@
+# Polymarket Integration Test — Session Handoff
+
+Handoff doc to continue in a new Claude Code session from inside
+`/Users/cerratoa/dega/aidd/claude-code-config`.
+
+## Goal
+
+Get working, tested Polymarket integration code in Canon Automations and the
+base templates. Operate as autonomously as possible; only ask the user for
+input on items that genuinely require a human decision (wallet/auth, real-money
+approval).
+
+## Context carried over from prior session
+
+- Prior conversation was in `/Users/cerratoa/dega/canon-docs` (docs-only repo,
+  no code).
+- User clarified the actual code lives under a `canon/` directory — which
+  exists here at `/Users/cerratoa/dega/aidd/claude-code-config/canon/`.
+- Base templates and Canon Automations referenced by the user are expected to
+  be inside this repo — confirm by exploring `canon/` and anywhere else that
+  references `pmxt` / `polymarket`.
+
+## Key findings from the docs repo (for reference, don't re-research)
+
+Pulled from `/Users/cerratoa/dega/canon-docs`:
+
+### Wallet / auth model
+
+- **No dedicated wallet-security pattern doc exists.** `specs/SAS_Security_Future.md:75`
+  explicitly scopes private-key / wallet management **out** of the general
+  security model.
+- `specs/SAS_UI_Collaboration.md:263` mentions a "Secrets Wallet" UI concept
+  (Doppler / `pass`-backed) for exchange API keys — not seeds.
+- `Canon_Managed_Agents_Research.md:14,193` — wallet keys must stay local
+  (cannot traverse Anthropic infra).
+- `Canon_DEGA_Token_Integration.md:223` — wallet security scoped out of the
+  certification network.
+
+### Polymarket auth reality (important)
+
+- **API-key-only auth is NOT sufficient for order placement.** Polymarket CLOB
+  requires **EIP-712 per-order signing** (`Prediction_Sets_Protocol.md:213-219`).
+- Polymarket "API credentials" (L2 keys) are derived from an L1 signature and
+  authenticate requests, but each order payload still needs an EIP-712
+  signature from the signing EOA.
+- Current Canon pattern (`Canon_Polymarket_Automation_Guide.md:60-63`):
+  ```python
+  exchange = pmxt.Polymarket(
+      private_key=os.getenv('POLYMARKET_PRIVATE_KEY'),
+      proxy_address=os.getenv('POLYMARKET_PROXY_ADDRESS')
+  )
+  ```
+  → user's private key in env vars, plus the proxy wallet address.
+- Workshop 3 flags this as unvalidated:
+  `hackathon/workshops/session-3/workshop3-demo-scope.md:62,85,112`.
+- Safer pattern described for SetVault only (not documented as a general Canon
+  MCP pattern): `Prediction_Sets_Protocol.md:227-236` — Gnosis Safe where user
+  EOA is owner, Safe holds USDC, executor keys scoped to
+  `placeOrder` / `cancelOrder` only (no withdraw).
+
+### pmxt status
+
+- `Canon_Polymarket_Automation_Guide.md` reads as **aspirational** (docs say
+  `pip install pmxt` / `npm install pmxtjs`).
+- Prior session memory note: "pmxt/RPA not started."
+- **Verify first** whether the `canon/` directory here actually uses a real
+  `pmxt` package, a vendored local copy, or calls `py-clob-client` directly.
+  If pmxt is vendored/partial, the autonomous path is probably to go direct to
+  `py-clob-client` (Polymarket's official SDK) for the test spike.
+
+## Recommended plan (pending user confirmation on auth only)
+
+1. **Explore** `canon/` inside `claude-code-config/` — find Polymarket-related
+   code, base templates, any existing test harness. Also grep for `pmxt`,
+   `polymarket`, `py-clob` across the whole repo.
+2. **Identify** what already works vs. what's stubbed. Report a short punch list.
+3. **Stand up a minimal smoke test**:
+   - Fetch a live market list.
+   - Fetch order book for one market.
+   - Construct + sign a tiny limit order far from mid (no fill).
+   - Cancel it.
+   - Teardown.
+4. **Environment:** Polygon mainnet with ~$5 USDC in a burner EOA. Amoy
+   testnet is an option but has thin/no real markets, so mainnet-tiny is more
+   realistic.
+5. **Wire the validated flow into the base templates** once the smoke test
+   passes.
+6. **Do not** add abstraction, fallbacks, or speculative config. Bug fix / test
+   spike only (per global CLAUDE.md: no premature abstraction, no speculative
+   features).
+
+## What to ask the user (only these)
+
+- Which is preferred for the smoke test:
+  1. User provides an existing funded burner EOA private key + Polymarket
+     proxy address, OR
+  2. Agent generates a fresh burner wallet and user funds it with ~$5 USDC
+     on Polygon mainnet.
+- Are we OK placing a real (tiny, far-from-mid, immediately-cancelled) order
+  on mainnet, or does the user want strict read-only for the first pass?
+
+Everything else — SDK install, market fetch, signing, cancel, teardown, wiring
+to templates, tests — proceed autonomously.
+
+## Open gap worth flagging (not blocking this task)
+
+No Canon doc currently describes a "user pre-authorizes via Safe / session
+keys so the MCP never touches their seed" pattern as a general MCP convention.
+Prior session offered to draft one in `specs/` next to `SAS_Security_Future.md`
+— user did not yet accept. Revisit after the smoke test works.
+
+## Repo pointers
+
+- This repo (code + config): `/Users/cerratoa/dega/aidd/claude-code-config`
+- Docs repo (reference only): `/Users/cerratoa/dega/canon-docs`
+- Sibling repos that may also contain Polymarket code if `canon/` here turns
+  out to be empty of it: `nba-strategy`, `sports-arb`, `test-arb*`, `canon-tui`,
+  `core-test`, `dega`.

--- a/canon/AGENTS.md
+++ b/canon/AGENTS.md
@@ -98,14 +98,39 @@ that return structured JSON. Install via `/apply-core`.
 | `canon-cli market orderbook <id>` | Fetch order book depth | No |
 | `canon-cli market ohlcv <id>` | Fetch OHLCV candlestick data | No |
 | `canon-cli position list` | List open positions with PnL | Yes |
-| `canon-cli balance` | Fetch wallet balances | Yes |
-| `canon-cli order create` | Place a new order | Yes |
+| `canon-cli balance` | On-chain balance (USDC.e tradeable, USDC/USDT/POL with swap hints) | Yes |
+| `canon-cli onboard [--execute]` | Swap non-USDC.e assets to USDC.e via Uniswap v3 | Yes |
+| `canon-cli order create` | Place a new order (min size: 5 shares) | Yes |
 | `canon-cli order cancel <id>` | Cancel a specific order | Yes |
-| `canon-cli order list` | List recent trades | Yes |
+| `canon-cli order open` | List currently-open orders | Yes |
+| `canon-cli order trades` | List trade history | Yes |
 | `canon-cli kill [--yes]` | Cancel all open orders | Yes |
 | `canon-cli help [skill]` | Show skill reference | No |
 
 Full reference: `canon/skills/canon-cli.md`
+
+### Where skill knowledge lives
+
+Canon skills (`canon-cli.md`, `polymarket.md`) have **two on-disk
+locations** that agents read from:
+
+| Location | Who writes it | Who reads it |
+|---|---|---|
+| `canon/skills/*.md` (this repo) | PRs to this repo | Agents running **inside this repo** (e.g. Conductor workers in worktrees) |
+| `~/.degacore/config/skills/*.md` | `/apply-core` installer | Agents running **anywhere on the machine** (Claude Code's global skill loader, `canon-cli help` fallback, other Canon projects) |
+
+**Edit rule:** always edit `canon/skills/*.md` in this repo. `/apply-core`
+copies them to the global location. Never edit the installed copy — it
+gets overwritten on the next install.
+
+**`canon-cli help` resolution:** reads project-local `canon/skills/` when
+the binary lives inside a checkout of this repo; falls back to
+`~/.degacore/config/skills/` otherwise. See `canon/cli/commands/help.ts`.
+
+**Canon TUI (`DEGAorg/conductor-view`, Toad fork):** separate repo. It
+does not automatically inherit these skills. See `canon/docs/tui-wiring.md`
+for the wiring contract (`canon-cli` subprocess + JSON envelope, skill
+file locations, what not to vendor/reimplement).
 
 ## Key Workflows
 1. **Discover** (`/discover`): Market analysis → opportunity → strategy design

--- a/canon/cli/__tests__/balance.test.ts
+++ b/canon/cli/__tests__/balance.test.ts
@@ -8,13 +8,12 @@ import {
 } from "vitest";
 
 vi.mock("canon-templates/client-polymarket.js", () => ({
-  fetchBalance: vi.fn(),
+  fetchOnChainBalances: vi.fn(),
 }));
 
 const mockClient = await import("canon-templates/client-polymarket.js");
-const fetchBalance = vi.mocked(mockClient.fetchBalance);
+const fetchOnChainBalances = vi.mocked(mockClient.fetchOnChainBalances);
 
-// Capture stdout/stderr writes
 let stdoutData: string;
 let stderrData: string;
 
@@ -49,52 +48,65 @@ afterEach(() => {
 const { run } = await import("../commands/balance.js");
 
 describe("balance", () => {
-  it("returns wallet balances", async () => {
-    fetchBalance.mockResolvedValueOnce([
+  it("returns on-chain balances with USDC.e tradeable", async () => {
+    fetchOnChainBalances.mockResolvedValueOnce([
       {
-        currency: "USDC",
-        total: 1000,
-        available: 750,
-        locked: 250,
+        currency: "USDC.e",
+        address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        amount: 9.88,
+        tradeable: true,
+      },
+      {
+        currency: "POL",
+        address: "native",
+        amount: 21.5,
+        tradeable: false,
+        note: "for gas only",
       },
     ]);
 
     await run([]);
 
-    expect(fetchBalance).toHaveBeenCalled();
-
+    expect(fetchOnChainBalances).toHaveBeenCalled();
     const parsed = JSON.parse(stdoutData) as {
       ok: boolean;
       data: Array<{
         currency: string;
-        total: number;
-        available: number;
-        locked: number;
+        address: string;
+        amount: number;
+        tradeable: boolean;
+        note?: string;
       }>;
     };
     expect(parsed.ok).toBe(true);
-    expect(parsed.data).toHaveLength(1);
-    expect(parsed.data[0]).toEqual({
-      currency: "USDC",
-      total: 1000,
-      available: 750,
-      locked: 250,
-    });
+    expect(parsed.data).toHaveLength(2);
+    expect(parsed.data[0]?.currency).toBe("USDC.e");
+    expect(parsed.data[0]?.tradeable).toBe(true);
+    expect(parsed.data[1]?.currency).toBe("POL");
+    expect(parsed.data[1]?.tradeable).toBe(false);
   });
 
-  it("returns multiple currencies", async () => {
-    fetchBalance.mockResolvedValueOnce([
+  it("includes native USDC with swap hint when present", async () => {
+    fetchOnChainBalances.mockResolvedValueOnce([
       {
-        currency: "USDC",
-        total: 500,
-        available: 400,
-        locked: 100,
+        currency: "USDC.e",
+        address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        amount: 0,
+        tradeable: true,
       },
       {
-        currency: "ETH",
-        total: 2.5,
-        available: 2.0,
-        locked: 0.5,
+        currency: "USDC",
+        address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+        amount: 5.0,
+        tradeable: false,
+        note: "native USDC — swap to USDC.e to trade on Polymarket",
+      },
+      {
+        currency: "POL",
+        address: "native",
+        amount: 1.0,
+        tradeable: false,
+        note: "for gas only",
       },
     ]);
 
@@ -102,23 +114,12 @@ describe("balance", () => {
 
     const parsed = JSON.parse(stdoutData) as {
       ok: boolean;
-      data: unknown[];
+      data: Array<{ currency: string; tradeable: boolean; note?: string }>;
     };
-    expect(parsed.ok).toBe(true);
-    expect(parsed.data).toHaveLength(2);
-  });
-
-  it("returns empty array when no balances", async () => {
-    fetchBalance.mockResolvedValueOnce([]);
-
-    await run([]);
-
-    const parsed = JSON.parse(stdoutData) as {
-      ok: boolean;
-      data: unknown[];
-    };
-    expect(parsed.ok).toBe(true);
-    expect(parsed.data).toHaveLength(0);
+    expect(parsed.data).toHaveLength(3);
+    const native = parsed.data.find((b) => b.currency === "USDC");
+    expect(native?.tradeable).toBe(false);
+    expect(native?.note).toContain("swap");
   });
 
   it("requires auth", async () => {
@@ -129,26 +130,26 @@ describe("balance", () => {
     const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toMatch(/requires authentication/);
-    expect(fetchBalance).not.toHaveBeenCalled();
+    expect(fetchOnChainBalances).not.toHaveBeenCalled();
   });
 
-  it("handles API errors", async () => {
-    fetchBalance.mockRejectedValueOnce(new Error("Wallet not found"));
+  it("handles RPC errors", async () => {
+    fetchOnChainBalances.mockRejectedValueOnce(new Error("RPC unreachable"));
 
     await run([]);
 
     const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
     expect(parsed.ok).toBe(false);
-    expect(parsed.error).toBe("Wallet not found");
+    expect(parsed.error).toBe("RPC unreachable");
   });
 
   it("supports --pretty flag", async () => {
-    fetchBalance.mockResolvedValueOnce([
+    fetchOnChainBalances.mockResolvedValueOnce([
       {
-        currency: "USDC",
-        total: 100,
-        available: 80,
-        locked: 20,
+        currency: "USDC.e",
+        address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        amount: 100,
+        tradeable: true,
       },
     ]);
 

--- a/canon/cli/__tests__/market.test.ts
+++ b/canon/cli/__tests__/market.test.ts
@@ -98,6 +98,8 @@ describe("market subcommand", () => {
         question: "Will Bitcoin hit $100k?",
         yesPrice: 0.65,
         noPrice: 0.35,
+        yesTokenId: "yes-token-abc",
+        noTokenId: "no-token-abc",
         resolutionDate: "2026-12-31T00:00:00.000Z",
       },
     ];

--- a/canon/cli/__tests__/onboard.test.ts
+++ b/canon/cli/__tests__/onboard.test.ts
@@ -1,0 +1,267 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.mock("canon-templates/client-polymarket.js", () => ({
+  fetchOnChainBalances: vi.fn(),
+  swapToUsdce: vi.fn(),
+}));
+
+const mockClient = await import("canon-templates/client-polymarket.js");
+const fetchOnChainBalances = vi.mocked(mockClient.fetchOnChainBalances);
+const swapToUsdce = vi.mocked(mockClient.swapToUsdce);
+
+let stdoutData: string;
+let stderrData: string;
+
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+beforeEach(() => {
+  stdoutData = "";
+  stderrData = "";
+  process.stdout.write = ((chunk: string) => {
+    stdoutData += chunk;
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string) => {
+    stderrData += chunk;
+    return true;
+  }) as typeof process.stderr.write;
+  process.exitCode = undefined;
+  process.env["POLYMARKET_PRIVATE_KEY"] = "0xtest";
+  delete process.env["ONBOARD_POL_GAS_RESERVE"];
+});
+
+afterEach(() => {
+  process.stdout.write = originalStdoutWrite;
+  process.stderr.write = originalStderrWrite;
+  delete process.env["POLYMARKET_PRIVATE_KEY"];
+  vi.clearAllMocks();
+});
+
+const { run } = await import("../commands/onboard.js");
+
+describe("onboard", () => {
+  describe("plan mode (no --execute)", () => {
+    it("returns empty plan when only USDC.e + POL", async () => {
+      fetchOnChainBalances.mockResolvedValueOnce([
+        { currency: "USDC.e", address: "0x2791", amount: 10, tradeable: true },
+        { currency: "POL", address: "native", amount: 1.5, tradeable: false },
+      ]);
+
+      await run([]);
+
+      const parsed = JSON.parse(stdoutData) as {
+        ok: boolean;
+        data: { plan: unknown[]; executed: boolean };
+      };
+      expect(parsed.ok).toBe(true);
+      expect(parsed.data.plan).toHaveLength(0);
+      expect(parsed.data.executed).toBe(false);
+      expect(swapToUsdce).not.toHaveBeenCalled();
+    });
+
+    it("plans native USDC → USDC.e swap", async () => {
+      fetchOnChainBalances.mockResolvedValueOnce([
+        { currency: "USDC.e", address: "0x2791", amount: 0, tradeable: true },
+        {
+          currency: "USDC",
+          address: "0x3c49",
+          amount: 5,
+          tradeable: false,
+          note: "swap",
+        },
+        { currency: "POL", address: "native", amount: 1.5, tradeable: false },
+      ]);
+
+      await run([]);
+
+      const parsed = JSON.parse(stdoutData) as {
+        ok: boolean;
+        data: {
+          plan: Array<{ from: string; amount: number; reason: string }>;
+          executed: boolean;
+        };
+      };
+      expect(parsed.data.executed).toBe(false);
+      expect(parsed.data.plan).toHaveLength(1);
+      expect(parsed.data.plan[0]?.from).toBe("USDC");
+      expect(parsed.data.plan[0]?.amount).toBe(5);
+      expect(swapToUsdce).not.toHaveBeenCalled();
+    });
+
+    it("plans USDT and POL-excess swaps", async () => {
+      fetchOnChainBalances.mockResolvedValueOnce([
+        { currency: "USDC.e", address: "0x2791", amount: 0, tradeable: true },
+        {
+          currency: "USDT",
+          address: "0xc213",
+          amount: 3,
+          tradeable: false,
+          note: "swap",
+        },
+        { currency: "POL", address: "native", amount: 20, tradeable: false },
+      ]);
+
+      await run([]);
+
+      const parsed = JSON.parse(stdoutData) as {
+        ok: boolean;
+        data: { plan: Array<{ from: string; amount: number }> };
+      };
+      expect(parsed.data.plan).toHaveLength(2);
+      const usdt = parsed.data.plan.find((s) => s.from === "USDT");
+      const pol = parsed.data.plan.find((s) => s.from === "POL");
+      expect(usdt?.amount).toBe(3);
+      expect(pol?.amount).toBe(19); // 20 - 1 (default reserve)
+    });
+
+    it("respects ONBOARD_POL_GAS_RESERVE env var", async () => {
+      process.env["ONBOARD_POL_GAS_RESERVE"] = "10";
+      fetchOnChainBalances.mockResolvedValueOnce([
+        { currency: "USDC.e", address: "0x2791", amount: 0, tradeable: true },
+        { currency: "POL", address: "native", amount: 20, tradeable: false },
+      ]);
+
+      await run([]);
+
+      const parsed = JSON.parse(stdoutData) as {
+        ok: boolean;
+        data: { plan: Array<{ from: string; amount: number }> };
+      };
+      expect(parsed.data.plan).toHaveLength(1);
+      expect(parsed.data.plan[0]?.amount).toBe(10); // 20 - 10
+    });
+
+    it("skips POL swap when excess < 1", async () => {
+      fetchOnChainBalances.mockResolvedValueOnce([
+        { currency: "USDC.e", address: "0x2791", amount: 0, tradeable: true },
+        { currency: "POL", address: "native", amount: 1.5, tradeable: false },
+      ]);
+
+      await run([]);
+
+      const parsed = JSON.parse(stdoutData) as {
+        ok: boolean;
+        data: { plan: unknown[] };
+      };
+      expect(parsed.data.plan).toHaveLength(0);
+    });
+  });
+
+  describe("execute mode", () => {
+    it("calls swapToUsdce for each planned step", async () => {
+      fetchOnChainBalances.mockResolvedValueOnce([
+        { currency: "USDC.e", address: "0x2791", amount: 0, tradeable: true },
+        {
+          currency: "USDC",
+          address: "0x3c49",
+          amount: 5,
+          tradeable: false,
+          note: "swap",
+        },
+        { currency: "POL", address: "native", amount: 1.5, tradeable: false },
+      ]);
+      swapToUsdce.mockResolvedValueOnce({
+        from: "USDC",
+        amountIn: 5,
+        amountOut: 4.99,
+        txHash: "0xabc",
+      });
+
+      await run(["--execute"]);
+
+      const parsed = JSON.parse(stdoutData) as {
+        ok: boolean;
+        data: { executed: boolean; swaps: Array<{ from: string }> };
+      };
+      expect(parsed.data.executed).toBe(true);
+      expect(parsed.data.swaps).toHaveLength(1);
+      expect(parsed.data.swaps[0]?.from).toBe("USDC");
+      expect(swapToUsdce).toHaveBeenCalledWith("USDC", 5);
+    });
+  });
+
+  describe("single-asset mode", () => {
+    it("rejects missing --amount when --asset given", async () => {
+      await run(["--asset", "USDC"]);
+      const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatch(/asset.*amount/i);
+    });
+
+    it("rejects invalid --asset", async () => {
+      await run(["--asset", "ETH", "--amount", "1"]);
+      const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatch(/Invalid --asset/);
+    });
+
+    it("rejects non-positive --amount", async () => {
+      await run(["--asset", "USDC", "--amount", "-1"]);
+      const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatch(/Invalid --amount/);
+    });
+
+    it("plans single swap without --execute", async () => {
+      await run(["--asset", "USDT", "--amount", "2.5"]);
+      const parsed = JSON.parse(stdoutData) as {
+        ok: boolean;
+        data: { plan: Array<{ from: string; amount: number }> };
+      };
+      expect(parsed.data.plan[0]?.from).toBe("USDT");
+      expect(parsed.data.plan[0]?.amount).toBe(2.5);
+      expect(swapToUsdce).not.toHaveBeenCalled();
+    });
+
+    it("executes single swap with --execute", async () => {
+      swapToUsdce.mockResolvedValueOnce({
+        from: "USDT",
+        amountIn: 2.5,
+        amountOut: 2.49,
+        txHash: "0xdef",
+      });
+      await run(["--asset", "USDT", "--amount", "2.5", "--execute"]);
+      expect(swapToUsdce).toHaveBeenCalledWith("USDT", 2.5);
+      const parsed = JSON.parse(stdoutData) as {
+        ok: boolean;
+        data: { executed: boolean };
+      };
+      expect(parsed.data.executed).toBe(true);
+    });
+  });
+
+  it("requires auth", async () => {
+    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    await run([]);
+    const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/requires authentication/);
+    expect(fetchOnChainBalances).not.toHaveBeenCalled();
+  });
+
+  it("propagates swap errors", async () => {
+    fetchOnChainBalances.mockResolvedValueOnce([
+      { currency: "USDC.e", address: "0x2791", amount: 0, tradeable: true },
+      {
+        currency: "USDC",
+        address: "0x3c49",
+        amount: 5,
+        tradeable: false,
+        note: "swap",
+      },
+    ]);
+    swapToUsdce.mockRejectedValueOnce(new Error("insufficient gas"));
+    await run(["--execute"]);
+    const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toBe("insufficient gas");
+  });
+});

--- a/canon/cli/__tests__/order.test.ts
+++ b/canon/cli/__tests__/order.test.ts
@@ -294,15 +294,7 @@ describe("order cancel", () => {
   it("cancels an order by ID", async () => {
     cancelOrder.mockResolvedValueOnce({
       id: "ord-1",
-      marketId: "mkt-1",
-      outcomeId: "tok-1",
-      side: "buy",
-      type: "limit",
-      amount: 10,
-      price: 0.65,
       status: "cancelled",
-      filled: 3,
-      remaining: 7,
     });
 
     await run(["cancel", "ord-1"]);
@@ -347,7 +339,7 @@ describe("order cancel", () => {
   });
 });
 
-describe("order list", () => {
+describe("order trades", () => {
   it("lists trades", async () => {
     fetchMyTrades.mockResolvedValueOnce([
       {
@@ -367,7 +359,7 @@ describe("order list", () => {
       },
     ]);
 
-    await run(["list"]);
+    await run(["trades"]);
 
     expect(fetchMyTrades).toHaveBeenCalledWith({});
     const parsed = JSON.parse(stdoutData) as {
@@ -381,7 +373,7 @@ describe("order list", () => {
   it("passes --market-id filter", async () => {
     fetchMyTrades.mockResolvedValueOnce([]);
 
-    await run(["list", "--market-id", "mkt-42"]);
+    await run(["trades", "--market-id", "mkt-42"]);
 
     expect(fetchMyTrades).toHaveBeenCalledWith({ marketId: "mkt-42" });
   });
@@ -389,7 +381,7 @@ describe("order list", () => {
   it("passes --limit filter", async () => {
     fetchMyTrades.mockResolvedValueOnce([]);
 
-    await run(["list", "--limit", "5"]);
+    await run(["trades", "--limit", "5"]);
 
     expect(fetchMyTrades).toHaveBeenCalledWith({ limit: 5 });
   });
@@ -397,7 +389,7 @@ describe("order list", () => {
   it("passes both filters", async () => {
     fetchMyTrades.mockResolvedValueOnce([]);
 
-    await run(["list", "--market-id", "mkt-1", "--limit", "10"]);
+    await run(["trades", "--market-id", "mkt-1", "--limit", "10"]);
 
     expect(fetchMyTrades).toHaveBeenCalledWith({
       marketId: "mkt-1",
@@ -406,7 +398,7 @@ describe("order list", () => {
   });
 
   it("errors on invalid limit", async () => {
-    await run(["list", "--limit", "abc"]);
+    await run(["trades", "--limit", "abc"]);
 
     const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
     expect(parsed.ok).toBe(false);
@@ -417,7 +409,7 @@ describe("order list", () => {
   it("requires auth", async () => {
     delete process.env["POLYMARKET_PRIVATE_KEY"];
 
-    await run(["list"]);
+    await run(["trades"]);
 
     const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
     expect(parsed.ok).toBe(false);
@@ -428,7 +420,7 @@ describe("order list", () => {
   it("handles API errors", async () => {
     fetchMyTrades.mockRejectedValueOnce(new Error("Network error"));
 
-    await run(["list"]);
+    await run(["trades"]);
 
     const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
     expect(parsed.ok).toBe(false);

--- a/canon/cli/canon-cli.ts
+++ b/canon/cli/canon-cli.ts
@@ -14,6 +14,7 @@ const COMMANDS: Record<string, string> = {
   balance: "Fetch wallet balance",
   order: "Create, cancel, or list orders",
   kill: "Cancel all open orders (kill switch)",
+  onboard: "Swap non-USDC.e assets to USDC.e (plan or --execute)",
   help: "Show help for a topic or list available skills",
 };
 

--- a/canon/cli/commands/balance.ts
+++ b/canon/cli/commands/balance.ts
@@ -1,10 +1,15 @@
 /**
- * Balance subcommand — fetch wallet balance.
+ * Balance subcommand — fetch on-chain balances for the EOA on Polygon.
  *
  * Requires POLYMARKET_PRIVATE_KEY.
  *
  * Usage:
  *   canon-cli balance [--pretty]
+ *
+ * Reports three assets:
+ *   - USDC.e (bridged) — tradeable on Polymarket
+ *   - USDC (native)    — needs swap to USDC.e (only shown if non-zero)
+ *   - POL              — for gas
  */
 
 import { requireAuth, AuthError } from "../auth.js";
@@ -22,10 +27,10 @@ export async function run(args: string[]): Promise<void> {
   }
 
   try {
-    const { fetchBalance } = await import(
+    const { fetchOnChainBalances } = await import(
       "canon-templates/client-polymarket.js"
     );
-    const balances = await fetchBalance();
+    const balances = await fetchOnChainBalances();
     writeSuccess(balances, args);
   } catch (err: unknown) {
     writeError(

--- a/canon/cli/commands/help.ts
+++ b/canon/cli/commands/help.ts
@@ -6,13 +6,37 @@
  *   canon-cli help <topic>        Show skill content for a topic
  */
 
-import { readdir, readFile } from "node:fs/promises";
+import { access, readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { stripFormatFlags, writeError, writeSuccess } from "../output.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-const SKILLS_DIR = resolve(HERE, "../../skills");
+const PROJECT_SKILLS_DIR = resolve(HERE, "../../skills");
+const GLOBAL_SKILLS_DIR = join(
+  homedir(),
+  ".degacore",
+  "config",
+  "skills",
+);
+
+/**
+ * Resolve which skills directory to read from.
+ *
+ * Project-local `canon/skills/` wins when it exists (latest-in-repo
+ * knowledge). Falls back to the globally-installed copy under
+ * `~/.degacore/config/skills/` so the CLI works from any directory
+ * after `/apply-core`.
+ */
+async function resolveSkillsDir(): Promise<string> {
+  try {
+    await access(PROJECT_SKILLS_DIR);
+    return PROJECT_SKILLS_DIR;
+  } catch {
+    return GLOBAL_SKILLS_DIR;
+  }
+}
 
 interface SkillFrontmatter {
   name: string;
@@ -97,7 +121,8 @@ export function parseFrontmatter(
 async function loadSkillFiles(): Promise<
   Array<{ filename: string; raw: string }>
 > {
-  const entries = await readdir(SKILLS_DIR);
+  const skillsDir = await resolveSkillsDir();
+  const entries = await readdir(skillsDir);
   const mdFiles = entries
     .filter((f) => f.endsWith(".md"))
     .sort();
@@ -105,7 +130,7 @@ async function loadSkillFiles(): Promise<
   const results: Array<{ filename: string; raw: string }> = [];
   for (const filename of mdFiles) {
     const raw = await readFile(
-      join(SKILLS_DIR, filename),
+      join(skillsDir, filename),
       "utf-8",
     );
     results.push({ filename, raw });

--- a/canon/cli/commands/onboard.ts
+++ b/canon/cli/commands/onboard.ts
@@ -1,0 +1,174 @@
+/**
+ * Onboard subcommand — scan on-chain balances, swap non-USDC.e
+ * assets to USDC.e so the user can start trading.
+ *
+ * Requires POLYMARKET_PRIVATE_KEY.
+ *
+ * Usage:
+ *   canon-cli onboard              Show plan (no swaps executed)
+ *   canon-cli onboard --execute    Execute the plan: swap all non-USDC.e
+ *                                  tradeable assets to USDC.e.
+ *   canon-cli onboard --asset <USDC|USDT|POL> --amount <n> --execute
+ *                                  Swap a specific asset/amount.
+ *
+ * POL swaps always reserve gas (default: 1 POL, override with
+ * ONBOARD_POL_GAS_RESERVE env var).
+ */
+
+import { requireAuth, AuthError } from "../auth.js";
+import { stripFormatFlags, writeError, writeSuccess } from "../output.js";
+
+type SwapSource = "USDC" | "USDT" | "POL";
+const ASSETS: readonly SwapSource[] = ["USDC", "USDT", "POL"];
+
+interface Step {
+  from: SwapSource;
+  amount: number;
+  reason: string;
+}
+
+function getFlag(args: readonly string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  if (idx === -1 || idx + 1 >= args.length) return undefined;
+  return args[idx + 1];
+}
+
+function isSwapSource(s: string | undefined): s is SwapSource {
+  return s !== undefined && (ASSETS as readonly string[]).includes(s);
+}
+
+export async function run(rawArgs: string[]): Promise<void> {
+  try {
+    requireAuth("onboard");
+  } catch (err: unknown) {
+    if (err instanceof AuthError) {
+      writeError(err.message, rawArgs);
+      return;
+    }
+    throw err;
+  }
+
+  const args = stripFormatFlags(rawArgs);
+  const execute = args.includes("--execute");
+  const assetArg = getFlag(args, "--asset");
+  const amountArg = getFlag(args, "--amount");
+
+  if ((assetArg === undefined) !== (amountArg === undefined)) {
+    writeError(
+      "--asset and --amount must be provided together",
+      rawArgs,
+    );
+    return;
+  }
+
+  if (assetArg !== undefined && !isSwapSource(assetArg)) {
+    writeError(
+      `Invalid --asset "${assetArg}": must be one of USDC, USDT, POL`,
+      rawArgs,
+    );
+    return;
+  }
+
+  try {
+    const { fetchOnChainBalances, swapToUsdce } = await import(
+      "canon-templates/client-polymarket.js"
+    );
+
+    // Single-asset mode: swap exactly what the user asked for.
+    if (assetArg !== undefined && amountArg !== undefined) {
+      const amount = Number(amountArg);
+      if (!Number.isFinite(amount) || amount <= 0) {
+        writeError(
+          `Invalid --amount "${amountArg}": must be a positive number`,
+          rawArgs,
+        );
+        return;
+      }
+      if (!execute) {
+        writeSuccess(
+          {
+            plan: [
+              { from: assetArg, amount, reason: "explicit --asset/--amount" },
+            ],
+            executed: false,
+          },
+          rawArgs,
+        );
+        return;
+      }
+      const result = await swapToUsdce(assetArg, amount);
+      writeSuccess({ executed: true, swaps: [result] }, rawArgs);
+      return;
+    }
+
+    // Auto-plan mode: build plan from on-chain balances.
+    const balances = await fetchOnChainBalances();
+    const byCurrency = new Map(balances.map((b) => [b.currency, b.amount]));
+
+    const polReserve = Number(
+      process.env["ONBOARD_POL_GAS_RESERVE"] ?? "1",
+    );
+    const plan: Step[] = [];
+
+    const usdcNative = byCurrency.get("USDC") ?? 0;
+    if (usdcNative > 0) {
+      plan.push({
+        from: "USDC",
+        amount: usdcNative,
+        reason: "native USDC is not accepted by Polymarket CLOB",
+      });
+    }
+    const usdt = byCurrency.get("USDT") ?? 0;
+    if (usdt > 0) {
+      plan.push({
+        from: "USDT",
+        amount: usdt,
+        reason: "USDT is not accepted by Polymarket CLOB",
+      });
+    }
+    const pol = byCurrency.get("POL") ?? 0;
+    if (pol > polReserve + 1) {
+      plan.push({
+        from: "POL",
+        amount: pol - polReserve,
+        reason: `POL excess (keeping ${String(polReserve)} for gas)`,
+      });
+    }
+
+    if (plan.length === 0) {
+      writeSuccess(
+        {
+          plan: [],
+          executed: execute,
+          note: "nothing to swap — USDC.e is already the tradeable balance",
+        },
+        rawArgs,
+      );
+      return;
+    }
+
+    if (!execute) {
+      writeSuccess(
+        {
+          plan,
+          executed: false,
+          note: "run with --execute to swap these on-chain",
+        },
+        rawArgs,
+      );
+      return;
+    }
+
+    const swaps = [];
+    for (const step of plan) {
+      const result = await swapToUsdce(step.from, step.amount);
+      swaps.push(result);
+    }
+    writeSuccess({ executed: true, swaps }, rawArgs);
+  } catch (err: unknown) {
+    writeError(
+      err instanceof Error ? err.message : String(err),
+      rawArgs,
+    );
+  }
+}

--- a/canon/cli/commands/order.ts
+++ b/canon/cli/commands/order.ts
@@ -6,7 +6,8 @@
  * Usage:
  *   canon-cli order create --token-id <id> --side <buy|sell> --size <n> --price <n> [--type <market|limit>] [--market-id <id>]
  *   canon-cli order cancel <order-id>
- *   canon-cli order list [--market-id <id>] [--limit <n>]
+ *   canon-cli order open [--market-id <id>]
+ *   canon-cli order trades [--market-id <id>] [--limit <n>]
  */
 
 import { requireAuth, AuthError } from "../auth.js";
@@ -137,9 +138,9 @@ async function handleCancel(rawArgs: readonly string[]): Promise<void> {
   }
 }
 
-async function handleList(rawArgs: readonly string[]): Promise<void> {
+async function handleTrades(rawArgs: readonly string[]): Promise<void> {
   try {
-    requireAuth("order list");
+    requireAuth("order trades");
   } catch (err: unknown) {
     if (err instanceof AuthError) {
       writeError(err.message, rawArgs);
@@ -177,13 +178,40 @@ async function handleList(rawArgs: readonly string[]): Promise<void> {
   }
 }
 
+async function handleOpen(rawArgs: readonly string[]): Promise<void> {
+  try {
+    requireAuth("order open");
+  } catch (err: unknown) {
+    if (err instanceof AuthError) {
+      writeError(err.message, rawArgs);
+      return;
+    }
+    throw err;
+  }
+
+  const args = stripFormatFlags(rawArgs);
+  const marketId = getFlag(args, "--market-id");
+
+  try {
+    const { fetchOpenOrders } = await import("canon-templates/client-polymarket.js");
+    const orders = await fetchOpenOrders(marketId);
+    writeSuccess(orders, rawArgs);
+  } catch (err: unknown) {
+    writeError(
+      err instanceof Error ? err.message : String(err),
+      rawArgs,
+    );
+  }
+}
+
 const SUBCOMMANDS: Record<
   string,
   (args: readonly string[]) => Promise<void>
 > = {
   create: handleCreate,
   cancel: handleCancel,
-  list: handleList,
+  open: handleOpen,
+  trades: handleTrades,
 };
 
 export async function run(args: string[]): Promise<void> {
@@ -192,7 +220,7 @@ export async function run(args: string[]): Promise<void> {
   if (!subcommand || !(subcommand in SUBCOMMANDS)) {
     writeError(
       `Unknown order subcommand "${subcommand ?? ""}". ` +
-        "Available: create, cancel, list",
+        "Available: create, cancel, open, trades",
       args,
     );
     return;

--- a/canon/cli/package-lock.json
+++ b/canon/cli/package-lock.json
@@ -28,6 +28,7 @@
       "name": "canon-templates",
       "version": "0.0.0",
       "dependencies": {
+        "pmxt-core": "2.22.1",
         "pmxtjs": "2.22.1"
       },
       "devDependencies": {

--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -229,6 +229,12 @@ mkdir -p src
 cp strategies/<name>/entry.ts src/main.ts
 ```
 
+3. Copy the strategy's flow definition for the TUI pipeline diagram:
+
+```bash
+cp strategies/<name>/flow.json .canon/flow.json 2>/dev/null || true
+```
+
 4. Verify the entry point compiles:
 
 ```bash

--- a/canon/docs/tui-wiring.md
+++ b/canon/docs/tui-wiring.md
@@ -1,0 +1,66 @@
+# Canon TUI Wiring
+
+How the Canon TUI (aka "conductor-view", a Toad fork at `DEGAorg/conductor-view`) accesses Canon knowledge and commands. **This is a separate repo** — it does not automatically inherit anything from `claude-code-config`.
+
+## Two surfaces the TUI needs
+
+1. **Commands** — exercise Polymarket and Canon operations.
+2. **Skills** — display agent-facing knowledge (e.g. show the user what `polymarket` explains, or render help inside the TUI).
+
+Both are already installed globally by `/apply-core` from this repo. The TUI only needs to read from the installed locations.
+
+## Command surface — `canon-cli`
+
+Invoke as a subprocess; parse the JSON envelope from stdout.
+
+- **Binary:** `~/.degacore/bin/canon-cli` (symlink created by `/apply-core`).
+- **Contract:** every command returns `{"ok": true, "data": <result>}` on stdout, or `{"ok": false, "error": "<message>"}` on stderr with exit 1.
+- **Auth:** set `POLYMARKET_PRIVATE_KEY` env var before invoking auth-gated commands. Read-only commands (`market`, `help`) don't need it.
+- **Reference:** full command list in `canon/skills/canon-cli.md` (in this repo) or `~/.degacore/config/skills/canon-cli.md` (globally).
+
+Minimum TUI integration:
+
+```
+exec("canon-cli", ["market", "search", query], { env: { POLYMARKET_PRIVATE_KEY: ... } })
+  .then(out => JSON.parse(out.stdout).data)
+```
+
+Handle the `{ ok: false, error }` case by surfacing the error string verbatim — messages are already human-readable and actionable.
+
+## Skill surface — knowledge display
+
+After `/apply-core`, these files exist on disk:
+
+- `~/.degacore/config/skills/canon-cli.md` — agent-facing command reference with intent→command map.
+- `~/.degacore/config/skills/polymarket.md` — platform mechanics, fees, USDC.e-only rule, common mistakes.
+- `~/.degacore/config/skills/<other>.md` — any other skills `/apply-core` installs.
+
+**Rendering path:** read the file, parse YAML frontmatter (see `canon/cli/commands/help.ts:parseFrontmatter` for a reference parser), display the markdown body. Frontmatter fields the TUI cares about: `name`, `description`, `domain`, `version`.
+
+Alternative: shell out to `canon-cli help <name>` and render the JSON `data.content` field. This gets the same markdown but lets the CLI own the file resolution (project-local vs global fallback).
+
+## What the TUI must NOT do
+
+- **Do not vendor a copy** of `canon-cli.md` or `polymarket.md` into the TUI repo. These get edited in `claude-code-config` and installed on every `/apply-core`. A vendored copy will silently drift.
+- **Do not read from a `claude-code-config` checkout path** — users running the TUI won't have that repo locally. Read from `~/.degacore/config/skills/`.
+- **Do not reimplement the CLI.** The CLI is the contract — call it as a subprocess. Reimplementing order signing / approvals / the Uniswap swap path in the TUI repo is a maintenance liability and a signing-key surface we don't want duplicated.
+
+## When to update this doc
+
+- A new command is added to `canon-cli` → add it to `canon/skills/canon-cli.md`. No TUI change needed if the TUI introspects via `canon-cli help`.
+- The install destination moves (unlikely) → update `commands/apply-core.md` and this file.
+- The JSON envelope contract changes (breaking) → treat as a TUI API break; version the CLI and coordinate.
+
+## Open items for the TUI side
+
+These need to be decided in the conductor-view repo, not here:
+
+- Caching strategy for skill content (re-read on each render, or cache in memory).
+- Whether the TUI should spawn its own burner wallet or require `POLYMARKET_PRIVATE_KEY` to be pre-set.
+- Presentation: raw markdown vs rendered blocks vs command palette with intent→command hints lifted from `canon-cli.md`.
+
+## Related
+
+- Install manifest: `commands/apply-core.md` (search `canon/skills/` to see what gets installed).
+- Help implementation: `canon/cli/commands/help.ts` — reference for frontmatter parsing and project-local / global fallback.
+- Dual-source rule: `canon/AGENTS.md` → "Where skill knowledge lives".

--- a/canon/skills/canon-cli.md
+++ b/canon/skills/canon-cli.md
@@ -1,7 +1,7 @@
 ---
 name: canon-cli
 description: Command reference for the Canon CLI — agent-callable trading tools for Polymarket
-version: 0.0.0
+version: 0.1.0
 domain: tools
 requires: [polymarket]
 tools: [canon-cli]
@@ -12,9 +12,24 @@ tools: [canon-cli]
 ## Context
 
 Load this skill when the user asks to interact with Polymarket — searching
-markets, checking positions, placing orders, or monitoring a portfolio.
-The Canon CLI wraps Polymarket APIs into shell commands that return
-structured JSON.
+markets, checking balances, placing orders, onboarding a new wallet, or
+monitoring a portfolio. The Canon CLI wraps Polymarket APIs and on-chain
+Polygon calls into shell commands that return structured JSON.
+
+Natural-language requests map to commands as follows:
+
+| User intent | Command |
+|---|---|
+| "How much can I trade with?" / "What's my balance?" | `canon-cli balance` |
+| "I sent USDC but Polymarket shows $0" | `canon-cli onboard` (then `--execute`) |
+| "Find markets about X" | `canon-cli market search "X"` |
+| "What's the price of market X?" | `canon-cli market price <conditionId>` |
+| "How deep is the book for X?" | `canon-cli market orderbook <tokenId>` |
+| "Buy/sell N shares of X at price P" | `canon-cli order create ...` |
+| "What orders do I have open?" | `canon-cli order open` |
+| "What have I traded recently?" | `canon-cli order trades` |
+| "Cancel order X" / "Cancel everything" | `canon-cli order cancel <id>` / `canon-cli kill --yes` |
+| "Show my positions and PnL" | `canon-cli position list` |
 
 ## How to Use
 
@@ -43,7 +58,7 @@ Add `--pretty` to any command for indented JSON (human-readable).
 ### Authentication
 
 Read-only commands (`market`, `help`) work without auth.
-Write commands (`position`, `balance`, `order`, `kill`) require:
+Write / account commands (`balance`, `position`, `order`, `kill`, `onboard`) require:
 
 ```bash
 export POLYMARKET_PRIVATE_KEY=<private-key>
@@ -62,101 +77,100 @@ canon-cli market search "bitcoin"
 canon-cli market search NBA playoffs
 ```
 
-Returns: array of matching market objects.
+Returns an array of binary (2-outcome) markets with YES/NO prices and token IDs.
 
 ```json
-{"ok": true, "data": [{"conditionId": "0x...", "question": "Will Bitcoin hit $100k?", "outcomes": ["Yes", "No"], "volume": 1500000}]}
+{"ok": true, "data": [{"conditionId": "553856", "question": "...", "yesPrice": 0.455, "noPrice": 0.545, "yesTokenId": "495002...", "noTokenId": "449144...", "resolutionDate": "2026-07-01T00:00:00Z"}]}
 ```
 
 ### market price
 
-Fetch current price for a market. No auth required.
+Fetch current YES/NO price for a market. No auth required.
 
 ```bash
 canon-cli market price <condition-id>
 ```
 
-Returns: price object with outcome prices.
-
-```json
-{"ok": true, "data": {"conditionId": "0x...", "outcomes": [{"label": "Yes", "price": 0.65}, {"label": "No", "price": 0.35}]}}
-```
-
 ### market orderbook
 
-Fetch order book for a token. No auth required.
+Fetch the order book for one outcome token. No auth required.
 
 ```bash
 canon-cli market orderbook <token-id>
 ```
 
-Returns: bids and asks arrays.
-
-```json
-{"ok": true, "data": {"bids": [{"price": 0.64, "size": 500}], "asks": [{"price": 0.66, "size": 300}]}}
-```
+Returns `bids` and `asks` arrays, each with `{price, size}`.
 
 ### market ohlcv
 
-Fetch OHLCV candlestick data for a token. No auth required.
+Fetch OHLCV candles for a token. No auth required. Sidecar-based path.
 
 ```bash
 canon-cli market ohlcv <token-id>
 canon-cli market ohlcv <token-id> --timeframe 1h
 ```
 
-Returns: array of candle objects.
-
-```json
-{"ok": true, "data": [{"open": 0.60, "high": 0.68, "low": 0.58, "close": 0.65, "volume": 12000, "timestamp": 1713100800}]}
-```
-
-### position list
-
-List all open positions with PnL summary. Auth required.
-
-```bash
-canon-cli position list
-```
-
-Returns: positions array and portfolio summary.
-
-```json
-{
-  "ok": true,
-  "data": {
-    "positions": [
-      {
-        "marketId": "0x...",
-        "outcomeId": "0x...",
-        "outcomeLabel": "Yes",
-        "size": 100,
-        "entryPrice": 0.45,
-        "currentPrice": 0.65,
-        "unrealizedPnL": 20.0
-      }
-    ],
-    "summary": {
-      "totalValue": 1500.0,
-      "dailyPnL": 42.5,
-      "positionCount": 3
-    }
-  }
-}
-```
-
 ### balance
 
-Fetch wallet balance. Auth required. No subcommands.
+On-chain balance scan: USDC.e (tradeable on Polymarket), native USDC (needs swap),
+USDT (needs swap), POL (gas). Auth required.
 
 ```bash
 canon-cli balance
 ```
 
-Returns: array of currency balances.
+```json
+{"ok": true, "data": [
+  {"currency": "USDC.e", "address": "0x2791...", "amount": 9.88, "tradeable": true},
+  {"currency": "POL",    "address": "native",  "amount": 21.5, "tradeable": false, "note": "for gas; excess can be swapped to USDC.e"}
+]}
+```
+
+**Key fact:** Polymarket only accepts USDC.e. If `balance` shows native USDC, USDT,
+or excess POL with `tradeable: false`, run `canon-cli onboard` to convert them.
+
+### onboard
+
+Convert non-USDC.e assets to USDC.e via Uniswap v3 so the user can trade. Auth required.
+
+Three modes:
+
+```bash
+# 1. Dry run — show the swap plan based on current balances
+canon-cli onboard
+
+# 2. Execute the full plan
+canon-cli onboard --execute
+
+# 3. Single-asset explicit swap
+canon-cli onboard --asset POL  --amount 1    --execute
+canon-cli onboard --asset USDC --amount 10   --execute
+canon-cli onboard --asset USDT --amount 5    --execute
+```
+
+Plan response:
 
 ```json
-{"ok": true, "data": [{"currency": "USDC", "total": 5000.0, "available": 3500.0, "locked": 1500.0}]}
+{"ok": true, "data": {"plan": [{"from": "USDC", "amount": 5, "reason": "..."}], "executed": false, "note": "run with --execute to swap these on-chain"}}
+```
+
+Execution response:
+
+```json
+{"ok": true, "data": {"executed": true, "swaps": [{"from": "USDC", "amountIn": 5, "amountOut": 4.998, "txHash": "0x..."}]}}
+```
+
+Env vars:
+- `ONBOARD_POL_GAS_RESERVE` (default `1`) — POL to keep for gas when auto-swapping.
+- `SWAP_SLIPPAGE_BPS` (default `50`) — max slippage in basis points (0.5%).
+- `POLYGON_RPC_URL` (default `https://polygon.drpc.org`) — RPC endpoint.
+
+### position list
+
+List open positions with PnL summary. Auth required.
+
+```bash
+canon-cli position list
 ```
 
 ### order create
@@ -165,83 +179,54 @@ Place a new order. Auth required.
 
 ```bash
 canon-cli order create \
+  --market-id <id> \
   --token-id <id> \
   --side buy \
   --size 50 \
   --price 0.45 \
-  --type limit \
-  --market-id <id>
+  --type limit
 ```
 
-Required flags: `--token-id`, `--side` (buy|sell), `--size` (>0), `--price` (0-1).
-Optional flags: `--type` (market|limit, default: limit), `--market-id`.
+Required: `--token-id`, `--side` (buy|sell), `--size` (>0), `--price` (0-1). `--market-id` recommended.
+Optional: `--type` (market|limit, default limit).
 
-Returns: order confirmation object.
-
-```json
-{"ok": true, "data": {"orderId": "abc123", "status": "placed", "tokenId": "0x...", "side": "buy", "size": 50, "price": 0.45}}
-```
+Polymarket **minimum order size is 5 shares**. Size below that is rejected by the exchange.
 
 ### order cancel
 
-Cancel a specific order. Auth required.
+Cancel a specific order. Auth required. Returns a sparse `{id, status}` — the sidecar confirms the cancel but doesn't echo the full order.
 
 ```bash
 canon-cli order cancel <order-id>
 ```
 
-Returns: cancellation result.
+### order open
 
-```json
-{"ok": true, "data": {"orderId": "abc123", "status": "cancelled"}}
-```
-
-### order list
-
-List recent trades. Auth required.
+List currently-open orders (not yet filled or cancelled). Auth required.
 
 ```bash
-canon-cli order list
-canon-cli order list --market-id <id> --limit 10
+canon-cli order open
+canon-cli order open --market-id <id>
 ```
 
-Optional flags: `--market-id` (filter by market), `--limit` (max results).
+### order trades
 
-Returns: array of trade objects.
+List trade history (historical fills). Auth required.
 
-```json
-{"ok": true, "data": [{"orderId": "abc123", "side": "buy", "size": 50, "price": 0.45, "status": "filled", "timestamp": 1713100800}]}
+```bash
+canon-cli order trades
+canon-cli order trades --market-id <id> --limit 10
 ```
+
+Optional: `--market-id`, `--limit`.
 
 ### kill
 
-Cancel all open orders (kill switch). Auth required.
-Without `--yes`, performs a dry run showing what would be cancelled.
+Cancel all open orders (kill switch). Auth required. Dry-run without `--yes`.
 
 ```bash
-# Dry run — inspect open orders first
-canon-cli kill
-
-# Execute — cancel all open orders
-canon-cli kill --yes
-```
-
-Dry-run response:
-
-```json
-{"ok": true, "data": {"dryRun": true, "orderCount": 3, "orders": [...], "message": "Found 3 open order(s). Re-run with --yes to cancel all."}}
-```
-
-Execution response:
-
-```json
-{"ok": true, "data": {"cancelled": ["id1", "id2"], "failed": []}}
-```
-
-No open orders:
-
-```json
-{"ok": true, "data": {"cancelled": [], "failed": [], "message": "No open orders"}}
+canon-cli kill           # dry-run: lists what would be cancelled
+canon-cli kill --yes     # actually cancel everything
 ```
 
 ### help
@@ -249,75 +234,67 @@ No open orders:
 List available skills or show skill details. No auth required.
 
 ```bash
-# List all skills
 canon-cli help
-
-# Show details for a specific skill
 canon-cli help polymarket
-```
-
-List response:
-
-```json
-{"ok": true, "data": {"skills": [{"name": "polymarket", "description": "...", "domain": "platform"}]}}
-```
-
-Detail response:
-
-```json
-{"ok": true, "data": {"name": "polymarket", "description": "...", "domain": "platform", "version": "1.0.0", "requires": ["prediction-markets"], "tools": ["canon-cli"], "content": "# Polymarket Platform Knowledge\n..."}}
 ```
 
 ## Agent Workflow Examples
 
-### Research a market before trading
+### Onboard a freshly-funded wallet
+
+```bash
+# 1. Check on-chain balances
+canon-cli balance
+
+# 2. If anything is not tradeable, preview the swap plan
+canon-cli onboard
+
+# 3. Execute
+canon-cli onboard --execute
+
+# 4. Confirm USDC.e is now available
+canon-cli balance
+```
+
+### Research a market and place a trade
 
 ```bash
 # 1. Find the market
-canon-cli market search "Will Biden win 2024"
+canon-cli market search "NBA champion"
 
-# 2. Check current price (use conditionId from search)
-canon-cli market price 0x1234...
+# 2. Check price (use conditionId from search result)
+canon-cli market price 553856
 
-# 3. Check liquidity (use tokenId from price response)
-canon-cli market orderbook 0x5678...
+# 3. Check liquidity (use yesTokenId or noTokenId from search)
+canon-cli market orderbook 49500299...
 
-# 4. Check price history
-canon-cli market ohlcv 0x5678... --timeframe 1d
-```
-
-### Place a trade and monitor
-
-```bash
-# 1. Check available funds
+# 4. Verify balance before trading
 canon-cli balance
 
-# 2. Place a limit buy order
-canon-cli order create --token-id 0x5678... --side buy --size 100 --price 0.45
+# 5. Place limit order (size >= 5)
+canon-cli order create \
+  --market-id 553856 \
+  --token-id 49500299... \
+  --side buy --size 10 --price 0.40 --type limit
 
-# 3. Check if it filled
-canon-cli order list --limit 1
-
-# 4. Monitor position
-canon-cli position list
+# 6. Watch open orders
+canon-cli order open
 ```
 
-### Emergency: cancel everything
+### Monitor and close out
 
 ```bash
-# 1. See what's open (dry run)
-canon-cli kill
-
-# 2. Cancel all
-canon-cli kill --yes
-
-# 3. Verify positions
-canon-cli position list
+canon-cli position list        # current positions + PnL
+canon-cli order open           # anything still resting?
+canon-cli order trades --limit 20   # recent fills
+canon-cli kill --yes           # cancel all resting orders
 ```
 
 ## Common Mistakes
 
-- **Wrong ID type:** `market price` takes a condition ID, `market orderbook` and `market ohlcv` take a token ID. These are different identifiers from the search results.
-- **Missing --yes on kill:** Without `--yes`, `kill` only lists orders (dry run). Always inspect before confirming.
-- **Price range:** `--price` for orders must be between 0 and 1 (probability). Not a dollar amount.
-- **Limit vs market orders:** Default is `limit`. Use `--type market` only when speed matters more than price. Limit orders avoid taker fees.
+- **Wrong ID type.** `market price` takes a **conditionId**; `market orderbook` and `market ohlcv` take a **tokenId** (one per outcome). Both are on the result of `market search`.
+- **Using native USDC.** Polymarket only accepts **USDC.e** (bridged, `0x2791…`). Native USDC (`0x3c49…`) shows `tradeable: false` on `balance` — run `onboard` to convert.
+- **Missing `--yes` on kill.** Without `--yes`, `kill` only prints the dry run.
+- **`--price` is a probability,** 0–1, not a dollar amount.
+- **Order size below 5** is rejected by the exchange.
+- **`order cancel` echoes a sparse object** (`{id, status}`). The cancel is real; the sidecar just doesn't return the full order shape.

--- a/canon/skills/polymarket.md
+++ b/canon/skills/polymarket.md
@@ -17,8 +17,9 @@ Polymarket has platform-specific mechanics that affect strategy design.
 
 ### Platform Mechanics
 - Blockchain-based (Polygon) — trades are on-chain transactions
-- CLOB (Central Limit Order Book) model via CTF Exchange
-- USDC-denominated — all positions and P&L in USDC
+- CLOB (Central Limit Order Book) model via CTF Exchange (`0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E`) and NegRisk CTF Exchange (`0xC5d563A36AE78145C45a50134d48A1215220f80a`)
+- **Collateral is USDC.e (bridged, `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) — NOT native USDC (`0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359`).** Users who fund with native USDC / USDT / excess POL must convert before trading; use `canon-cli onboard`.
+- Minimum order size: 5 shares. Price is a probability in `[0, 1]`.
 - Conditional tokens: ERC-1155 tokens representing outcome shares
 
 ### Fee Structure
@@ -31,7 +32,8 @@ Polymarket has platform-specific mechanics that affect strategy design.
 - REST API for market data, order placement, position tracking
 - WebSocket for real-time order book and trade updates
 - Rate limits: Respect rate limits to avoid API bans
-- Authentication: API key-based (CLOB API key)
+- Authentication: EOA-based by default (user provides `POLYMARKET_PRIVATE_KEY`). L2 API credentials are derived automatically from the EOA's L1 signature on first use. For order signing, `signatureType: "eoa"` (type 0). Gnosis Safe mode (type 2) is supported by pmxtjs but not wired into Canon yet.
+- Order-placement requires USDC.e approval to CTFExchange / NegRiskCTFExchange / NegRiskAdapter on the EOA. This is a one-time setup per wallet.
 
 ### Resolution Process
 - Oracle-based resolution (UMA optimistic oracle)
@@ -56,11 +58,23 @@ Polymarket has platform-specific mechanics that affect strategy design.
 ### Monitoring Positions
 - Check positions via `canon-cli position list`
 - Monitor P&L via `canon-cli position list` (includes PnL summary)
+- List currently-open orders via `canon-cli order open`
+- List trade history via `canon-cli order trades`
 - Watch for resolution approaching — exit or hold decision
 - Set alerts for price movements >10% (potential information event)
 
+### Wallet Onboarding
+When a user wallet has no tradeable USDC.e but has other assets:
+- Native USDC → swap to USDC.e (Uniswap v3, 0.01% pool)
+- USDT → swap to USDC.e (0.01% / 0.05%)
+- Excess POL → swap to USDC.e (0.3%), keeping a gas reserve
+Run `canon-cli onboard` (dry-run) and `canon-cli onboard --execute` (live).
+Single-asset: `canon-cli onboard --asset POL --amount 1 --execute`.
+
 ## Common Mistakes
-- **Ignoring gas costs:** Polygon gas is low but not zero — frequent small trades add up
-- **Market order slippage:** Large market orders in thin books get terrible fills
-- **Missing resolution disputes:** Disputed resolutions can lock capital for weeks
-- **API rate limiting:** Aggressive polling gets your key throttled — use WebSocket for live data
+- **Funding with native USDC:** Polymarket is USDC.e-only. Users who send `0x3c499c...` USDC see `balance: 0` on Polymarket; fix with `canon-cli onboard`.
+- **Ignoring gas costs:** Polygon gas is low but not zero — frequent small trades add up. Keep ~1 POL reserve.
+- **Market order slippage:** Large market orders in thin books get terrible fills.
+- **Missing resolution disputes:** Disputed resolutions can lock capital for weeks.
+- **Order below 5-share minimum:** rejected by the exchange. Bump `size` if price is low.
+- **API rate limiting:** Aggressive polling gets your key throttled — use WebSocket for live data.

--- a/canon/templates/__tests__/approve-allowances.ts
+++ b/canon/templates/__tests__/approve-allowances.ts
@@ -1,0 +1,51 @@
+import { ethers } from "ethers";
+import { readFileSync } from "node:fs";
+
+const env = readFileSync(new URL("../.env", import.meta.url), "utf-8");
+for (const line of env.split("\n")) {
+  const m = line.match(/^([A-Z_]+)=(.*)$/);
+  if (m && m[1] && !process.env[m[1]]) process.env[m[1]] = m[2];
+}
+
+const USDC = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+const CTF_EXCHANGE = "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E";
+const NEG_RISK_EXCHANGE = "0xC5d563A36AE78145C45a50134d48A1215220f80a";
+const NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296";
+
+const provider = new ethers.providers.StaticJsonRpcProvider("https://polygon.drpc.org", { name: "polygon", chainId: 137 });
+const signer = new ethers.Wallet(process.env["POLYMARKET_PRIVATE_KEY"]!, provider);
+const usdc = new ethers.Contract(
+  USDC,
+  [
+    "function approve(address,uint256) returns (bool)",
+    "function allowance(address,address) view returns (uint256)",
+  ],
+  signer,
+);
+const MAX = ethers.constants.MaxUint256;
+
+for (const [name, spender] of [
+  ["CTF Exchange", CTF_EXCHANGE],
+  ["NegRisk Exchange", NEG_RISK_EXCHANGE],
+  ["NegRisk Adapter", NEG_RISK_ADAPTER],
+] as const) {
+  const current = await usdc["allowance"](signer.address, spender);
+  if (current.gte(MAX.div(2))) {
+    console.log(`${name}: already approved`);
+    continue;
+  }
+  console.log(`${name}: approving... (spender ${spender})`);
+  const block = await provider.getBlock("latest");
+  const baseFee = block.baseFeePerGas ?? ethers.utils.parseUnits("50", "gwei");
+  const tip = ethers.utils.parseUnits("30", "gwei");
+  const maxFee = baseFee.mul(2).add(tip);
+  const tx = await usdc["approve"](spender, MAX, {
+    maxPriorityFeePerGas: tip,
+    maxFeePerGas: maxFee,
+    gasLimit: 100_000,
+  });
+  console.log(`  tx: ${tx.hash}`);
+  const rcpt = await tx.wait();
+  console.log(`  mined block ${rcpt.blockNumber} gas=${rcpt.gasUsed.toString()}`);
+}
+console.log("done");

--- a/canon/templates/__tests__/check-balances.ts
+++ b/canon/templates/__tests__/check-balances.ts
@@ -1,0 +1,21 @@
+import { ethers } from "ethers";
+import { readFileSync } from "node:fs";
+
+const env = readFileSync(new URL("../.env", import.meta.url), "utf-8");
+for (const line of env.split("\n")) {
+  const m = line.match(/^([A-Z_]+)=(.*)$/);
+  if (m && m[1] && !process.env[m[1]]) process.env[m[1]] = m[2];
+}
+const signer = new ethers.Wallet(process.env["POLYMARKET_PRIVATE_KEY"]!);
+const provider = new ethers.providers.StaticJsonRpcProvider("https://polygon.drpc.org", { name: "polygon", chainId: 137 });
+const tokens = {
+  "Native USDC (0x3c49)": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+  "USDC.e bridged (0x2791)": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+};
+for (const [name, addr] of Object.entries(tokens)) {
+  const c = new ethers.Contract(addr, ["function balanceOf(address) view returns (uint256)"], provider);
+  const b = await c["balanceOf"](signer.address);
+  console.log(`${name}: ${ethers.utils.formatUnits(b, 6)}`);
+}
+const pol = await provider.getBalance(signer.address);
+console.log(`POL: ${ethers.utils.formatUnits(pol, 18)}`);

--- a/canon/templates/__tests__/gen-burner.ts
+++ b/canon/templates/__tests__/gen-burner.ts
@@ -1,0 +1,17 @@
+import { Wallet } from "ethers";
+import { writeFileSync, existsSync } from "node:fs";
+
+const envPath = new URL("../.env", import.meta.url).pathname;
+if (existsSync(envPath)) {
+  console.error(`refusing to overwrite existing ${envPath}`);
+  process.exit(1);
+}
+
+const w = Wallet.createRandom();
+writeFileSync(
+  envPath,
+  `POLYMARKET_PRIVATE_KEY=${w.privateKey}\n`,
+  { mode: 0o600 },
+);
+console.log("address:", w.address);
+console.log("saved key to:", envPath);

--- a/canon/templates/__tests__/integration-auth.test.ts
+++ b/canon/templates/__tests__/integration-auth.test.ts
@@ -113,7 +113,7 @@ describe.runIf(HAS_AUTH)(
         marketId: testMarketId,
         tokenId: testTokenId,
         side: "buy",
-        size: 1,
+        size: 200,
         price: 0.01,
         orderType: "limit",
       };
@@ -125,7 +125,7 @@ describe.runIf(HAS_AUTH)(
       expect(result.params.outcomeId).toBe(testTokenId);
       expect(result.params.side).toBe("buy");
       expect(result.params.type).toBe("limit");
-      expect(result.params.amount).toBe(1);
+      expect(result.params.amount).toBe(200);
       expect(result.params.price).toBe(0.01);
     }, 15_000);
 
@@ -139,7 +139,7 @@ describe.runIf(HAS_AUTH)(
           marketId: testMarketId,
           tokenId: testTokenId,
           side: "buy",
-          size: 1,
+          size: 200,
           price: 0.01,
           orderType: "limit",
         };
@@ -153,9 +153,9 @@ describe.runIf(HAS_AUTH)(
         expect(created.outcomeId).toBe(testTokenId);
         expect(created.side).toBe("buy");
         expect(created.type).toBe("limit");
-        expect(created.amount).toBe(1);
+        expect(created.amount).toBe(200);
         expect(created.filled).toBe(0);
-        expect(created.remaining).toBe(1);
+        expect(created.remaining).toBe(200);
 
         // Cancel immediately
         const cancelled = await cancelOrder(created.id);

--- a/canon/templates/__tests__/orders.test.ts
+++ b/canon/templates/__tests__/orders.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type {
   createOrder as CreateOrderFn,
   cancelOrder as CancelOrderFn,
@@ -6,18 +6,14 @@ import type {
   OrderParams,
 } from "../client-polymarket.js";
 
-const mockCreateOrder = vi.fn();
-const mockCancelOrder = vi.fn();
-const mockBuildOrder = vi.fn();
+const mockCallSidecar = vi.fn();
+const mockCreateOrder = mockCallSidecar;
+const mockCancelOrder = mockCallSidecar;
+const mockBuildOrder = mockCallSidecar;
 
-vi.mock("pmxtjs", () => {
-  class MockPolymarket {
-    createOrder = mockCreateOrder;
-    cancelOrder = mockCancelOrder;
-    buildOrder = mockBuildOrder;
-  }
-  return { Polymarket: MockPolymarket };
-});
+vi.mock("../sidecar.js", () => ({
+  callSidecar: mockCallSidecar,
+}));
 
 let createOrder: typeof CreateOrderFn;
 let cancelOrder: typeof CancelOrderFn;
@@ -26,10 +22,15 @@ let buildOrder: typeof BuildOrderFn;
 beforeEach(async () => {
   vi.clearAllMocks();
   vi.resetModules();
+  process.env["POLYMARKET_PRIVATE_KEY"] = "0xtest";
   const mod = await import("../client-polymarket.js");
   createOrder = mod.createOrder;
   cancelOrder = mod.cancelOrder;
   buildOrder = mod.buildOrder;
+});
+
+afterEach(() => {
+  delete process.env["POLYMARKET_PRIVATE_KEY"];
 });
 
 function validParams(
@@ -177,7 +178,11 @@ describe("cancelOrder", () => {
       id: "order-001",
       status: "cancelled",
     });
-    expect(mockCancelOrder).toHaveBeenCalledWith("order-001");
+    expect(mockCancelOrder).toHaveBeenCalledWith(
+      "cancelOrder",
+      ["order-001"],
+      expect.objectContaining({ privateKey: "0xtest" }),
+    );
   });
 
   it("propagates error for unknown order", async () => {
@@ -206,7 +211,11 @@ describe("buildOrder", () => {
     });
     expect(result.signedOrder).toBeDefined();
     expect(mockBuildOrder).toHaveBeenCalledOnce();
-    expect(mockCreateOrder).not.toHaveBeenCalled();
+    expect(mockBuildOrder).toHaveBeenCalledWith(
+      "buildOrder",
+      expect.any(Array),
+      expect.objectContaining({ privateKey: "0xtest" }),
+    );
   });
 
   it("validates price same as createOrder", async () => {

--- a/canon/templates/__tests__/smoke-auth-init.ts
+++ b/canon/templates/__tests__/smoke-auth-init.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+
+const env = readFileSync(new URL("../.env", import.meta.url), "utf-8");
+for (const line of env.split("\n")) {
+  const m = line.match(/^([A-Z_]+)=(.*)$/);
+  if (m && m[1] && !process.env[m[1]]) process.env[m[1]] = m[2];
+}
+console.log("key loaded, length:", process.env["POLYMARKET_PRIVATE_KEY"]?.length);
+
+const { fetchBalance, fetchPositions } = await import("../client-polymarket.js");
+
+console.log("fetchBalance (unfunded)...");
+try {
+  const bal = await fetchBalance();
+  console.log("  →", JSON.stringify(bal));
+} catch (e) {
+  console.error("  FAIL:", e instanceof Error ? e.message : String(e));
+}
+
+console.log("fetchPositions (unfunded)...");
+try {
+  const pos = await fetchPositions();
+  console.log(`  → ${pos.length} positions`);
+} catch (e) {
+  console.error("  FAIL:", e instanceof Error ? e.message : String(e));
+}
+process.exit(0);

--- a/canon/templates/__tests__/smoke-readonly.ts
+++ b/canon/templates/__tests__/smoke-readonly.ts
@@ -1,0 +1,21 @@
+import { searchMarkets, fetchOrderBook } from "../client-polymarket.js";
+
+const query = process.argv[2] ?? "NBA";
+console.log(`searchMarkets("${query}")...`);
+const matches = await searchMarkets(query);
+console.log(`  → ${matches.length} markets`);
+const first = matches[0];
+if (!first) {
+  console.log("no markets returned; exiting");
+  process.exit(0);
+}
+console.log(`  first: ${first.question}`);
+console.log(`         yes=${first.yesPrice} no=${first.noPrice}`);
+console.log(`         yesTokenId=${first.yesTokenId}`);
+
+console.log(`fetchOrderBook(${first.yesTokenId})...`);
+const book = await fetchOrderBook(first.yesTokenId);
+console.log(`  bids=${book.bids.length} asks=${book.asks.length}`);
+if (book.bids[0]) console.log(`  top bid: ${book.bids[0].price} x ${book.bids[0].size}`);
+if (book.asks[0]) console.log(`  top ask: ${book.asks[0].price} x ${book.asks[0].size}`);
+process.exit(0);

--- a/canon/templates/__tests__/smoke-sidecar.ts
+++ b/canon/templates/__tests__/smoke-sidecar.ts
@@ -1,0 +1,29 @@
+import { searchMarkets, fetchOHLCV, watchOrderBook } from "../client-polymarket.js";
+
+const markets = await searchMarkets("NBA");
+const m = markets.find((x) => x.yesTokenId);
+if (!m) {
+  console.error("no market with tokenId");
+  process.exit(1);
+}
+console.log(`market: ${m.question}`);
+console.log(`token:  ${m.yesTokenId}`);
+
+console.log("fetchOHLCV 1h...");
+try {
+  const candles = await fetchOHLCV(m.yesTokenId, { timeframe: "1h" });
+  console.log(`  → ${candles.length} candles`);
+  const last = candles.at(-1);
+  if (last) console.log(`  last: o=${last.open} h=${last.high} l=${last.low} c=${last.close} ts=${last.timestamp}`);
+} catch (e) {
+  console.error("  FAIL:", e instanceof Error ? e.message : String(e));
+}
+
+console.log("watchOrderBook...");
+try {
+  const book = await watchOrderBook(m.yesTokenId);
+  console.log(`  → bids=${book.bids.length} asks=${book.asks.length} ts=${book.timestamp}`);
+} catch (e) {
+  console.error("  FAIL:", e instanceof Error ? e.message : String(e));
+}
+process.exit(0);

--- a/canon/templates/__tests__/swap-to-usdce.ts
+++ b/canon/templates/__tests__/swap-to-usdce.ts
@@ -1,0 +1,74 @@
+import { ethers } from "ethers";
+import { readFileSync } from "node:fs";
+
+const env = readFileSync(new URL("../.env", import.meta.url), "utf-8");
+for (const line of env.split("\n")) {
+  const m = line.match(/^([A-Z_]+)=(.*)$/);
+  if (m && m[1] && !process.env[m[1]]) process.env[m[1]] = m[2];
+}
+
+const USDC_NATIVE = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
+const USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+const ROUTER = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"; // Uniswap SwapRouter02
+
+const provider = new ethers.providers.StaticJsonRpcProvider("https://polygon.drpc.org", { name: "polygon", chainId: 137 });
+const signer = new ethers.Wallet(process.env["POLYMARKET_PRIVATE_KEY"]!, provider);
+
+const erc20 = (addr: string) =>
+  new ethers.Contract(
+    addr,
+    [
+      "function approve(address,uint256) returns (bool)",
+      "function allowance(address,address) view returns (uint256)",
+      "function balanceOf(address) view returns (uint256)",
+    ],
+    signer,
+  );
+
+const usdcNative = erc20(USDC_NATIVE);
+const usdcE = erc20(USDC_E);
+
+const feeOpts = async () => {
+  const block = await provider.getBlock("latest");
+  const baseFee = block.baseFeePerGas ?? ethers.utils.parseUnits("50", "gwei");
+  const tip = ethers.utils.parseUnits("30", "gwei");
+  return { maxPriorityFeePerGas: tip, maxFeePerGas: baseFee.mul(2).add(tip) };
+};
+
+// 1. Approve router
+const curAllow = await usdcNative["allowance"](signer.address, ROUTER);
+const bal = await usdcNative["balanceOf"](signer.address);
+console.log(`native USDC balance: ${ethers.utils.formatUnits(bal, 6)}`);
+if (curAllow.lt(bal)) {
+  console.log("approving router...");
+  const t = await usdcNative["approve"](ROUTER, ethers.constants.MaxUint256, { ...(await feeOpts()), gasLimit: 100_000 });
+  console.log("  tx:", t.hash);
+  await t.wait();
+  console.log("  mined");
+}
+
+// 2. Swap (exactInputSingle)
+const router = new ethers.Contract(
+  ROUTER,
+  ["function exactInputSingle((address,address,uint24,address,uint256,uint256,uint160)) payable returns (uint256)"],
+  signer,
+);
+const amountIn = bal; // swap entire balance
+const amountOutMin = amountIn.mul(9990).div(10000); // allow up to 0.1% slippage
+const params = [
+  USDC_NATIVE,
+  USDC_E,
+  100, // 0.01% fee tier
+  signer.address,
+  amountIn,
+  amountOutMin,
+  0,
+];
+console.log("swapping...");
+const swapTx = await router["exactInputSingle"](params, { ...(await feeOpts()), gasLimit: 300_000 });
+console.log("  tx:", swapTx.hash);
+const rcpt = await swapTx.wait();
+console.log(`  mined block ${rcpt.blockNumber}`);
+
+const bal2 = await usdcE["balanceOf"](signer.address);
+console.log(`USDC.e balance after swap: ${ethers.utils.formatUnits(bal2, 6)}`);

--- a/canon/templates/__tests__/wait-funds.ts
+++ b/canon/templates/__tests__/wait-funds.ts
@@ -1,0 +1,32 @@
+import { ethers } from "ethers";
+
+const ADDR = "0x7b2d23fd477bbC52D98620cD36e2EAa470e0fC8C";
+const USDC = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
+const RPC = "https://polygon.drpc.org";
+
+const provider = new ethers.providers.StaticJsonRpcProvider(RPC, { name: "polygon", chainId: 137 });
+const usdc = new ethers.Contract(USDC, ["function balanceOf(address) view returns (uint256)"], provider);
+const formatUnits = ethers.utils.formatUnits;
+
+const MAX_TRIES = 30;
+for (let i = 1; i <= MAX_TRIES; i++) {
+  try {
+    const [pol, bal] = await Promise.all([
+      provider.getBalance(ADDR),
+      usdc["balanceOf"](ADDR),
+    ]);
+    const polStr = formatUnits(pol, 18);
+    const usdcStr = formatUnits(bal, 6);
+    const ts = new Date().toISOString().slice(11, 19);
+    console.log(`[${ts}] try ${i}/${MAX_TRIES}  POL=${polStr}  USDC=${usdcStr}`);
+    if (pol.gt(0) && bal.gt(0)) {
+      console.log("FUNDED");
+      process.exit(0);
+    }
+  } catch (e) {
+    console.error(`try ${i}: RPC error: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  if (i < MAX_TRIES) await new Promise((r) => setTimeout(r, 60_000));
+}
+console.error("TIMEOUT — funds not arrived in 30 min");
+process.exit(1);

--- a/canon/templates/client-polymarket.ts
+++ b/canon/templates/client-polymarket.ts
@@ -59,6 +59,32 @@ export interface AccountBalance {
   locked: number;
 }
 
+/** On-chain balance entry with product metadata for the user. */
+export interface OnChainBalance {
+  /** Display symbol (e.g. "USDC.e", "USDC", "POL"). */
+  currency: string;
+  /** Token contract address, or "native" for POL. */
+  address: string;
+  /** Human-readable balance (decimal-adjusted). */
+  amount: number;
+  /** True if this token can be used directly on Polymarket. */
+  tradeable: boolean;
+  /** Optional hint for the user about what to do with this balance. */
+  note?: string;
+}
+
+/** Assets swap-to-usdce supports on Polygon. */
+export type SwapSource = "USDC" | "USDT" | "POL";
+
+/** Result of a swap-to-USDC.e on-chain transaction. */
+export interface SwapResult {
+  from: SwapSource;
+  amountIn: number;
+  amountOut: number;
+  txHash: string;
+  approveTxHash?: string;
+}
+
 /** A single trade from the authenticated user's trade history. */
 export interface UserTrade {
   id: string;
@@ -276,6 +302,277 @@ export async function fetchBalance(): Promise<AccountBalance[]> {
 }
 
 /**
+ * Fetch on-chain balances for the authenticated EOA on Polygon.
+ *
+ * Returns USDC.e (tradeable), native USDC (swap needed), and POL (gas).
+ * This is the user-facing balance — what `canon-cli balance` should show.
+ *
+ * Requires `POLYMARKET_PRIVATE_KEY`. Uses a public Polygon RPC.
+ */
+export async function fetchOnChainBalances(): Promise<OnChainBalance[]> {
+  const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
+  if (!privateKey) throw new Error("POLYMARKET_PRIVATE_KEY required");
+
+  const { ethers } = await import("ethers");
+  const rpc = process.env["POLYGON_RPC_URL"] ?? "https://polygon.drpc.org";
+  const provider = new ethers.providers.StaticJsonRpcProvider(
+    rpc,
+    { name: "polygon", chainId: 137 },
+  );
+  const address = new ethers.Wallet(privateKey).address;
+
+  const USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+  const USDC_NATIVE = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
+  const abi = ["function balanceOf(address) view returns (uint256)"];
+  const usdcE = new ethers.Contract(USDC_E, abi, provider);
+  const usdcNative = new ethers.Contract(USDC_NATIVE, abi, provider);
+
+  const [polRaw, usdcERaw, usdcNativeRaw] = await Promise.all([
+    provider.getBalance(address),
+    usdcE["balanceOf"](address),
+    usdcNative["balanceOf"](address),
+  ]);
+
+  const fmt6 = (v: { toString(): string }): number =>
+    Number(ethers.utils.formatUnits(v.toString(), 6));
+  const fmt18 = (v: { toString(): string }): number =>
+    Number(ethers.utils.formatUnits(v.toString(), 18));
+
+  const out: OnChainBalance[] = [
+    {
+      currency: "USDC.e",
+      address: USDC_E,
+      amount: fmt6(usdcERaw),
+      tradeable: true,
+    },
+  ];
+
+  const nativeAmt = fmt6(usdcNativeRaw);
+  if (nativeAmt > 0) {
+    out.push({
+      currency: "USDC",
+      address: USDC_NATIVE,
+      amount: nativeAmt,
+      tradeable: false,
+      note: "native USDC — swap to USDC.e to trade on Polymarket",
+    });
+  }
+
+  const USDT_ADDR = "0xc2132D05D31c914a87C6611C10748AEb04B58e8F";
+  const usdt = new ethers.Contract(USDT_ADDR, abi, provider);
+  const usdtRaw = (await usdt["balanceOf"](address)) as { toString(): string };
+  const usdtAmt = fmt6(usdtRaw);
+  if (usdtAmt > 0) {
+    out.push({
+      currency: "USDT",
+      address: USDT_ADDR,
+      amount: usdtAmt,
+      tradeable: false,
+      note: "swap to USDC.e to trade on Polymarket",
+    });
+  }
+
+  out.push({
+    currency: "POL",
+    address: "native",
+    amount: fmt18(polRaw),
+    tradeable: false,
+    note: "for gas; excess can be swapped to USDC.e",
+  });
+
+  return out;
+}
+
+const SWAP_ROUTER = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45";
+const UNISWAP_QUOTER_V2 = "0x61fFE014bA17989E743c5F6cB21bF9697530B21e";
+const USDC_E_ADDR = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+const WPOL_ADDR = "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270";
+
+interface SwapRoute {
+  tokenIn: string;
+  decimals: number;
+  /** Fee tiers to try in order — first one with a quote wins. */
+  feeCandidates: readonly number[];
+  isNative: boolean;
+}
+
+const SWAP_ROUTES: Record<SwapSource, SwapRoute> = {
+  USDC: {
+    tokenIn: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
+    decimals: 6,
+    feeCandidates: [100, 500],
+    isNative: false,
+  },
+  USDT: {
+    tokenIn: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F",
+    decimals: 6,
+    feeCandidates: [100, 500, 3000],
+    isNative: false,
+  },
+  POL: {
+    tokenIn: WPOL_ADDR,
+    decimals: 18,
+    feeCandidates: [3000, 500, 10000],
+    isNative: true,
+  },
+};
+
+/**
+ * Swap a supported asset (native USDC, USDT, or POL) to USDC.e on Uniswap v3.
+ *
+ * Required because Polymarket's CTFExchange only accepts USDC.e. Users who
+ * fund the burner with native USDC / USDT / excess POL need a one-call
+ * conversion path. Approves the swap router if allowance is insufficient.
+ * Slippage tolerance is 0.5% (configurable via SWAP_SLIPPAGE_BPS env var).
+ *
+ * @param from - Source asset symbol.
+ * @param amountIn - Amount to swap in human units (e.g. 5 = 5 USDC).
+ */
+export async function swapToUsdce(
+  from: SwapSource,
+  amountIn: number,
+): Promise<SwapResult> {
+  if (amountIn <= 0) throw new Error(`amountIn must be > 0, got ${amountIn}`);
+  const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
+  if (!privateKey) throw new Error("POLYMARKET_PRIVATE_KEY required");
+
+  const route = SWAP_ROUTES[from];
+  const slippageBps = Number(process.env["SWAP_SLIPPAGE_BPS"] ?? "50");
+  if (!Number.isFinite(slippageBps) || slippageBps < 0 || slippageBps > 1000) {
+    throw new Error(`SWAP_SLIPPAGE_BPS invalid: ${String(slippageBps)}`);
+  }
+
+  const { ethers } = await import("ethers");
+  const rpc = process.env["POLYGON_RPC_URL"] ?? "https://polygon.drpc.org";
+  const provider = new ethers.providers.StaticJsonRpcProvider(
+    rpc,
+    { name: "polygon", chainId: 137 },
+  );
+  const signer = new ethers.Wallet(privateKey, provider);
+
+  const amountInRaw = ethers.utils.parseUnits(
+    amountIn.toFixed(route.decimals),
+    route.decimals,
+  );
+
+  const block = await provider.getBlock("latest");
+  const baseFee = block.baseFeePerGas ?? ethers.utils.parseUnits("50", "gwei");
+  const tip = ethers.utils.parseUnits("30", "gwei");
+  const feeOpts = {
+    maxPriorityFeePerGas: tip,
+    maxFeePerGas: baseFee.mul(2).add(tip),
+  };
+
+  let approveTxHash: string | undefined;
+  if (!route.isNative) {
+    const erc20 = new ethers.Contract(
+      route.tokenIn,
+      [
+        "function allowance(address,address) view returns (uint256)",
+        "function approve(address,uint256) returns (bool)",
+      ],
+      signer,
+    );
+    const allow = (await erc20["allowance"](
+      signer.address,
+      SWAP_ROUTER,
+    )) as { lt(other: unknown): boolean };
+    if (allow.lt(amountInRaw)) {
+      const approveTx = (await erc20["approve"](
+        SWAP_ROUTER,
+        ethers.constants.MaxUint256,
+        { ...feeOpts, gasLimit: 100_000 },
+      )) as { hash: string; wait(): Promise<unknown> };
+      approveTxHash = approveTx.hash;
+      await approveTx.wait();
+    }
+  }
+
+  // Find a pool with liquidity and fetch a real quote via QuoterV2 staticCall.
+  const quoter = new ethers.Contract(
+    UNISWAP_QUOTER_V2,
+    [
+      "function quoteExactInputSingle((address tokenIn,address tokenOut,uint256 amountIn,uint24 fee,uint160 sqrtPriceLimitX96)) returns (uint256 amountOut,uint160,uint32,uint256)",
+    ],
+    provider,
+  );
+  let chosenFee = 0;
+  let expectedOut: { toString(): string; mul(n: number): { div(n: number): unknown }} | undefined;
+  for (const fee of route.feeCandidates) {
+    try {
+      const quoteFn = quoter.callStatic["quoteExactInputSingle"];
+      if (!quoteFn) throw new Error("quoteExactInputSingle not on contract");
+      const result = (await quoteFn({
+        tokenIn: route.tokenIn,
+        tokenOut: USDC_E_ADDR,
+        amountIn: amountInRaw,
+        fee,
+        sqrtPriceLimitX96: 0,
+      })) as readonly [{ toString(): string; mul(n: number): { div(n: number): unknown } }];
+      const [amountOut] = result;
+      chosenFee = fee;
+      expectedOut = amountOut;
+      break;
+    } catch {
+      continue;
+    }
+  }
+  if (chosenFee === 0 || !expectedOut) {
+    throw new Error(
+      `No Uniswap v3 pool found for ${from} → USDC.e (tried fees ${route.feeCandidates.join(", ")})`,
+    );
+  }
+  const minOut = expectedOut.mul(10_000 - slippageBps).div(10_000);
+
+  const router = new ethers.Contract(
+    SWAP_ROUTER,
+    [
+      "function exactInputSingle((address,address,uint24,address,uint256,uint256,uint160)) payable returns (uint256)",
+    ],
+    signer,
+  );
+  const params = [
+    route.tokenIn,
+    USDC_E_ADDR,
+    chosenFee,
+    signer.address,
+    amountInRaw,
+    minOut,
+    0,
+  ];
+  const usdcE = new ethers.Contract(
+    USDC_E_ADDR,
+    ["function balanceOf(address) view returns (uint256)"],
+    provider,
+  );
+  const beforeRaw = (await usdcE["balanceOf"](signer.address)) as {
+    toString(): string;
+  };
+
+  const swapTx = (await router["exactInputSingle"](params, {
+    ...feeOpts,
+    ...(route.isNative ? { value: amountInRaw } : {}),
+    gasLimit: 300_000,
+  })) as { hash: string; wait(): Promise<{ logs: unknown[] }> };
+  await swapTx.wait();
+
+  const afterRaw = (await usdcE["balanceOf"](signer.address)) as {
+    toString(): string;
+  };
+  const before = Number(ethers.utils.formatUnits(beforeRaw.toString(), 6));
+  const after = Number(ethers.utils.formatUnits(afterRaw.toString(), 6));
+  const amountOut = Number((after - before).toFixed(6));
+
+  return {
+    from,
+    amountIn,
+    amountOut,
+    txHash: swapTx.hash,
+    ...(approveTxHash !== undefined ? { approveTxHash } : {}),
+  };
+}
+
+/**
  * Fetch trade history for the authenticated Polymarket account.
  *
  * Requires `POLYMARKET_PRIVATE_KEY` to be set. Auth errors from
@@ -362,7 +659,7 @@ export interface OrderParams {
   orderType: "market" | "limit";
 }
 
-/** Order response from createOrder or cancelOrder. */
+/** Order response from createOrder. */
 export interface OrderResponse {
   id: string;
   marketId: string;
@@ -374,6 +671,12 @@ export interface OrderResponse {
   status: string;
   filled: number;
   remaining: number;
+}
+
+/** Result of a cancelOrder call — sparse response from the exchange. */
+export interface CancelResult {
+  id: string;
+  status: string;
 }
 
 /** Dry-run result from buildOrder. */
@@ -432,15 +735,31 @@ export async function createOrder(
   params: OrderParams,
 ): Promise<OrderResponse> {
   validateOrderParams(params);
-  const poly = getClient();
-  const order = await poly.createOrder({
-    marketId: params.marketId,
-    outcomeId: params.tokenId,
-    side: params.side,
-    type: params.orderType,
-    amount: params.size,
-    price: params.price,
-  });
+  const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
+  if (!privateKey) throw new Error("POLYMARKET_PRIVATE_KEY required");
+  const order = await callSidecar<{
+    id: string;
+    marketId: string;
+    outcomeId: string;
+    side: "buy" | "sell";
+    type: "market" | "limit";
+    amount: number;
+    price?: number;
+    status: string;
+    filled: number;
+    remaining: number;
+  }>(
+    "createOrder",
+    [{
+      marketId: params.marketId,
+      outcomeId: params.tokenId,
+      side: params.side,
+      type: params.orderType,
+      amount: params.size,
+      price: params.price,
+    }],
+    { privateKey, signatureType: "eoa" },
+  );
   return {
     id: order.id,
     marketId: order.marketId,
@@ -462,20 +781,17 @@ export async function createOrder(
  */
 export async function cancelOrder(
   orderId: string,
-): Promise<OrderResponse> {
-  const poly = getClient();
-  const order = await poly.cancelOrder(orderId);
+): Promise<CancelResult> {
+  const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
+  if (!privateKey) throw new Error("POLYMARKET_PRIVATE_KEY required");
+  const order = await callSidecar<{ id?: string; status?: string }>(
+    "cancelOrder",
+    [orderId],
+    { privateKey, signatureType: "eoa" },
+  );
   return {
-    id: order.id,
-    marketId: order.marketId,
-    outcomeId: order.outcomeId,
-    side: order.side,
-    type: order.type,
-    amount: order.amount,
-    price: order.price ?? 0,
-    status: order.status,
-    filled: order.filled,
-    remaining: order.remaining,
+    id: order.id ?? orderId,
+    status: order.status ?? "cancelled",
   };
 }
 
@@ -490,15 +806,32 @@ export async function buildOrder(
   params: OrderParams,
 ): Promise<BuildOrderResult> {
   validateOrderParams(params);
-  const poly = getClient();
-  const built = await poly.buildOrder({
-    marketId: params.marketId,
-    outcomeId: params.tokenId,
-    side: params.side,
-    type: params.orderType,
-    amount: params.size,
-    price: params.price,
-  });
+  const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
+  if (!privateKey) throw new Error("POLYMARKET_PRIVATE_KEY required");
+  const built = await callSidecar<{
+    exchange: string;
+    params: {
+      marketId: string;
+      outcomeId: string;
+      side: string;
+      type: string;
+      amount: number;
+      price?: number;
+    };
+    signedOrder?: Record<string, unknown>;
+    raw: unknown;
+  }>(
+    "buildOrder",
+    [{
+      marketId: params.marketId,
+      outcomeId: params.tokenId,
+      side: params.side,
+      type: params.orderType,
+      amount: params.size,
+      price: params.price,
+    }],
+    { privateKey, signatureType: "eoa" },
+  );
   return {
     exchange: built.exchange,
     params: {

--- a/canon/templates/package.json
+++ b/canon/templates/package.json
@@ -14,7 +14,8 @@
     "node": ">=22"
   },
   "dependencies": {
-    "pmxtjs": "2.22.1"
+    "pmxtjs": "2.22.1",
+    "pmxt-core": "2.22.1"
   },
   "devDependencies": {
     "oxlint": "1.60.0",

--- a/canon/templates/pnpm-lock.yaml
+++ b/canon/templates/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      pmxt-core:
+        specifier: 2.22.1
+        version: 2.22.1(@types/node@25.6.0)(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@6.0.6)
       pmxtjs:
         specifier: 2.22.1
         version: 2.22.1(@types/node@25.6.0)(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@6.0.6)
@@ -3805,7 +3808,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -3974,7 +3977,7 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 25.6.0
 
   '@types/ws@8.18.1':
     dependencies:

--- a/canon/templates/runner.ts
+++ b/canon/templates/runner.ts
@@ -4,6 +4,8 @@
  * and structured execution logging.
  */
 
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 import type { TradeSignal } from "./types/TradeSignal.js";
 import type { RiskInterface, Portfolio } from "./types/RiskInterface.js";
 import type { ExecutionLogEntry } from "./execution-log.js";
@@ -97,6 +99,31 @@ export function createRunner(
     process.stdout.write(`${tag} ${msg}\n`);
   }
 
+  const flowPath = join(
+    config.baseDir.replace(/\/execution$/, ""),
+    "flow.json",
+  );
+
+  function updateFlow(
+    active: string,
+    completed: string[],
+  ): void {
+    if (!existsSync(flowPath)) return;
+    try {
+      const flow = JSON.parse(readFileSync(flowPath, "utf-8")) as {
+        steps: string[];
+        labels: Record<string, string>;
+        active: string;
+        completed: string[];
+      };
+      flow.active = active;
+      flow.completed = completed;
+      writeFileSync(flowPath, JSON.stringify(flow, null, 2) + "\n");
+    } catch {
+      // flow.json missing or malformed — skip silently
+    }
+  }
+
   async function processSignal(
     signal: TradeSignal,
     portfolio: Portfolio,
@@ -144,6 +171,7 @@ export function createRunner(
       return;
     }
 
+    updateFlow("execute", ["scan", "signal", "risk"]);
     try {
       const result = await deps.executor.submit(submittable);
       deps.log(
@@ -170,14 +198,20 @@ export function createRunner(
 
   async function cycle(): Promise<void> {
     cycleCount++;
+    updateFlow("scan", []);
     out("SCAN", `Cycle ${String(cycleCount)}`);
 
     const portfolio = await deps.positions.reconcile();
+
+    updateFlow("signal", ["scan"]);
     const signals = await deps.strategy();
 
     for (const signal of signals) {
+      updateFlow("risk", ["scan", "signal"]);
       await processSignal(signal, portfolio);
     }
+
+    updateFlow("log", ["scan", "signal", "risk", "execute"]);
 
     if (signals.length === 0) {
       out(
@@ -185,6 +219,8 @@ export function createRunner(
         `Cycle ${String(cycleCount)} — 0 signals, no edges`,
       );
     }
+
+    updateFlow("", ["scan", "signal", "risk", "execute", "log"]);
   }
 
   function stop(): void {

--- a/canon/templates/sidecar.ts
+++ b/canon/templates/sidecar.ts
@@ -79,17 +79,20 @@ async function readLockFile(): Promise<SidecarLockData> {
 export async function callSidecar<T>(
   method: string,
   args: ReadonlyArray<unknown>,
+  credentials?: { privateKey: string; signatureType?: string },
 ): Promise<T> {
   const lock = await readLockFile();
 
   const url = `http://localhost:${String(lock.port)}/api/polymarket/${method}`;
+  const body: Record<string, unknown> = { args };
+  if (credentials) body["credentials"] = credentials;
   const response = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       "x-pmxt-access-token": lock.accessToken,
     },
-    body: JSON.stringify({ args }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {

--- a/canon/templates/strategies/arb-binary/config.ts
+++ b/canon/templates/strategies/arb-binary/config.ts
@@ -9,7 +9,7 @@ import type { ArbBinaryConfig } from "./signal.js";
 
 /** C2 production defaults for ARB-01 binary arbitrage. */
 export const DEFAULT_ARB_BINARY_CONFIG: ArbBinaryConfig = {
-  category: "NBA",
+  category: "NBA Champion",
   kellyFraction: 0.25,
   maxExposure: 0.08,
   hurdleRate: 0.015,

--- a/canon/templates/strategies/arb-binary/entry.ts
+++ b/canon/templates/strategies/arb-binary/entry.ts
@@ -33,16 +33,21 @@ const risk = createRiskChecker({
 
 const strategy = async () => {
   const markets = await polySearchMarkets(strategyConfig.category);
-  const marketData: MarketData[] = markets.map((m) => ({
-    conditionId: m.conditionId,
-    question: m.question,
-    category: strategyConfig.category,
-    yesAsk: m.yesPrice,
-    noAsk: m.noPrice,
-    yesTokenId: m.yesTokenId ?? "",
-    noTokenId: m.noTokenId ?? "",
-    estimatedSlippage: 0,
-  }));
+  const marketData: MarketData[] = [];
+  for (const m of markets) {
+    // Skip dead markets with no liquidity
+    if (m.yesPrice <= 0 || m.noPrice <= 0) continue;
+    marketData.push({
+      conditionId: m.conditionId,
+      question: m.question,
+      category: strategyConfig.category,
+      yesAsk: m.yesPrice,
+      noAsk: m.noPrice,
+      yesTokenId: m.yesTokenId ?? "",
+      noTokenId: m.noTokenId ?? "",
+      estimatedSlippage: 0,
+    });
+  }
   return detectSignals(marketData, strategyConfig);
 };
 

--- a/canon/templates/strategies/arb-binary/entry.ts
+++ b/canon/templates/strategies/arb-binary/entry.ts
@@ -1,35 +1,49 @@
 /**
  * ARB-01 Binary Arbitrage — Project Entry Point
  *
- * This file is copied to src/main.ts by canon-start when the user
- * selects the arb-binary strategy. It wires the real Polymarket
- * client into the strategy's scan layer.
+ * Wires the real Polymarket client into the arb-binary strategy.
+ * Uses search result prices directly for signal detection — same
+ * pattern as the nba-momentum template. No order book calls needed
+ * for dry-run scanning.
  */
 
-import { createArbBinaryRunner } from "../strategies/arb-binary/main.js";
+import { createRunner } from "../runner.js";
+import { appendEntry } from "../execution-log.js";
+import { searchMarkets as polySearchMarkets } from "../client-polymarket.js";
+import { detectSignals } from "../strategies/arb-binary/signal.js";
 import { DEFAULT_ARB_BINARY_CONFIG } from "../strategies/arb-binary/config.js";
-import {
-  searchMarkets as polySearchMarkets,
-  fetchOrderBook as polyFetchOrderBook,
-} from "../client-polymarket.js";
-import type { ArbBinaryRunnerConfig } from "../strategies/arb-binary/main.js";
-import type { ScanSearchResult } from "../strategies/arb-binary/scan.js";
+import { createRiskChecker } from "../strategies/arb-binary/risk.js";
+import type { MarketData } from "../strategies/arb-binary/signal.js";
 import type { ExecutorDeps, PositionDeps } from "../runner.js";
 import type { Portfolio } from "../types/RiskInterface.js";
+import type { ExecutionLogEntry } from "../execution-log.js";
 
 const dryRun = process.argv.includes("--dry-run");
 const pollIntervalMs =
   Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
 
-const config: ArbBinaryRunnerConfig = {
-  strategy: DEFAULT_ARB_BINARY_CONFIG,
-  runner: {
-    pollIntervalMs,
-    dryRun,
-    baseDir: ".canon/execution",
-    statePath: ".canon/state.json",
-  },
+const strategyConfig = DEFAULT_ARB_BINARY_CONFIG;
+
+const risk = createRiskChecker({
+  bankroll: strategyConfig.bankroll,
+  kellyFraction: strategyConfig.kellyFraction,
+  maxExposure: strategyConfig.maxExposure,
   maxConsecutiveLosses: 3,
+});
+
+const strategy = async () => {
+  const markets = await polySearchMarkets(strategyConfig.category);
+  const marketData: MarketData[] = markets.map((m) => ({
+    conditionId: m.conditionId,
+    question: m.question,
+    category: strategyConfig.category,
+    yesAsk: m.yesPrice,
+    noAsk: m.noPrice,
+    yesTokenId: m.yesTokenId ?? "",
+    noTokenId: m.noTokenId ?? "",
+    estimatedSlippage: 0,
+  }));
+  return detectSignals(marketData, strategyConfig);
 };
 
 const stubExecutor: ExecutorDeps = {
@@ -40,7 +54,7 @@ const stubExecutor: ExecutorDeps = {
 };
 
 const emptyPortfolio: Portfolio = {
-  total_value: config.strategy.bankroll,
+  total_value: strategyConfig.bankroll,
   positions: [],
   daily_pnl: 0,
 };
@@ -54,22 +68,17 @@ const stubPositions: PositionDeps = {
   },
 };
 
-const runner = createArbBinaryRunner(config, {
-  scan: {
-    async searchMarkets(query: string): Promise<ScanSearchResult[]> {
-      const markets = await polySearchMarkets(query);
-      return markets.map((m) => ({
-        conditionId: m.conditionId,
-        question: m.question,
-        yesTokenId: m.yesTokenId,
-        noTokenId: m.noTokenId,
-      }));
-    },
-    fetchOrderBook: polyFetchOrderBook,
+const runner = createRunner(
+  { pollIntervalMs, dryRun, baseDir: ".canon/execution", statePath: ".canon/state.json" },
+  {
+    strategy,
+    risk,
+    executor: stubExecutor,
+    positions: stubPositions,
+    log: (entry: ExecutionLogEntry) =>
+      appendEntry(".canon/execution", entry),
   },
-  executor: stubExecutor,
-  positions: stubPositions,
-});
+);
 
 process.stdout.write(
   `START ARB-01 scanner (${dryRun ? "dry-run" : "live"}) poll=${String(pollIntervalMs)}ms\n`,

--- a/canon/templates/strategies/arb-binary/flow.json
+++ b/canon/templates/strategies/arb-binary/flow.json
@@ -1,0 +1,12 @@
+{
+  "steps": ["scan", "signal", "risk", "execute", "log"],
+  "labels": {
+    "scan": "Scan Markets",
+    "signal": "Detect Signal",
+    "risk": "Risk Check",
+    "execute": "Execute",
+    "log": "Log"
+  },
+  "active": "",
+  "completed": []
+}

--- a/commands/apply-core.md
+++ b/commands/apply-core.md
@@ -116,6 +116,7 @@ Files available:
 - `canon/cli/commands/balance.ts`
 - `canon/cli/commands/order.ts`
 - `canon/cli/commands/kill.ts`
+- `canon/cli/commands/onboard.ts`
 - `canon/cli/commands/help.ts`
 - `canon/skills/canon-cli.md`
 - `canon/skills/polymarket.md`
@@ -578,6 +579,7 @@ Write each source file to `~/.degacore/canon-cli/`:
 - `canon/cli/commands/balance.ts` -> `~/.degacore/canon-cli/commands/balance.ts`
 - `canon/cli/commands/order.ts` -> `~/.degacore/canon-cli/commands/order.ts`
 - `canon/cli/commands/kill.ts` -> `~/.degacore/canon-cli/commands/kill.ts`
+- `canon/cli/commands/onboard.ts` -> `~/.degacore/canon-cli/commands/onboard.ts`
 - `canon/cli/commands/help.ts` -> `~/.degacore/canon-cli/commands/help.ts`
 
 Write the agent discovery skills:

--- a/commands/apply-core.md
+++ b/commands/apply-core.md
@@ -118,6 +118,7 @@ Files available:
 - `canon/cli/commands/kill.ts`
 - `canon/cli/commands/help.ts`
 - `canon/skills/canon-cli.md`
+- `canon/skills/polymarket.md`
 - `canon/templates/` (entire directory — project shell copied wholesale by scaffold)
 
 ---
@@ -579,8 +580,9 @@ Write each source file to `~/.degacore/canon-cli/`:
 - `canon/cli/commands/kill.ts` -> `~/.degacore/canon-cli/commands/kill.ts`
 - `canon/cli/commands/help.ts` -> `~/.degacore/canon-cli/commands/help.ts`
 
-Write the agent discovery skill:
+Write the agent discovery skills:
 - `canon/skills/canon-cli.md` -> `~/.degacore/config/skills/canon-cli.md`
+- `canon/skills/polymarket.md` -> `~/.degacore/config/skills/polymarket.md`
 
 Safe to overwrite — these are CLI source files and skills with no user
 customization.
@@ -791,7 +793,7 @@ Installed to ~/.degacore/:
   Commands -> config/commands/ (fix-issue, review-pr, plan, cleanup, doc-garden, core-init)
   Rules -> config/rules/ (python, node-typescript, rust, bash, github-actions)
   Hooks -> scripts/hooks/ (enforce-loop-mode, enforce-exec-plan-naming, enforce-package-manager, log-gam)
-  Skills -> config/skills/ (custom-linter-authoring, app-legibility, sound-notifications)
+  Skills -> config/skills/ (custom-linter-authoring, app-legibility, sound-notifications, canon-cli, polymarket)
   Logging -> scripts/log-server.py + scripts/hooks/ (local-only; add gcp-sa.json to enable GCP)
   Sounds -> sounds/ (MP3 + OGG) + scripts/hooks/play-sound.sh
   Terminal UI -> scripts/terminal-ui/ (built with pnpm)

--- a/data/timeline.json
+++ b/data/timeline.json
@@ -4,15 +4,15 @@
     "subtitle": "Internal planning view",
     "generated": "2026-04-17",
     "startDate": "2026-03-19",
-    "hackathonDate": "2026-04-18",
+    "hackathonDate": "2026-05-04",
     "finaleDate": "2026-05-11",
     "totalDays": 54
   },
   "stats": [
     {
-      "value": "1",
-      "label": "Days to hackathon",
-      "color": "red"
+      "value": "17",
+      "label": "Days to hackathon (May 4)",
+      "color": "yellow"
     },
     {
       "value": "17",
@@ -312,10 +312,10 @@
     },
     {
       "label": "Hackathon",
-      "startDay": 30,
-      "days": 21,
+      "startDay": 46,
+      "days": 7,
       "color": "yellow",
-      "text": "3 weeks — NBA Playoffs",
+      "text": "May 4–11 — NBA Playoffs",
       "status": "pending"
     },
     {
@@ -323,7 +323,7 @@
       "startDay": 52,
       "days": 2,
       "color": "red",
-      "text": "Livestream",
+      "text": "Livestream — May 11",
       "status": "pending"
     }
   ],
@@ -334,8 +334,8 @@
       "type": "gate"
     },
     {
-      "day": 30,
-      "label": "KICKOFF",
+      "day": 46,
+      "label": "HACKATHON START (May 4)",
       "type": "event"
     },
     {
@@ -377,7 +377,7 @@
     },
     {
       "name": "HACKATHON",
-      "timing": "Apr 18",
+      "timing": "May 4",
       "type": "event"
     }
   ],
@@ -525,44 +525,40 @@
     },
     {
       "num": 5,
-      "dates": "Apr 13 – 18",
-      "theme": "Final Testing + Launch",
+      "dates": "Apr 13 – May 3",
+      "theme": "Final Build + Workshops + Launch Prep",
       "current": true,
       "tasks": [
         {
-          "text": "Final testing + fixes",
+          "text": "Arena MVP build + testing",
           "type": "product"
         },
         {
-          "text": "Deploy stable version",
+          "text": "Canon CLI remaining commands",
           "type": "product"
         },
         {
-          "text": "Final outreach + workshops wrap up",
+          "text": "Integration tests + deploy stable",
+          "type": "product"
+        },
+        {
+          "text": "Workshop 4 (Apr 17), Workshop 5 (Apr 22/24)",
           "type": "marketing"
         },
         {
-          "text": "Apr 18 — KICKOFF",
-          "type": "event"
+          "text": "DM outreach continues",
+          "type": "marketing"
         }
       ]
     },
     {
       "num": "6-8",
-      "dates": "Apr 18 – May 11",
+      "dates": "May 4 – May 11",
       "theme": "Hackathon Live",
       "current": false,
       "tasks": [
         {
-          "text": "Week 1 checkpoint (Apr 24)",
-          "type": "event"
-        },
-        {
-          "text": "WS5 content + Workshop 5 (Apr 29)",
-          "type": "event"
-        },
-        {
-          "text": "Week 2 checkpoint (May 1)",
+          "text": "May 4 — HACKATHON STARTS",
           "type": "event"
         },
         {

--- a/data/timeline.json
+++ b/data/timeline.json
@@ -2,7 +2,7 @@
   "meta": {
     "title": "Canon Hackathon Dashboard",
     "subtitle": "Internal planning view",
-    "generated": "2026-04-02",
+    "generated": "2026-04-17",
     "startDate": "2026-03-19",
     "hackathonDate": "2026-04-18",
     "finaleDate": "2026-05-11",
@@ -10,9 +10,9 @@
   },
   "stats": [
     {
-      "value": "16",
+      "value": "1",
       "label": "Days to hackathon",
-      "color": "yellow"
+      "color": "red"
     },
     {
       "value": "17",
@@ -138,7 +138,7 @@
         "orch"
       ],
       "startDay": 15,
-      "description": "Strategy-specific template configs built on TS/Python base. Half done \u2014 selecting from Sampson's 18 types.",
+      "description": "Strategy-specific template configs built on TS/Python base. Half done — selecting from Sampson's 18 types.",
       "status": "active"
     },
     {
@@ -179,7 +179,7 @@
       "startDay": 0,
       "days": 3,
       "color": "green",
-      "text": "Canon TUI \u2014 done",
+      "text": "Canon TUI — done",
       "status": "done"
     },
     {
@@ -203,7 +203,7 @@
       "startDay": 5,
       "days": 3,
       "color": "green",
-      "text": "init + start \u2014 done",
+      "text": "init + start — done",
       "status": "done"
     },
     {
@@ -219,7 +219,7 @@
       "startDay": 0,
       "days": 4,
       "color": "green",
-      "text": "Sampson \u2014 18 types reviewed",
+      "text": "Sampson — 18 types reviewed",
       "status": "done"
     },
     {
@@ -227,7 +227,7 @@
       "startDay": 8,
       "days": 1,
       "color": "green",
-      "text": "TS base \u2014 done",
+      "text": "TS base — done",
       "status": "done"
     },
     {
@@ -243,7 +243,7 @@
       "startDay": 15,
       "days": 2,
       "color": "accent",
-      "text": "Half done \u2014 Apr 3 start",
+      "text": "Half done — Apr 3 start",
       "status": "active"
     },
     {
@@ -259,7 +259,7 @@
       "startDay": 11,
       "days": 1,
       "color": "green",
-      "text": "YouTube \u2014 recorded Mar 30",
+      "text": "YouTube — recorded Mar 30",
       "status": "done"
     },
     {
@@ -291,31 +291,31 @@
       "startDay": 15,
       "days": 21,
       "color": "green",
-      "text": "Listing Apr 3, DMs Apr 4-24 (3 weeks)",
-      "status": "pending"
+      "text": "Tested + sending — DMs active",
+      "status": "active"
     },
     {
       "label": "Content Tracking",
       "startDay": 17,
       "days": 7,
-      "color": "orange",
-      "text": "WS content due Apr 5\u201311",
-      "status": "pending"
+      "color": "green",
+      "text": "WS1-4 content done",
+      "status": "done"
     },
     {
       "label": "Workshops",
       "startDay": 20,
       "days": 22,
-      "color": "cyan",
-      "text": "5 sessions: Apr 8, 10, 15, 17, 29",
-      "status": "pending"
+      "color": "accent",
+      "text": "WS3 done, WS4 today — 5 sessions",
+      "status": "active"
     },
     {
       "label": "Hackathon",
       "startDay": 30,
       "days": 21,
       "color": "yellow",
-      "text": "3 weeks \u2014 NBA Playoffs",
+      "text": "3 weeks — NBA Playoffs",
       "status": "pending"
     },
     {
@@ -401,7 +401,7 @@
   "weeks": [
     {
       "num": 1,
-      "dates": "Mar 19 \u2013 23",
+      "dates": "Mar 19 – 23",
       "theme": "Foundation + Conductor",
       "current": false,
       "tasks": [
@@ -426,19 +426,19 @@
           "type": "planning"
         },
         {
-          "text": "pmxt result \u2192 CLI approach",
+          "text": "pmxt result → CLI approach",
           "type": "gate"
         }
       ]
     },
     {
       "num": 2,
-      "dates": "Mar 24 \u2013 29",
+      "dates": "Mar 24 – 29",
       "theme": "Canon CLI",
       "current": false,
       "tasks": [
         {
-          "text": "Canon CLI \u2014 build through Conductor",
+          "text": "Canon CLI — build through Conductor",
           "type": "product"
         },
         {
@@ -454,23 +454,23 @@
           "type": "marketing"
         },
         {
-          "text": "Mar 25 \u2014 budget locked",
+          "text": "Mar 25 — budget locked",
           "type": "gate"
         }
       ]
     },
     {
       "num": 3,
-      "dates": "Mar 30 \u2013 Apr 5",
+      "dates": "Mar 30 – Apr 5",
       "theme": "Arena MVP",
-      "current": true,
+      "current": false,
       "tasks": [
         {
-          "text": "Arena \u2014 scaffold, API, leaderboard, Polymarket data",
+          "text": "Arena — scaffold, API, leaderboard, Polymarket data",
           "type": "product"
         },
         {
-          "text": "Canon CLI \u2194 Arena integration",
+          "text": "Canon CLI ↔ Arena integration",
           "type": "product"
         },
         {
@@ -497,12 +497,12 @@
     },
     {
       "num": 4,
-      "dates": "Apr 6 \u2013 12",
+      "dates": "Apr 6 – 12",
       "theme": "Testing + GO/NO-GO",
       "current": false,
       "tasks": [
         {
-          "text": "Heavy testing \u2014 all modules",
+          "text": "Heavy testing — all modules",
           "type": "product"
         },
         {
@@ -525,9 +525,9 @@
     },
     {
       "num": 5,
-      "dates": "Apr 13 \u2013 18",
+      "dates": "Apr 13 – 18",
       "theme": "Final Testing + Launch",
-      "current": false,
+      "current": true,
       "tasks": [
         {
           "text": "Final testing + fixes",
@@ -542,14 +542,14 @@
           "type": "marketing"
         },
         {
-          "text": "Apr 18 \u2014 KICKOFF",
+          "text": "Apr 18 — KICKOFF",
           "type": "event"
         }
       ]
     },
     {
       "num": "6-8",
-      "dates": "Apr 18 \u2013 May 11",
+      "dates": "Apr 18 – May 11",
       "theme": "Hackathon Live",
       "current": false,
       "tasks": [

--- a/docs/agent-operating-mode.md
+++ b/docs/agent-operating-mode.md
@@ -1,0 +1,139 @@
+# Agent Operating Mode
+
+Defaults for any agent (Claude, Codex, Gemini) working in this repo. **Follow these without being asked.** Do not re-negotiate them at the start of every session.
+
+The goal: maximum autonomous progress with minimum human interruption. The human sets direction and reviews outcomes; the agent executes, verifies, and reports.
+
+---
+
+## Decide and move
+
+On anything **reversible** — editing code, running tests, running lint, committing locally, running scripts, spawning exploration agents — decide and move. Do not ask permission. State the assumption in one sentence if it matters, then act.
+
+Examples of reversible actions (no confirmation needed):
+- Edit files, run `tsc`, run `vitest`, run `oxlint`.
+- Create local commits on a feature branch.
+- Spawn an Explore / Plan / general-purpose agent for research.
+- Read on-chain state, call public RPCs, call read-only APIs.
+- Write new scripts under `__tests__/` or `scripts/` to verify something.
+
+Confirm before acting on anything **hard to reverse or visible to others**:
+- Destructive git operations (`reset --hard`, force-push, branch delete).
+- Pushing to remote (first time on a branch — announce it).
+- Opening / closing / commenting on PRs and issues that affect shared state.
+- Sending real value on-chain beyond what the user explicitly authorized.
+- Modifying CI, shared infra, or anything under `~/.degacore/` / `~/.claude/` at user-install level.
+
+Default: **lean toward action on anything local-and-reversible.** The cost of a tiny extra commit is near zero; the cost of a back-and-forth "should I?" question is a stalled session.
+
+---
+
+## Report like a peer, not a secretary
+
+Say what you did and what's next. Skip the ceremony.
+
+- **No long preambles.** Don't narrate "let me start by checking…". Do the check, then report findings.
+- **No wall-of-text summaries at the end of every turn.** One or two sentences: what changed, what's blocking, what's next.
+- **Cite with links.** PR number, issue number, tx hash, file:line. Never "I updated the skill doc" — always "Updated `canon/skills/polymarket.md:42`" or "PR #182".
+- **Distinguish verified vs assumed.** If you ran it and saw output, say "verified". If you reasoned it should work but didn't run it, say "not yet run". The user needs to know which claims to trust.
+
+---
+
+## Self-verify before shipping
+
+Before saying a piece of work is done, run the checks yourself. No "should work" without evidence.
+
+Minimum gate before declaring done:
+1. **Typecheck** (`tsc --noEmit` / `ty check` / `cargo check`).
+2. **Tests** (`vitest run` / `pytest -q` / `cargo test`) — relevant subset, not the full monorepo unless the change is load-bearing.
+3. **Lint** (`oxlint` / `ruff check` / `cargo clippy`). Zero warnings policy: fix them, don't suppress.
+4. **Live smoke** if feasible — actually run the new command / hit the new endpoint / place the tiny test order. For UI changes, open a browser. Type-checking is not feature-correctness.
+
+If a gate fails, debug and fix. Do not ask the user to debug for you — diagnose first, ask only if you genuinely need information the user has and you don't.
+
+---
+
+## Keep PRs focused
+
+Each PR: one intent, one scope. Do not commingle unrelated commits just because they happen to be on the same branch.
+
+- **Never assume `main` is the PR target.** Resolve it dynamically every time — see the section below. Use the resolved base for both `git checkout -b <new> origin/<base>` and `gh pr create --base <base>`.
+- When cherry-picking onto a fresh branch, verify the test suite still passes on the new base before pushing — cherry-picks can silently lose context (interface changes, prior refactors) that existed on the source branch.
+- Stack related PRs explicitly: PR B "based on #A" in the description, so the reviewer knows the dependency.
+- If a PR needs "while I'm here" cleanup, log it to `docs/exec-plans/tech-debt.md` instead of growing the diff.
+
+### PR target resolution
+
+Never hardcode `main`. For every new branch and every `gh pr create`, resolve the target in this order:
+
+1. **`github.pr_target` from `dega-core.yaml`** at the repo root, if the key is present. This is the authoritative per-repo setting.
+   ```bash
+   PR_TARGET=$(grep '^\s*pr_target:' dega-core.yaml 2>/dev/null | awk '{print $2}' | tr -d ' ')
+   ```
+2. **`develop`** if `origin/develop` exists on the remote and step 1 returned nothing.
+   ```bash
+   git ls-remote --exit-code --heads origin develop >/dev/null 2>&1 && echo develop
+   ```
+3. **`main`** as the last-resort fallback.
+
+One-liner that captures the whole rule:
+
+```bash
+PR_TARGET=$(grep '^\s*pr_target:' dega-core.yaml 2>/dev/null | awk '{print $2}' | tr -d ' ')
+: "${PR_TARGET:=$(git ls-remote --exit-code --heads origin develop >/dev/null 2>&1 && echo develop || echo main)}"
+```
+
+Then: `git checkout -b <branch> "origin/${PR_TARGET}"` and `gh pr create --base "${PR_TARGET}" ...`.
+
+If `pr_target` points at a user/integration branch (e.g. `ace-work`) rather than a trunk, that means the user reviews PRs into that branch first and promotes to `main` themselves. Do not "correct" this by targeting `main` — respect the config.
+
+---
+
+## Use agents for research, not for code edits you could do yourself
+
+Spawn Explore / Plan / general-purpose subagents when:
+- The question spans the codebase and needs multiple greps / reads.
+- The answer could bloat the main context with raw command output.
+- The research is genuinely independent of your next write step.
+
+Do not spawn a subagent to:
+- Read one file. Use `Read`.
+- Search for one string. Use `Grep`.
+- Make a small edit you already know how to make.
+
+When spawning, brief the agent like a smart colleague who walked into the room — state the goal, list what to check, ask for a bounded report (e.g. "under 200 words"). Prescriptive steps waste capacity; questions focus it.
+
+---
+
+## Track work with the task tool
+
+For anything with 3+ steps: create tasks, mark in-progress when starting, completed when done. Not for trivial 1-2 step work.
+
+Tasks are for the current session. **Persistent decisions, follow-ups, and tech debt go in the repo** — either in `docs/exec-plans/tech-debt.md` or as GitHub issues.
+
+Never describe ongoing work in prose-only form ("I'll also need to do X later"). Either do it now or log it where someone can find it later.
+
+---
+
+## Log follow-ups as tech debt
+
+If you notice something adjacent that's worth fixing but out of scope: add an entry to `docs/exec-plans/tech-debt.md` with the format already established there. Include severity (P1/P2/P3), area, date, context, and a concrete fix sketch.
+
+Do not leave follow-ups buried in PR descriptions, commit messages, or conversation logs. They rot there.
+
+---
+
+## Memory and persistence
+
+This file and `canon/docs/tui-wiring.md` are the permanent behavior spec. **Do not re-derive this from scratch in future sessions.** Read it at session start if needed, then apply.
+
+`~/.claude/projects/.../memory/` is for user-level and temporary context (current work, user preferences, references). Repo-level behavior rules live here in the repo.
+
+---
+
+## When to break these rules
+
+- The user explicitly overrides one in the current session ("just do it, no PR").
+- A rule is clearly wrong for the specific situation — in which case say so, explain why, and suggest updating this doc.
+
+The goal is maximum leverage per minute of the human's attention. If following a rule is blocking that, surface it.

--- a/docs/exec-plans/tech-debt.md
+++ b/docs/exec-plans/tech-debt.md
@@ -370,3 +370,17 @@ only copy of the work when the push/PR step fails.
 **Fix:** Step 9 (worktree cleanup + branch delete) must be gated on step 8 success.
 If push or PR creation fails, preserve the worktree and branch, increment the error
 count, and print recovery instructions (`git push origin <branch>` + `gh pr create`).
+
+---
+
+<!-- Resolved 2026-04-18: shipped `swapToUsdce()` + `canon-cli onboard`. -->
+<!-- See canon/templates/client-polymarket.ts and canon/cli/commands/onboard.ts. -->
+
+## Polymarket onboarding — ETH-from-bridge path
+
+**Severity:** P3
+**Area:** canon/cli/commands/onboard.ts
+**Logged:** 2026-04-18
+**Context:** Autoswap shipped for native USDC / USDT / POL. Users bridging ETH from L1 land with POS-bridged WETH on Polygon, not covered by the current onboard plan.
+
+**Fix:** add WETH as a `SwapSource`. Same Uniswap v3 quoter-driven pattern; pool exists at 0.05%.


### PR DESCRIPTION
Promotes 8 commits from \`ace-work\` to \`develop\` so \`/apply-core\` pulls the latest artifacts.

## What's new on develop after this merge

- **#181-#183** — Canon CLI session work: order routing via sidecar, \`canon-cli onboard\` (autoswap), \`canon-cli balance\` (on-chain), \`order open\`/\`trades\`, install manifest additions (\`polymarket.md\`, \`help.ts\` fallback, dual-source docs), agent operating-mode spec, Canon TUI wiring spec.
- **#184** — Dynamic PR target: \`github.pr_target\` from \`dega-core.yaml\` → \`develop\` → \`main\`. Repo default is \`ace-work\`.
- **#185** — Install manifest fix: \`canon/cli/commands/onboard.ts\` added (oversight from #182).
- Timeline + template fixes accumulated on ace-work but not yet on develop.

## Why this matters

The \`/apply-core\` skill fetches from \`https://raw.githubusercontent.com/DEGAorg/claude-code-config/develop/\`. Without this merge, installing agents anywhere on the machine gets pre-session artifacts — no \`onboard\` command, no updated skills, no help fallback, no dynamic pr_target.

## Conflict
develop has one commit ace-work doesn't (\`#180\` arb-binary fix + flow.json). Confirmed on scan: no overlap with our changes — clean 3-way merge expected.

## Merge
Use a merge commit (not squash) so the individual PR commits stay visible in develop's history for future cherry-picks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)