### PR TITLE
chore: sync develop → main (pre-strategy-templates)

### DIFF
--- a/dega-core.yaml
+++ b/dega-core.yaml
@@ -20,7 +20,7 @@ github:
   labels: true
   comments: true
   close_on_ship: true
-  pr_target: ace-work
+  pr_target: develop
 
 timeline:
   repo: DEGAorg/claude-code-config


### PR DESCRIPTION
Sync develop into main before strategy-template PR #220 lands. Establishes main as the official release branch. A follow-up PR updates `commands/apply-core.md` to point the installer at `main` instead of `develop`.