### PR TITLE
fix(ci): shfmt canon-scaffold.sh — unblock Lint hooks

### DIFF
--- a/scripts/canon-scaffold.sh
+++ b/scripts/canon-scaffold.sh
@@ -69,7 +69,7 @@ fetch() {
 sed_inplace() {
   local expr="$1" file="$2"
   local tmp="${file}.tmp.$$"
-  sed "${expr}" "${file}" > "${tmp}" && mv "${tmp}" "${file}"
+  sed "${expr}" "${file}" >"${tmp}" && mv "${tmp}" "${file}"
 }
 
 # ── 0. Ensure git repo exists (orchestrator needs it for worktree isolation)


### PR DESCRIPTION
## Summary

One-line \`shfmt -i 2\` fix in \`scripts/canon-scaffold.sh:72\`. CI's \"Lint hooks\" check has been red on ace-work since commit \`35b9cefa\` (plan #176 \`20260415-wire-templates\`), which introduced \`sed \"\${expr}\" \"\${file}\" > \"\${tmp}\"\` with a space before \`>\`. \`shfmt -i 2\` normalizes that to \`>\"\${tmp}\"\`.

This is the only formatting deviation in the whole linted tree — \`shfmt -i 2 -d hooks/*.sh scripts/*.sh tests/*.sh\` is clean after the fix.

Merging this unblocks CI on open ace-work PRs #192, #193, #194, #195, #200, #203. All five were failing the same check.

## Test plan

- [x] \`shfmt -i 2 -d hooks/*.sh scripts/*.sh tests/*.sh\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)