### PR TITLE
docs: rename conductor-view → canon-tui (live refs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,7 +263,7 @@ Active work:
 
 ### Canon TUI wiring
 
-The Canon TUI (`DEGAorg/conductor-view`, separate repo) is not auto-wired to this repo's knowledge. See `canon/docs/tui-wiring.md` for what the TUI must do to access `canon-cli` commands and installed skills, and what it must NOT duplicate.
+The Canon TUI (`DEGAorg/canon-tui`, separate repo) is not auto-wired to this repo's knowledge. See `canon/docs/tui-wiring.md` for what the TUI must do to access `canon-cli` commands and installed skills, and what it must NOT duplicate.
 
 ### Commit and push — prohibited
 

--- a/canon/AGENTS.md
+++ b/canon/AGENTS.md
@@ -127,7 +127,7 @@ gets overwritten on the next install.
 the binary lives inside a checkout of this repo; falls back to
 `~/.degacore/config/skills/` otherwise. See `canon/cli/commands/help.ts`.
 
-**Canon TUI (`DEGAorg/conductor-view`, Toad fork):** separate repo. It
+**Canon TUI (`DEGAorg/canon-tui`, Toad fork):** separate repo. It
 does not automatically inherit these skills. See `canon/docs/tui-wiring.md`
 for the wiring contract (`canon-cli` subprocess + JSON envelope, skill
 file locations, what not to vendor/reimplement).

--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -445,7 +445,7 @@ Dashboard state writes degrade gracefully:
 
 **Canon TUI detection:** The session is valid if ANY of these are true:
 - `$TMUX` is set (tmux fallback)
-- `$CANON_TUI` is set (Canon TUI / conductor-view)
+- `$CANON_TUI` is set (Canon TUI / canon-tui)
 - `.canon/state.json` exists and was updated within the last 5 minutes (TUI wrote init state)
 
 Every `terminal-ui-write.sh` call in this command is already guarded with

--- a/canon/docs/tui-wiring.md
+++ b/canon/docs/tui-wiring.md
@@ -1,6 +1,6 @@
 # Canon TUI Wiring
 
-How the Canon TUI (aka "conductor-view", a Toad fork at `DEGAorg/conductor-view`) accesses Canon knowledge and commands. **This is a separate repo** — it does not automatically inherit anything from `claude-code-config`.
+How the Canon TUI (aka "canon-tui", a Toad fork at `DEGAorg/canon-tui`) accesses Canon knowledge and commands. **This is a separate repo** — it does not automatically inherit anything from `claude-code-config`.
 
 ## Two surfaces the TUI needs
 
@@ -53,7 +53,7 @@ Alternative: shell out to `canon-cli help <name>` and render the JSON `data.cont
 
 ## Open items for the TUI side
 
-These need to be decided in the conductor-view repo, not here:
+These need to be decided in the canon-tui repo, not here:
 
 - Caching strategy for skill content (re-read on each render, or cache in memory).
 - Whether the TUI should spawn its own burner wallet or require `POLYMARKET_PRIVATE_KEY` to be pre-set.

--- a/commands/canon-init.md
+++ b/commands/canon-init.md
@@ -30,7 +30,7 @@ Do not stop at the first failure — check all of them so the user gets one comp
 
 | Check | Command | If missing |
 |-------|---------|-----------|
-| canon or tmux | `command -v canon \|\| command -v tmux` | "Install canon (preferred): see DEGAorg/conductor-view README, or tmux: `brew install tmux`" |
+| canon or tmux | `command -v canon \|\| command -v tmux` | "Install canon (preferred): see DEGAorg/canon-tui README, or tmux: `brew install tmux`" |
 | agent-shim.sh | `[[ -f "${DEGA_CORE_HOME:-${HOME}/.degacore}/scripts/agent-shim.sh" ]]` | "Run `/apply-core` to install the agent shim" |
 | canon-scaffold.sh | `[[ -f "${DEGA_CORE_HOME:-${HOME}/.degacore}/scripts/canon-scaffold.sh" ]]` | "Run `/apply-core` and select Canon Scaffold" |
 
@@ -108,7 +108,7 @@ fi
 # ── Fallback: tmux with agent + dashboard ────────────────────────────
 if ! command -v tmux >/dev/null 2>&1; then
   echo "error: neither canon nor tmux found. Install one of:"
-  echo "  canon — see DEGAorg/conductor-view README"
+  echo "  canon — see DEGAorg/canon-tui README"
   echo "  tmux  — brew install tmux"
   exit 1
 fi

--- a/docs/canon-quickstart.md
+++ b/docs/canon-quickstart.md
@@ -8,7 +8,7 @@ Run `/apply-core` inside any AI agent (Claude, Gemini, Codex) and select
 **Canon Bootstrap**. This installs the Canon scripts globally.
 
 You also need one of:
-- **Canon TUI** (recommended) — see DEGAorg/conductor-view README
+- **Canon TUI** (recommended) — see DEGAorg/canon-tui README
 - **tmux** — `brew install tmux`
 
 ## Steps
@@ -77,6 +77,6 @@ my-strategy/
 | Problem | Fix |
 |---------|-----|
 | `/canon-init` says prerequisites missing | Run `/apply-core` and select Canon Bootstrap + Terminal UI |
-| `./canon.sh` says neither canon nor tmux found | Install the Canon TUI (see DEGAorg/conductor-view) or `brew install tmux` |
+| `./canon.sh` says neither canon nor tmux found | Install the Canon TUI (see DEGAorg/canon-tui) or `brew install tmux` |
 | Scaffold fails to fetch from GitHub | Check internet connection; scaffold fetches from `raw.githubusercontent.com` |
 | Build phase hangs | Check `dega-core.yaml` has a valid `check_command` for your project |

--- a/docs/canon-tui-integration.md
+++ b/docs/canon-tui-integration.md
@@ -1,9 +1,9 @@
-# Conductor TUI Integration — Work Items for conductor-view
+# Conductor TUI Integration — Work Items for canon-tui
 
 > **Date:** 2026-04-06
-> **Repo:** DEGAorg/conductor-view (`/Users/cerratoa/dega/conductor-view`)
+> **Repo:** DEGAorg/canon-tui (`/Users/cerratoa/dega/canon-tui`)
 > **Context:** The Conductor agent prompt lives in `claude-code-config/agents/conductor.md`.
-> This document lists work needed in the conductor-view repo to make the
+> This document lists work needed in the canon-tui repo to make the
 > Conductor the default entry agent and clean up panel control.
 
 ---
@@ -159,7 +159,7 @@ see a clear indication they're talking to the Conductor, not raw Claude.
 
 ---
 
-## File Reference (all paths relative to conductor-view root)
+## File Reference (all paths relative to canon-tui root)
 
 | File | Purpose |
 |------|---------|

--- a/docs/conductor-agent-design.md
+++ b/docs/conductor-agent-design.md
@@ -144,7 +144,7 @@ Same notification mechanism.
   interception pattern). Replace with socket CLI usage in the Conductor
   agent prompt.
 
-### Conductor-view repo (DEGAorg/conductor-view)
+### Conductor-view repo (DEGAorg/canon-tui)
 
 - [ ] Add panel-specific socket commands (e.g.,
   `{"cmd": "panel", "id": "project_state", "action": "open"}`) so the

--- a/focus-instructions.md
+++ b/focus-instructions.md
@@ -15,9 +15,9 @@ in the claude-code-config repository.
 ## Multi-repo plans
 
 Plans that modify repos other than claude-code-config must:
-- Include a `repo:` field in the plan header (e.g., `repo: conductor-view`)
+- Include a `repo:` field in the plan header (e.g., `repo: canon-tui`)
 - Be tracked as GitHub Issues in the core repo (DEGAorg/claude-code-config)
-- Use `repo:conductor-view` label for routing
+- Use `repo:canon-tui` label for routing
 - Account for separate worktree setup in the target repo
 - Reference the decision doc: `docs/decisions/20260321-multi-repo-plan-architecture.md`
 

--- a/scripts/canon.sh
+++ b/scripts/canon.sh
@@ -31,7 +31,7 @@ fi
 # ── Fallback: tmux with agent + dashboard ────────────────────────────
 if ! command -v tmux >/dev/null 2>&1; then
   echo "error: neither canon nor tmux found. Install one of:"
-  echo "  canon — see DEGAorg/conductor-view README"
+  echo "  canon — see DEGAorg/canon-tui README"
   echo "  tmux  — brew install tmux"
   exit 1
 fi

--- a/skills/tui-control.md
+++ b/skills/tui-control.md
@@ -6,7 +6,7 @@ widgets from shell commands.
 
 ## Client
 
-Use `canon-ctl` (in the conductor-view repo) or `socat` directly:
+Use `canon-ctl` (in the canon-tui repo) or `socat` directly:
 
 ```bash
 # Auto-discovers the socket


### PR DESCRIPTION
## Summary

Updates live user-facing references from `DEGAorg/conductor-view` to `DEGAorg/canon-tui`. GitHub repo rename already happened; this aligns docs, scripts, and skills with the current name.

## Scope

11 files, +18/-18 plus one rename (`docs/conductor-tui-integration.md` → `docs/canon-tui-integration.md`).

Touches: `AGENTS.md`, `canon/AGENTS.md`, `scripts/canon.sh`, `commands/canon-init.md`, `canon/commands/canon-start.md`, `docs/canon-quickstart.md`, `skills/tui-control.md`, `canon/docs/tui-wiring.md`, `focus.yaml`, `focus-instructions.md`, `docs/conductor-agent-design.md`.

## Out of scope (kept as-is)

- `docs/exec-plans/completed/*` — frozen plan snapshots
- `docs/decisions/*` — point-in-time design docs
- `ace/*` — personal session notes
- `docs/exec-plans/active/20260330-canon-toad-*` — stale active plans (handle separately if revived)
- `docs/toad-canon-sections-spec.md` — tied to those stale plans

## Related

Part of Canon TUI migration admin cleanup. Milestone #45 already closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)