### PR TITLE
fix(orch): ship steps 5-7 commit in worktree, not REPO_ROOT (#227)

### DIFF
--- a/scripts/orch-engine.sh
+++ b/scripts/orch-engine.sh
@@ -629,21 +629,33 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
   write_heartbeat
 
   # --- Step 7: Append to changelog ---
+  # Commit to the worktree (isolated checkout of orch branch) rather than
+  # REPO_ROOT to avoid landing stale-base trees on origin. Fall back to
+  # REPO_ROOT only if the worktree is absent.
+  WORKTREE_DIR="${ORCH_STATE_DIR}/worktrees/${SLUG}"
+  if [[ -d "${WORKTREE_DIR}" ]]; then
+    CHANGELOG_TARGET="${WORKTREE_DIR}"
+  else
+    CHANGELOG_TARGET="${REPO_ROOT}"
+  fi
   if [[ "${GH_SYNC}" == true ]]; then
     PLAN_TITLE=$(sed -n 's/^# Plan: *//p' "${PLAN_DIR}/plan.md" 2>/dev/null || true)
   else
     PLAN_TITLE=$(sed -n 's/^# Plan: *//p' "${COMPLETED_DIR}/plan.md" 2>/dev/null || true)
   fi
   if [[ -n "${PLAN_TITLE}" ]]; then
-    if orch_changelog_append "${SLUG}" "${PLAN_TITLE}" ""; then
-      git -C "${REPO_ROOT}" add "CHANGELOG.md"
-      if ! git -C "${REPO_ROOT}" diff --cached --quiet; then
-        if ! git -C "${REPO_ROOT}" commit --no-verify -m "orch: update changelog for ${SLUG}"; then
-          echo "orch-engine: ERROR — git commit failed for changelog update" >&2
+    if ORCH_REPO_ROOT="${CHANGELOG_TARGET}" orch_changelog_append "${SLUG}" "${PLAN_TITLE}" ""; then
+      git -C "${CHANGELOG_TARGET}" add "CHANGELOG.md"
+      if git -C "${CHANGELOG_TARGET}" diff --cached --quiet; then
+        echo "orch-engine: [SHIP 7/9] changelog unchanged — nothing to commit"
+      else
+        if orch_guarded_commit "${CHANGELOG_TARGET}" "orch: update changelog for ${SLUG}" "CHANGELOG.md"; then
+          echo "orch-engine: [SHIP 7/9] appended to changelog"
+        else
+          echo "orch-engine: ERROR — guarded commit failed for changelog update" >&2
           SHIP_ERRORS=$((SHIP_ERRORS + 1))
         fi
       fi
-      echo "orch-engine: [SHIP 7/9] appended to changelog"
     else
       echo "orch-engine: WARN — changelog append failed (non-fatal)"
     fi

--- a/scripts/orch-engine.sh
+++ b/scripts/orch-engine.sh
@@ -555,14 +555,26 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
 
   write_heartbeat
 
+  # Ship steps 4-7 run inside the worktree (isolated checkout of
+  # orch/<slug>) rather than REPO_ROOT. Committing inside REPO_ROOT
+  # when it is behind origin produces stale-tree commits that silently
+  # drop files added by interim PRs on origin/main. The worktree always
+  # reflects the orch branch so its tree is consistent with what the PR
+  # will merge. Fall back to REPO_ROOT only if the worktree is absent.
+  if [[ -d "${WORKTREE_DIR}" ]]; then
+    SHIP_TARGET="${WORKTREE_DIR}"
+  else
+    SHIP_TARGET="${REPO_ROOT}"
+  fi
+
   # --- Step 4: Move plan from active/ to completed/ ---
-  COMPLETED_DIR="${REPO_ROOT}/docs/exec-plans/completed/${SLUG}"
+  COMPLETED_DIR="${SHIP_TARGET}/docs/exec-plans/completed/${SLUG}"
   if [[ "${GH_SYNC}" == true ]]; then
     echo "orch-engine: [SHIP 4/9] skipped — GH mode (no local plan move)"
   else
-    ACTIVE_PLAN_DIR="${REPO_ROOT}/docs/exec-plans/active/${SLUG}"
+    ACTIVE_PLAN_DIR="${SHIP_TARGET}/docs/exec-plans/active/${SLUG}"
     if [[ -d "${ACTIVE_PLAN_DIR}" ]]; then
-      mkdir -p "${REPO_ROOT}/docs/exec-plans/completed"
+      mkdir -p "${SHIP_TARGET}/docs/exec-plans/completed"
       if mv "${ACTIVE_PLAN_DIR}" "${COMPLETED_DIR}"; then
         echo "orch-engine: [SHIP 4/9] moved plan to completed/"
       else
@@ -587,18 +599,27 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
   else
     # Stage the deletion of active/ (already moved by step 4) and new completed/ dir.
     # Guard each path — step 4 may have partially failed or paths may not exist.
-    git -C "${REPO_ROOT}" rm -r --cached --ignore-unmatch \
+    git -C "${SHIP_TARGET}" rm -r --cached --ignore-unmatch \
       "docs/exec-plans/active/${SLUG}" 2>/dev/null || true
-    if [[ -d "${REPO_ROOT}/docs/exec-plans/completed/${SLUG}" ]]; then
-      git -C "${REPO_ROOT}" add "docs/exec-plans/completed/${SLUG}"
+    if [[ -d "${SHIP_TARGET}/docs/exec-plans/completed/${SLUG}" ]]; then
+      git -C "${SHIP_TARGET}" add "docs/exec-plans/completed/${SLUG}"
     fi
-    if git -C "${REPO_ROOT}" diff --cached --quiet; then
+    if git -C "${SHIP_TARGET}" diff --cached --quiet; then
       echo "orch-engine: WARN — nothing to commit (plan move produced no diff)"
     else
-      if git -C "${REPO_ROOT}" commit --no-verify -m "orch: move ${SLUG} to completed"; then
+      # Allowlist matches only the active/<slug>/ and completed/<slug>/
+      # subtrees — any other staged path (e.g. a file deleted because of
+      # a stale-base mismatch) aborts the commit. Deletions under
+      # active/<slug>/ are expected because step 4 mv'd the directory,
+      # so ORCH_GUARDED_ALLOW_DELETIONS=1 is enabled for this step only.
+      if ORCH_GUARDED_ALLOW_DELETIONS=1 orch_guarded_commit \
+        "${SHIP_TARGET}" \
+        "orch: move ${SLUG} to completed" \
+        "docs/exec-plans/active/${SLUG}/*" \
+        "docs/exec-plans/completed/${SLUG}/*"; then
         echo "orch-engine: [SHIP 5/9] committed plan move"
       else
-        echo "orch-engine: ERROR — git commit failed for plan move" >&2
+        echo "orch-engine: ERROR — guarded commit failed for plan move" >&2
         SHIP_ERRORS=$((SHIP_ERRORS + 1))
       fi
     fi
@@ -611,12 +632,15 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
   if [[ "${GH_SYNC}" == true ]]; then
     echo "orch-engine: [SHIP 6/9] skipped — GH mode (issues are the registry)"
   else
-    if orch_registry_append "${SLUG}" "completed" "${ITER_COUNT}" "orch"; then
+    if ORCH_REPO_ROOT="${SHIP_TARGET}" \
+      orch_registry_append "${SLUG}" "completed" "${ITER_COUNT}" "orch"; then
       # Commit registry update
-      git -C "${REPO_ROOT}" add "docs/exec-plans/REGISTRY.md"
-      if ! git -C "${REPO_ROOT}" diff --cached --quiet; then
-        if ! git -C "${REPO_ROOT}" commit --no-verify -m "orch: update plan registry for ${SLUG}"; then
-          echo "orch-engine: ERROR — git commit failed for registry update" >&2
+      git -C "${SHIP_TARGET}" add "docs/exec-plans/REGISTRY.md"
+      if ! git -C "${SHIP_TARGET}" diff --cached --quiet; then
+        if ! orch_guarded_commit "${SHIP_TARGET}" \
+          "orch: update plan registry for ${SLUG}" \
+          "docs/exec-plans/REGISTRY.md"; then
+          echo "orch-engine: ERROR — guarded commit failed for registry update" >&2
           SHIP_ERRORS=$((SHIP_ERRORS + 1))
         fi
       fi
@@ -629,27 +653,18 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
   write_heartbeat
 
   # --- Step 7: Append to changelog ---
-  # Commit to the worktree (isolated checkout of orch branch) rather than
-  # REPO_ROOT to avoid landing stale-base trees on origin. Fall back to
-  # REPO_ROOT only if the worktree is absent.
-  WORKTREE_DIR="${ORCH_STATE_DIR}/worktrees/${SLUG}"
-  if [[ -d "${WORKTREE_DIR}" ]]; then
-    CHANGELOG_TARGET="${WORKTREE_DIR}"
-  else
-    CHANGELOG_TARGET="${REPO_ROOT}"
-  fi
   if [[ "${GH_SYNC}" == true ]]; then
     PLAN_TITLE=$(sed -n 's/^# Plan: *//p' "${PLAN_DIR}/plan.md" 2>/dev/null || true)
   else
     PLAN_TITLE=$(sed -n 's/^# Plan: *//p' "${COMPLETED_DIR}/plan.md" 2>/dev/null || true)
   fi
   if [[ -n "${PLAN_TITLE}" ]]; then
-    if ORCH_REPO_ROOT="${CHANGELOG_TARGET}" orch_changelog_append "${SLUG}" "${PLAN_TITLE}" ""; then
-      git -C "${CHANGELOG_TARGET}" add "CHANGELOG.md"
-      if git -C "${CHANGELOG_TARGET}" diff --cached --quiet; then
+    if ORCH_REPO_ROOT="${SHIP_TARGET}" orch_changelog_append "${SLUG}" "${PLAN_TITLE}" ""; then
+      git -C "${SHIP_TARGET}" add "CHANGELOG.md"
+      if git -C "${SHIP_TARGET}" diff --cached --quiet; then
         echo "orch-engine: [SHIP 7/9] changelog unchanged — nothing to commit"
       else
-        if orch_guarded_commit "${CHANGELOG_TARGET}" "orch: update changelog for ${SLUG}" "CHANGELOG.md"; then
+        if orch_guarded_commit "${SHIP_TARGET}" "orch: update changelog for ${SLUG}" "CHANGELOG.md"; then
           echo "orch-engine: [SHIP 7/9] appended to changelog"
         else
           echo "orch-engine: ERROR — guarded commit failed for changelog update" >&2

--- a/scripts/orch-state.sh
+++ b/scripts/orch-state.sh
@@ -618,6 +618,11 @@ orch_guarded_commit() {
   local message="$2"
   shift 2
   local allowed=("$@")
+  # Opt-in: permit staged deletions (D entries) when the path matches
+  # the allowlist. Off by default so the stale-base guard still applies
+  # to single-file ship steps (CHANGELOG, REGISTRY). Step 5 (plan move)
+  # sets this to 1 because the move legitimately removes active/<slug>/.
+  local allow_deletions="${ORCH_GUARDED_ALLOW_DELETIONS:-0}"
 
   if [[ ! -d "${dir}" ]]; then
     echo "orch_guarded_commit: directory not found: ${dir}" >&2
@@ -646,15 +651,12 @@ orch_guarded_commit() {
     R* | C*) path="${rest}" ;;
     esac
 
-    if [[ "${change_type}" == D* ]]; then
-      echo "orch_guarded_commit: refusing to commit — staged deletion of '${path}' not allowed" >&2
-      return 1
-    fi
-
     local matched=false
     local allow
     for allow in "${allowed[@]}"; do
-      if [[ "${path}" == "${allow}" ]]; then
+      # Unquoted RHS: enable glob matching (e.g. "docs/path/<slug>/*").
+      # shellcheck disable=SC2053
+      if [[ "${path}" == ${allow} ]]; then
         matched=true
         break
       fi
@@ -662,6 +664,11 @@ orch_guarded_commit() {
 
     if [[ "${matched}" != true ]]; then
       echo "orch_guarded_commit: refusing to commit — staged path '${path}' not in allowlist (${allowed[*]})" >&2
+      return 1
+    fi
+
+    if [[ "${change_type}" == D* && "${allow_deletions}" != "1" ]]; then
+      echo "orch_guarded_commit: refusing to commit — staged deletion of '${path}' not allowed" >&2
       return 1
     fi
   done <<<"${staged}"

--- a/scripts/orch-state.sh
+++ b/scripts/orch-state.sh
@@ -607,6 +607,68 @@ orch_create_worktree() {
   echo "orch-state: created worktree at ${worktree_dir} on branch ${branch}"
 }
 
+# Commit pre-staged changes in <dir>, verifying every staged path is on
+# the allowlist and rejecting any delete entries. Ship-step commits must
+# not remove files — the guard defends against stale-base bugs where the
+# staged diff silently drops files present on origin but absent locally.
+#   Usage: orch_guarded_commit <dir> <message> <allowed_path>...
+# Caller pre-stages files; this helper only verifies + commits.
+orch_guarded_commit() {
+  local dir="$1"
+  local message="$2"
+  shift 2
+  local allowed=("$@")
+
+  if [[ ! -d "${dir}" ]]; then
+    echo "orch_guarded_commit: directory not found: ${dir}" >&2
+    return 1
+  fi
+
+  if ((${#allowed[@]} == 0)); then
+    echo "orch_guarded_commit: at least one allowed path is required" >&2
+    return 1
+  fi
+
+  local staged
+  staged=$(git -C "${dir}" diff --cached --name-status 2>/dev/null || true)
+
+  if [[ -z "${staged}" ]]; then
+    echo "orch_guarded_commit: no staged changes in ${dir}" >&2
+    return 1
+  fi
+
+  while IFS=$'\t' read -r change_type path rest; do
+    [[ -z "${change_type}" ]] && continue
+
+    # Rename/copy entries have form "R100<TAB>old<TAB>new" — the new path
+    # is what the commit introduces and is what must match the allowlist.
+    case "${change_type}" in
+    R* | C*) path="${rest}" ;;
+    esac
+
+    if [[ "${change_type}" == D* ]]; then
+      echo "orch_guarded_commit: refusing to commit — staged deletion of '${path}' not allowed" >&2
+      return 1
+    fi
+
+    local matched=false
+    local allow
+    for allow in "${allowed[@]}"; do
+      if [[ "${path}" == "${allow}" ]]; then
+        matched=true
+        break
+      fi
+    done
+
+    if [[ "${matched}" != true ]]; then
+      echo "orch_guarded_commit: refusing to commit — staged path '${path}' not in allowlist (${allowed[*]})" >&2
+      return 1
+    fi
+  done <<<"${staged}"
+
+  git -C "${dir}" commit --no-verify -m "${message}"
+}
+
 orch_commit_worktree() {
   local slug="$1"
   local worktree_dir="${ORCH_STATE_DIR}/worktrees/${slug}"

--- a/tests/orch/test_ship_hook_deletion.bats
+++ b/tests/orch/test_ship_hook_deletion.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# Regression test for the ship hook deletion bug (#227).
+#
+# The bug: SHIP step 7 committed CHANGELOG.md against REPO_ROOT. When
+# REPO_ROOT was behind origin (another PR had merged in the background),
+# the commit pinned to a stale local HEAD. Later sync paths could land
+# that stale-tree commit on origin, silently deleting files introduced
+# by the interim PR.
+#
+# The fix: SHIP steps 5/6/7 run inside the worktree (on the orch/<slug>
+# branch) and use orch_guarded_commit to reject any staged path outside
+# the allowlist. This test verifies:
+#
+#   1. REPO_ROOT's HEAD is untouched by the ship-step commit.
+#   2. The worktree commit adds CHANGELOG.md and nothing else.
+#   3. Merging the orch branch into origin/main via a three-way merge
+#      preserves files added by the interim "other PR" commit.
+
+SCRIPTS_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../../scripts" && pwd)"
+
+setup() {
+  TEST_TMPDIR="$(mktemp -d -t orch-ship-XXXXXX)"
+  ORIGIN_DIR="${TEST_TMPDIR}/origin.git"
+  REPO_ROOT="${TEST_TMPDIR}/repo"
+  SLUG="stale-base"
+
+  git init --quiet --bare --initial-branch=main "${ORIGIN_DIR}"
+
+  # REPO_ROOT: base commit, pushed to origin/main.
+  git clone --quiet "${ORIGIN_DIR}" "${REPO_ROOT}"
+  git -C "${REPO_ROOT}" config user.email "test@example.com"
+  git -C "${REPO_ROOT}" config user.name "Test"
+  git -C "${REPO_ROOT}" config commit.gpgsign false
+  echo "base" >"${REPO_ROOT}/README.md"
+  git -C "${REPO_ROOT}" add README.md
+  git -C "${REPO_ROOT}" commit --quiet --no-verify -m "base"
+  git -C "${REPO_ROOT}" push --quiet origin main
+
+  # "Other PR" merges into origin/main adding docs/exec-plans/completed/plan-a.
+  # REPO_ROOT does not fetch — it stays on the stale base.
+  OTHER_DIR="${TEST_TMPDIR}/other"
+  git clone --quiet "${ORIGIN_DIR}" "${OTHER_DIR}"
+  git -C "${OTHER_DIR}" config user.email "test@example.com"
+  git -C "${OTHER_DIR}" config user.name "Test"
+  git -C "${OTHER_DIR}" config commit.gpgsign false
+  mkdir -p "${OTHER_DIR}/docs/exec-plans/completed/plan-a"
+  echo "# Plan A" >"${OTHER_DIR}/docs/exec-plans/completed/plan-a/plan.md"
+  git -C "${OTHER_DIR}" add docs/exec-plans/completed/plan-a/plan.md
+  git -C "${OTHER_DIR}" commit --quiet --no-verify -m "add plan-a"
+  git -C "${OTHER_DIR}" push --quiet origin main
+
+  # Create an orch worktree forked from REPO_ROOT's stale HEAD.
+  ORCH_STATE_DIR="${REPO_ROOT}/.orchestrator"
+  WORKTREE_DIR="${ORCH_STATE_DIR}/worktrees/${SLUG}"
+  mkdir -p "${ORCH_STATE_DIR}/worktrees"
+  git -C "${REPO_ROOT}" worktree add --quiet -b "orch/${SLUG}" \
+    "${WORKTREE_DIR}" HEAD
+  git -C "${WORKTREE_DIR}" config user.email "test@example.com"
+  git -C "${WORKTREE_DIR}" config user.name "Test"
+  git -C "${WORKTREE_DIR}" config commit.gpgsign false
+
+  export ORCH_REPO_ROOT="${REPO_ROOT}"
+  export ORCH_STATE_DIR
+
+  # shellcheck source=/dev/null
+  source "${SCRIPTS_DIR}/orch-state.sh"
+}
+
+teardown() {
+  if [[ -n "${TEST_TMPDIR:-}" && -d "${TEST_TMPDIR}" ]]; then
+    rm -rf "${TEST_TMPDIR}"
+  fi
+}
+
+@test "ship step 7 commits in worktree only and preserves files added on origin" {
+  local repo_head_before
+  repo_head_before=$(git -C "${REPO_ROOT}" rev-parse HEAD)
+
+  # Simulate SHIP step 7: append CHANGELOG relative to the worktree and
+  # commit inside the worktree via the guarded helper.
+  ORCH_REPO_ROOT="${WORKTREE_DIR}" \
+    orch_changelog_append "${SLUG}" "Fix ship hook deletion" "Fixed"
+
+  [ -f "${WORKTREE_DIR}/CHANGELOG.md" ]
+
+  git -C "${WORKTREE_DIR}" add CHANGELOG.md
+  run orch_guarded_commit "${WORKTREE_DIR}" \
+    "orch: update changelog for ${SLUG}" "CHANGELOG.md"
+  [ "${status}" -eq 0 ]
+
+  # REPO_ROOT's HEAD must be untouched — no SHIP-step commit lands there.
+  local repo_head_after
+  repo_head_after=$(git -C "${REPO_ROOT}" rev-parse HEAD)
+  [ "${repo_head_before}" = "${repo_head_after}" ]
+
+  # REPO_ROOT's working tree must have no staged or unstaged changes.
+  [ -z "$(git -C "${REPO_ROOT}" status --porcelain)" ]
+
+  # The worktree advanced by exactly one commit whose diff adds CHANGELOG.md
+  # and touches nothing else (no deletions, no unrelated paths).
+  local wt_commits
+  wt_commits=$(git -C "${WORKTREE_DIR}" rev-list \
+    --count "${repo_head_before}..HEAD")
+  [ "${wt_commits}" -eq 1 ]
+
+  local name_status
+  name_status=$(git -C "${WORKTREE_DIR}" diff --name-status HEAD~1 HEAD)
+  [ "${name_status}" = "A"$'\t'"CHANGELOG.md" ]
+
+  # End-to-end: merging orch/<slug> into origin/main via a three-way merge
+  # must not drop plan-a.md (the file the interim PR added to origin).
+  git -C "${WORKTREE_DIR}" push --quiet origin "orch/${SLUG}"
+
+  local MERGE_DIR="${TEST_TMPDIR}/merge"
+  git clone --quiet "${ORIGIN_DIR}" "${MERGE_DIR}"
+  git -C "${MERGE_DIR}" config user.email "test@example.com"
+  git -C "${MERGE_DIR}" config user.name "Test"
+  git -C "${MERGE_DIR}" config commit.gpgsign false
+  git -C "${MERGE_DIR}" fetch --quiet origin "orch/${SLUG}"
+  git -C "${MERGE_DIR}" merge --quiet --no-ff --no-edit FETCH_HEAD
+
+  [ -f "${MERGE_DIR}/docs/exec-plans/completed/plan-a/plan.md" ]
+  [ -f "${MERGE_DIR}/CHANGELOG.md" ]
+}

--- a/tests/orch/test_ship_hook_deletion.bats
+++ b/tests/orch/test_ship_hook_deletion.bats
@@ -49,8 +49,10 @@ setup() {
   git -C "${OTHER_DIR}" commit --quiet --no-verify -m "add plan-a"
   git -C "${OTHER_DIR}" push --quiet origin main
 
-  # Create an orch worktree forked from REPO_ROOT's stale HEAD.
-  ORCH_STATE_DIR="${REPO_ROOT}/.orchestrator"
+  # Create an orch worktree forked from REPO_ROOT's stale HEAD. The
+  # worktree is placed outside REPO_ROOT so it does not appear as an
+  # untracked directory in REPO_ROOT's working tree.
+  ORCH_STATE_DIR="${TEST_TMPDIR}/orchestrator"
   WORKTREE_DIR="${ORCH_STATE_DIR}/worktrees/${SLUG}"
   mkdir -p "${ORCH_STATE_DIR}/worktrees"
   git -C "${REPO_ROOT}" worktree add --quiet -b "orch/${SLUG}" \


### PR DESCRIPTION
## Summary

- Relocates SHIP steps 5 (plan move), 6 (registry), and 7 (changelog) in `scripts/orch-engine.sh` from `REPO_ROOT` → worktree.
- Adds `orch_guarded_commit` helper in `scripts/orch-state.sh` that rejects commits containing unexpected paths or deletions.
- Adds regression test `tests/orch/test_ship_hook_deletion.bats` that reproduces the stale-base scenario from #227 and asserts no files are deleted.

## Why

Per #227, when the user ran orch from a local branch behind `origin`, the ship-hook commit pinned to the stale HEAD and deleted the in-between PR's files when later synced. The worktree is an isolated checkout of the orch branch — committing there removes the entire class of "stale REPO_ROOT" incidents.

Closes #231, fixes #227.

## Test plan

- [x] `bats tests/orch/test_ship_hook_deletion.bats` — 1/1 pass
- [x] `shellcheck scripts/orch-engine.sh scripts/orch-state.sh` exits 0
- [x] `shfmt -d scripts/orch-engine.sh scripts/orch-state.sh` exits 0
- [x] No \`git -C "\${REPO_ROOT}" add|commit\` in SHIP lines 550-660

## Note on orchestrator run

Orch completed all 4 implementation items but hit the known VERIFYING hang (memory: project_orch_verify_hang) on item 5 (verification-only, no file changes). Ran the completion criteria manually — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)