### PR TITLE
fix(arb-binary): route entry.ts through scan.ts order books, tolerate missing books

### DIFF
--- a/canon/templates/strategies/arb-binary/__tests__/scan.test.ts
+++ b/canon/templates/strategies/arb-binary/__tests__/scan.test.ts
@@ -287,6 +287,52 @@ describe("scanMarkets", () => {
     expect(deps.fetchOrderBook).not.toHaveBeenCalled();
   });
 
+  it("skips market when fetchOrderBook throws and still returns others", async () => {
+    const marketA = makeSearchResult({
+      conditionId: "cond-A",
+      question: "Market A",
+      yesTokenId: "tok-yes-A",
+      noTokenId: "tok-no-A",
+    });
+    const marketB = makeSearchResult({
+      conditionId: "cond-B",
+      question: "Market B",
+      yesTokenId: "tok-yes-B",
+      noTokenId: "tok-no-B",
+    });
+    const books: Record<string, OrderBook> = {
+      "tok-yes-B": makeOrderBook(
+        "tok-yes-B",
+        [{ price: 0.55, size: 100 }],
+        [{ price: 0.53, size: 300 }],
+      ),
+      "tok-no-B": makeOrderBook(
+        "tok-no-B",
+        [{ price: 0.30, size: 250 }],
+        [{ price: 0.28, size: 350 }],
+      ),
+    };
+    const deps: ScanDeps = {
+      searchMarkets: vi.fn(
+        async (_query: string) => [marketA, marketB],
+      ),
+      fetchOrderBook: vi.fn(
+        async (tokenId: string): Promise<OrderBook> => {
+          if (tokenId === "tok-yes-A" || tokenId === "tok-no-A") {
+            throw new Error("boom");
+          }
+          return (
+            books[tokenId] ?? { tokenId, asks: [], bids: [] }
+          );
+        },
+      ),
+    };
+    const result = await scanMarkets(makeConfig(), deps);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.conditionId).toBe("cond-B");
+  });
+
   it("skips market when order book has no asks", async () => {
     const market = makeSearchResult();
     const books: Record<string, OrderBook> = {

--- a/canon/templates/strategies/arb-binary/entry.ts
+++ b/canon/templates/strategies/arb-binary/entry.ts
@@ -1,19 +1,18 @@
 /**
  * ARB-01 Binary Arbitrage — Project Entry Point
  *
- * Wires the real Polymarket client into the arb-binary strategy.
- * Uses search result prices directly for signal detection — same
- * pattern as the nba-momentum template. No order book calls needed
- * for dry-run scanning.
+ * Wires the real Polymarket client into the arb-binary strategy via
+ * scanMarkets(), which fetches order books and derives best-ask prices
+ * from CLOB depth before running signal detection.
  */
 
 import { createRunner } from "../runner.js";
 import { appendEntry } from "../execution-log.js";
-import { searchMarkets as polySearchMarkets } from "../client-polymarket.js";
+import { searchMarkets, fetchOrderBook } from "../client-polymarket.js";
+import { scanMarkets } from "../strategies/arb-binary/scan.js";
 import { detectSignals } from "../strategies/arb-binary/signal.js";
 import { DEFAULT_ARB_BINARY_CONFIG } from "../strategies/arb-binary/config.js";
 import { createRiskChecker } from "../strategies/arb-binary/risk.js";
-import type { MarketData } from "../strategies/arb-binary/signal.js";
 import type { ExecutorDeps, PositionDeps } from "../runner.js";
 import type { Portfolio } from "../types/RiskInterface.js";
 import type { ExecutionLogEntry } from "../execution-log.js";
@@ -32,22 +31,10 @@ const risk = createRiskChecker({
 });
 
 const strategy = async () => {
-  const markets = await polySearchMarkets(strategyConfig.category);
-  const marketData: MarketData[] = [];
-  for (const m of markets) {
-    // Skip dead markets with no liquidity
-    if (m.yesPrice <= 0 || m.noPrice <= 0) continue;
-    marketData.push({
-      conditionId: m.conditionId,
-      question: m.question,
-      category: strategyConfig.category,
-      yesAsk: m.yesPrice,
-      noAsk: m.noPrice,
-      yesTokenId: m.yesTokenId ?? "",
-      noTokenId: m.noTokenId ?? "",
-      estimatedSlippage: 0,
-    });
-  }
+  const marketData = await scanMarkets(strategyConfig, {
+    searchMarkets,
+    fetchOrderBook,
+  });
   return detectSignals(marketData, strategyConfig);
 };
 

--- a/canon/templates/strategies/arb-binary/scan.ts
+++ b/canon/templates/strategies/arb-binary/scan.ts
@@ -46,10 +46,20 @@ export async function scanMarkets(
   const results: MarketData[] = [];
 
   for (const market of markets) {
-    const [yesBook, noBook] = await Promise.all([
-      deps.fetchOrderBook(market.yesTokenId),
-      deps.fetchOrderBook(market.noTokenId),
-    ]);
+    if (!market.yesTokenId || !market.noTokenId) {
+      continue;
+    }
+
+    let yesBook: OrderBook;
+    let noBook: OrderBook;
+    try {
+      [yesBook, noBook] = await Promise.all([
+        deps.fetchOrderBook(market.yesTokenId),
+        deps.fetchOrderBook(market.noTokenId),
+      ]);
+    } catch {
+      continue;
+    }
 
     if (yesBook.asks.length === 0 || noBook.asks.length === 0) {
       continue;


### PR DESCRIPTION
## Summary

Fix two bugs in the `canon/templates/strategies/arb-binary/` template. Both were proven and patched in `test-arb4` before landing here.

**Bug 1 — `entry.ts` bypassed `scan.ts`.** The strategy closure mapped `searchMarkets()` summary prices directly to YES/NO asks (`yesAsk: m.yesPrice`, `noAsk: m.noPrice`). Polymarket's summary prices always sum to 1.000 by construction, so `signal.ts`'s `if (cost >= 1.0) continue;` filter rejected every market. The scanner could never emit a signal against live data. Fixed by routing the closure through `scanMarkets()`, which fetches real order books and picks the lowest ask on each side.

**Bug 2 — `scan.ts` crashed on one bad market.** `Promise.all([fetchOrderBook(yesTokenId), fetchOrderBook(noTokenId)])` had no per-market error handling. When a market had no listed CLOB book (inactive, closed, or not yet listed), the Polymarket SDK threw `Order not found` and the whole cycle rejected. Fixed by wrapping the `Promise.all` in try/catch with `continue`, and by skipping markets with falsy `yesTokenId`/`noTokenId` before attempting the fetch.

Plan issue: #199.

## Commits

- \`b49eb1df\` — Add failing scan.test.ts case: \`fetchOrderBook\` throws for one market → \`scanMarkets\` skips it and still returns others
- \`ac33dd35\` — Fix scan.ts: try/catch + falsy-tokenId skip
- \`91707f28\` — Fix entry.ts: route through scanMarkets, drop inline summary-price mapping, rewrite misleading header comment

## Test plan

- [x] \`pnpm exec vitest run strategies/arb-binary\` from \`canon/templates/\` — 26/26 pass (includes new error-tolerance case)
- [ ] Reviewer confirms header comment in entry.ts accurately describes the order-book-based flow
- [ ] Reviewer confirms scan.ts try/catch placement doesn't swallow errors unrelated to missing books

## Out of scope (tracked separately)

- Pre-existing \`ethers\` module errors in \`client-polymarket.ts\` + tests — unrelated to arb-binary; separate plan coming.
- \`requirements.yaml\` convention for template-declared secrets — separate work.
- Live-API integration guard test (\`scan.live.test.ts\`) — separate work.
- Removing the \`src/main.ts\` duplicate in the scaffold — scaffold-script change, not a template change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)