### PR TITLE
Add safe local Claude and Codex skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,18 +337,19 @@ This uses `type: "prompt"` instead of `type: "command"` -- Claude Code sends the
 
 ### Plugins and Skills
 
-Agents' capabilities come from skills (reusable workflows, checklists, decision frameworks), subagents (specialized personas), and slash commands (scripted sequences). In DEGA Core, these live directly in this repo — not in external marketplaces — and are installed into each supported agent (`~/.claude/`, `~/.gemini/`, `~/.codex/`) by `/apply-core`.
+Agents' capabilities come from skills (reusable workflows, checklists, decision frameworks), subagents (specialized personas), and slash commands (scripted sequences). In DEGA Core, these live directly in this repo — not in external marketplaces. Shared Core artifacts are installed by `/apply-core`; harness-specific skill packages are stored here and can be copied into the matching agent until installer support is wired in.
 
-| Kind | Source in this repo | Installed to |
+| Kind | Source in this repo | Install behavior |
 |------|---------------------|--------------|
-| Skills | `skills/` | `~/.claude/skills/`, `~/.gemini/skills/`, `~/.codex/skills/` |
+| Shared skills | `skills/*.md` | Installed as agent-readable DEGA Core skill references |
+| Harness skills | `skills/claude/<name>/`, `skills/codex/<name>/` | Stored as Claude/Codex `SKILL.md` packages; copy manually until installer support lands |
 | Subagents | `agents/` | `~/.claude/agents/` (Claude-only) |
 | Slash commands | `commands/` | `~/.claude/commands/`, `~/.gemini/commands/`, `~/.codex/commands/` |
 | Rules | `rules/` | `~/.claude/rules/`, `~/.gemini/rules/`, `~/.codex/rules/` |
 
-To add or change any of these: edit the file in this repo, commit, and re-run `/core-update` (or `update dega core`) on any machine. The install is idempotent — running it again brings every artifact to latest `main`.
+To add or change shared installer-owned artifacts: edit the file in this repo, commit, and re-run `/core-update` (or `update dega core`) on any machine. The install is idempotent — running it again brings installer-supported artifacts to latest `main`.
 
-For authoring conventions (SKILL.md frontmatter, structure, testing locally) see **[Writing Skills and Agents](#writing-skills-and-agents)** below.
+For authoring conventions, package layout, and privacy review steps, see **[Writing Skills and Agents](#writing-skills-and-agents)** below.
 
 #### agent-browser skill
 
@@ -587,28 +588,130 @@ Skills and agents encode expertise rather than procedures. Where a command runs 
 
 ### Adding a skill to this repo
 
-1. Create `skills/<skill-name>/SKILL.md` (or a single `skills/<skill-name>.md` for tiny skills — see existing examples in `skills/`).
-2. Use this frontmatter:
+There are two skill layouts:
 
-   ```markdown
-   ---
-   name: <skill-name>
-   description: One-line hook — when should the agent invoke this?
-   ---
+- `skills/*.md` — compact shared DEGA Core references used by this repo's
+  own workflows.
+- `skills/claude/<skill-name>/` and `skills/codex/<skill-name>/` — packaged
+  Claude Code and Codex skills with `SKILL.md` and optional bundled resources.
 
-   # <Skill Name>
+Before adding a local skill, inspect the repo for overlap:
 
-   <body: when to use, what to do, decision framework>
-   ```
+```bash
+find skills canon/skills -maxdepth 3 -type f | sort
+rg -n "<skill-name>|<distinctive phrase from the skill>" skills canon/skills README.md
+```
 
-3. Test locally before publishing: copy the file into `~/.claude/skills/` (or run `/core-update` from this checkout) and invoke it in a session.
-4. Commit and push. Users pick it up the next time they run `update dega core` or `/core-update`.
+If an existing skill is redundant or materially overlaps, decide whether to
+skip, replace, merge, rename, or keep both with clearer descriptions before
+copying files.
 
-The same pattern applies to `agents/` (subagent prompts), `commands/` (slash commands), and `rules/` (language standards). Anything dropped into these directories is installed by `/apply-core` into every detected agent's config directory.
+For a packaged harness skill, create both harness directories when both variants
+exist:
+
+```text
+skills/
+  claude/
+    <skill-name>/
+      SKILL.md
+      scripts/
+      references/
+  codex/
+    <skill-name>/
+      SKILL.md
+      scripts/
+      references/
+```
+
+Use this frontmatter for Claude Code:
+
+```markdown
+---
+name: <skill-name>
+description: One-line hook — when should the agent invoke this?
+argument-hint: "[optional invocation hint]"
+allowed-tools: Bash Read Write Edit Glob Grep  # list only the tools actually needed
+user-invocable: true
+---
+
+# <Skill Name>
+
+<body: when to use, what to do, decision framework>
+
+## Task
+
+$ARGUMENTS
+```
+
+Use this frontmatter for Codex:
+
+```markdown
+---
+name: <skill-name>
+description: One-line hook — when should the agent invoke this?
+---
+
+# <Skill Name>
+
+<body: when to use, what to do, decision framework>
+```
+
+Adapt between harnesses deliberately:
+
+- Claude Code supports `argument-hint`, `allowed-tools`, `user-invocable`, and
+  the trailing `## Task` / `$ARGUMENTS` section.
+- Codex uses only `name` and `description` frontmatter for routing, so keep the
+  body direct and avoid Claude-specific tool names unless the skill is
+  explicitly Claude-only.
+- Copy shared resources into both harness directories. Do not symlink between
+  `.claude` and `.codex` paths; either harness should work independently.
+
+Only include files that directly support the skill:
+
+- Include: `SKILL.md`, small reference files, deterministic helper scripts, and
+  optional UI metadata such as `agents/openai.yaml`.
+- Exclude: virtual environments, caches, compiled files, generated output,
+  local state, credential files, and machine-specific setup artifacts.
+
+Run a privacy and portability pass before committing:
+
+```bash
+find skills -name '__pycache__' -o -name '*.pyc' -o -name '.venv' -o -name '.env' -o -name '.env.*'
+private_scan='(/Us''ers/|TO''KEN|SEC''RET|API_''KEY|PASS''WORD|Bea''rer|oauth2''service)'
+rg -n "$private_scan" skills
+rg -n '<private-email>|<private-domain>|<private-org>|<private-project>' skills
+```
+
+Normalize examples to use `$HOME`, `$CLAUDE_HOME`, `$CODEX_HOME`, or
+skill-relative paths. Never commit real credentials, personal account
+inventories, private domains, private project names, hardcoded machine paths, or
+instructions that depend on one person's local auth state.
+
+Test locally before publishing by copying the packaged skill into a throwaway
+agent config directory or by installing it into the matching local harness and
+invoking it in a fresh session:
+
+```bash
+cp -R skills/claude/<skill-name> "${CLAUDE_HOME:-$HOME/.claude}/skills/<skill-name>"
+cp -R skills/codex/<skill-name> "${CODEX_HOME:-$HOME/.codex}/skills/<skill-name>"
+```
+
+Commit only after reviewing the full diff:
+
+```bash
+git diff --check
+git diff --stat
+git diff
+```
+
+The same review discipline applies to `agents/` (subagent prompts), `commands/`
+(slash commands), and `rules/` (language standards). Keep generated artifacts
+out of git and verify how `/apply-core` installs each surface before relying on
+automatic distribution.
 
 ### Publishing skills
 
-Skills live in this repo — open a PR against `DEGAorg/claude-code-config`. There is no separate marketplace. Once merged to `main`, every installed instance picks up the skill on the next `update dega core` / `/core-update`.
+Skills live in this repo — open a PR against `DEGAorg/claude-code-config`. There is no separate marketplace. Shared skills are picked up on the next `update dega core` / `/core-update`; harness-specific `SKILL.md` packages are available from the repo and must be copied into the matching agent directory until installer support is added.
 
 ## Recommended Skills
 

--- a/skills/claude/calendar-create-event/SKILL.md
+++ b/skills/claude/calendar-create-event/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: calendar-create-event
+description: Create calendar events, reminders, recurring series, or .ics fallback files for Calendar workflows. Use when the user asks to create calendar events, reminders, invites, recurring reminders, or importable .ics files.
+argument-hint: "[what event or reminder series to create, including date/time, attendees, recurrence, and whether direct creation or .ics fallback is acceptable]"
+allowed-tools: Bash Read Write Edit Glob Grep
+user-invocable: true
+---
+
+# Calendar Create Event
+
+Use this skill when the user wants calendar events created, especially reminders, guest invites, recurring schedules, or a local `.ics` file they can import.
+
+1. Parse the request into concrete calendar inputs:
+   - target calendar/account
+   - event title
+   - start date/time
+   - timezone
+   - duration
+   - attendees
+   - recurrence
+   - alarms/reminders
+   - direct-creation vs `.ics` fallback preference
+
+2. Prefer direct calendar creation if the available integration/auth path supports it.
+   - If using a Google Workspace service-account flow, test the Calendar scope once.
+   - If the Calendar scope is blocked or undelegated, do not keep retrying. Switch to `.ics` fallback.
+
+3. Prefer one recurring event over many separate events when the reminders describe the same obligation.
+   - Monthly reminders for the same deadline should usually be one event with an `RRULE`, not 10 standalone `VEVENT`s.
+   - Only create separate events if the user explicitly asks for them.
+
+4. For `.ics` fallback:
+   - Use Write or Edit to create a valid iCalendar file.
+   - Use one `VEVENT` plus `RRULE` for recurring series whenever possible.
+   - Include `UID`, `DTSTAMP`, `SUMMARY`, `DESCRIPTION`, `ORGANIZER`, attendee lines if requested, and `VALARM` when reminders are wanted.
+   - Put the file somewhere convenient, usually `~/Downloads`, unless the user asked for a different location.
+
+5. Keep the process efficient.
+   - Do not repeatedly inspect the same auth failure.
+   - Do not create many standalone events when a recurring series is cleaner.
+   - Verify recurrence count, first occurrence, timezone, and attendee list before finishing.
+
+6. When using `.ics`, explicitly tell the user that importing usually adds the event(s) locally, but guest invitations may not be emailed automatically after import.
+
+7. Consult [playbook.md](playbook.md) for recurrence rules, `.ics` patterns, and Google Workspace Calendar fallback guidance.
+
+8. Report the result clearly:
+   - whether the event was created directly or via `.ics`
+   - title
+   - first occurrence
+   - recurrence rule or count
+   - attendees
+   - file path if an `.ics` file was written
+
+## Task
+
+$ARGUMENTS

--- a/skills/claude/calendar-create-event/playbook.md
+++ b/skills/claude/calendar-create-event/playbook.md
@@ -1,0 +1,85 @@
+# Calendar Create Event Playbook
+
+Use this playbook for creating reminders, recurring events, and `.ics` fallback files.
+
+## Decision order
+
+1. Prefer direct event creation if the auth path actually supports Calendar writes.
+2. If the direct Calendar API path fails due to missing delegation or blocked auth, switch to `.ics` fallback immediately.
+3. If the user wants repeated reminders for one obligation, prefer one recurring event instead of many separate events.
+
+## Google Workspace Calendar fallback
+
+- The Google Workspace helper may support Gmail or Admin SDK tasks while Calendar remains undelegated.
+- If `https://www.googleapis.com/auth/calendar` returns `401 unauthorized_client`, do not keep retrying.
+- In that case, create an importable `.ics` file instead.
+
+## Recurrence defaults
+
+For repeated reminders about the same deadline:
+
+- Monthly reminders should usually be one `VEVENT` with:
+  - `RRULE:FREQ=MONTHLY;COUNT=<n>`
+- Use separate events only if the user explicitly wants separate acceptances, different descriptions, different attendees, or irregular dates.
+
+Example:
+
+```ics
+BEGIN:VEVENT
+UID:example-1@local
+DTSTAMP:20260422T000000Z
+DTSTART;TZID=America/New_York:20300915T090000
+DTEND;TZID=America/New_York:20300915T091500
+SUMMARY:Example recurring reminder
+RRULE:FREQ=MONTHLY;COUNT=10
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:Example recurring reminder
+TRIGGER:-PT0M
+END:VALARM
+END:VEVENT
+```
+
+## `.ics` minimum structure
+
+```ics
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Local Skill//Calendar Create Event//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VEVENT
+...
+END:VEVENT
+END:VCALENDAR
+```
+
+Recommended event fields:
+
+- `UID`
+- `DTSTAMP`
+- `DTSTART`
+- `DTEND`
+- `SUMMARY`
+- `DESCRIPTION`
+- `RRULE` when recurring
+- `ORGANIZER`
+- `ATTENDEE` lines when the user wants guests
+- `VALARM` when a reminder should appear on import
+
+## Attendee caveat
+
+Including attendees in an `.ics` file is useful, but importing the file does not always cause Google Calendar or other providers to send invitation emails automatically.
+
+Tell the user this plainly when you use `.ics` fallback.
+
+## Output checklist
+
+Before finishing, confirm:
+
+- title is correct
+- timezone is correct
+- first occurrence is correct
+- recurrence count/rule is correct
+- attendees are correct
+- file path is easy to access

--- a/skills/claude/git-update/SKILL.md
+++ b/skills/claude/git-update/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: git-update
+description: Stage, commit, and push the current git work safely. Use when the user asks to "git update", commit current changes, ship the current branch, or stage, commit, and push a set of completed edits to the remote repository.
+argument-hint: "[optional: files or scope to commit]"
+allowed-tools: Bash Read Grep
+user-invocable: true
+---
+
+# Git Update
+
+Determine the active repository first. If the current working directory is
+inside a nested repository, operate on that repository; otherwise operate on the
+parent repository. Confirm with `git rev-parse --show-toplevel`.
+
+Inspect the current state before changing anything:
+
+```bash
+git status
+git diff --staged
+git diff
+git log --oneline -5
+```
+
+Stop if there is nothing relevant to commit. If the tree is clean, or only
+unrelated/generated noise is present, report that and do not create an empty
+commit.
+
+Stage only the files relevant to the recent work. Prefer explicit paths over
+`git add -A` or `git add .` so credentials, env files, binaries, and unrelated
+churn do not get swept in accidentally.
+
+Write a concise commit message that explains the reason for the change, not a
+file-by-file summary. Match the repository's recent commit style when it is
+clear.
+
+Commit non-interactively. Prefer `git commit -F -` with piped message content
+or `git commit -m` for a short single-line message. Do not open an editor.
+
+Before pushing, inspect the branch and repository policy. Never force push. Do
+not push directly from `main`, `master`, or a branch that matches the repo's
+configured PR target. Stop and tell the user to create a feature branch and PR
+instead.
+
+Push only a non-trunk feature branch to the current branch's tracking remote. If
+no upstream is configured, detect the branch name and push with
+`git push -u origin <branch>`.
+
+If push fails because the environment blocks network access or needs approval,
+request escalation rather than stopping at the local commit.
+
+Report the result with the commit hash and whether the push succeeded.
+
+## Task
+
+$ARGUMENTS

--- a/skills/claude/ls/SKILL.md
+++ b/skills/claude/ls/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: ls
+description: List files and directories in the current working directory (or a specified path) as a readable multi-column markdown table. Use when the user wants to see folder contents.
+argument-hint: [path]
+allowed-tools: Read Glob
+user-invocable: true
+---
+
+# List Directory Contents
+
+List files and directories formatted as a 3-column markdown table, sorted alphabetically. Directories are marked with a trailing `/`.
+
+## Instructions
+
+1. Use the Glob tool with pattern `*` on the target directory (use the argument as the path if provided, otherwise use the current working directory).
+2. Also glob for directories specifically using pattern `*/` on the same path to identify which entries are directories.
+3. Sort all entries alphabetically (case-insensitive).
+4. Append `/` to directory names.
+5. Format the results into a 3-column markdown table with headers `| Name | Name | Name |`.
+6. Fill columns left-to-right, row by row. If the last row has fewer than 3 entries, leave remaining cells empty.
+7. Show a total count at the bottom: `**N items** (X files, Y directories)`
+
+## Example Output
+
+| Name | Name | Name |
+|---|---|---|
+| README.md | canon-slides/ | docs/ |
+| index.ts | package.json | specs/ |
+| tsconfig.json | | |
+
+**7 items** (4 files, 3 directories)
+
+## Task
+
+$ARGUMENTS

--- a/skills/claude/make-universal-skill/SKILL.md
+++ b/skills/claude/make-universal-skill/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: make-universal-skill
+description: Create a new skill that works in both Claude Code (~/.claude/skills/) and Codex (~/.codex/skills/) from a single request. Writes two adapted SKILL.md files plus any shared resource files. Use when the user asks to create, author, or scaffold a new skill and wants it available in both harnesses.
+argument-hint: "[skill name and what it does]"
+allowed-tools: Bash Read Write Edit Glob Grep
+user-invocable: true
+---
+
+# Make Universal Skill
+
+Author a new skill that exists in **both** `~/.claude/skills/<name>/` and `~/.codex/skills/<name>/`. A single logical skill, two harness-appropriate SKILL.md files, with shared resource files (reference docs, playbooks, helper scripts) duplicated across both directories so either harness is self-sufficient.
+
+## When to invoke
+
+The user says something like "make a skill that...", "create a /foo skill", "I want a universal skill for X". Also fire when they explicitly say "for both Claude and Codex" or "in both harnesses."
+
+## Input handling
+
+`$ARGUMENTS` is the user's skill request. It usually contains a name and a purpose. If the name is unclear, derive a kebab-case slug from the purpose. If the purpose is too vague to write a useful skill, ask **one** focused clarifying question before proceeding (what should it actually *do* when invoked?). Don't demand a full spec — enough to draft.
+
+## Workflow
+
+1. **Decide the name and shape.** Pick a kebab-case slug (`my-skill`). Decide whether the skill needs auxiliary files:
+   - A reference doc (`reference.md`, `playbook.md`, `api-reference.md`) — use when the skill benefits from loading a large body of reusable knowledge only when actually running.
+   - A helper script (`scripts/*.py`, `scripts/*.sh`) — use when the skill does deterministic work better done by code than by the model.
+   - A credential wrapper script + migration setup script — use whenever the skill needs an API key or bot token. See **Secrets and credentials** below for the full pattern.
+   - Just SKILL.md — most cases.
+
+2. **Check for collisions.** Before writing, glob `~/.claude/skills/<name>/` and `~/.codex/skills/<name>/`. If either exists, ask the user whether to overwrite, pick a different name, or edit the existing skill instead.
+
+3. **Write the Claude Code SKILL.md** at `~/.claude/skills/<name>/SKILL.md` with this structure:
+
+   ```markdown
+   ---
+   name: <slug>
+   description: <one sentence: what it does + "Use when..." trigger phrasing so the skill router can match it>
+   argument-hint: "[what the user should type after /<slug>]"
+   allowed-tools: <space-separated tool names the skill actually uses — Bash Read Write Edit Glob Grep etc.>
+   user-invocable: true
+   ---
+
+   # <Title Case Name>
+
+   <Body: instructions written to Claude. Reference Claude tools by name (Glob, Grep, Read, Edit, Write, Bash, TaskCreate). Reference aux files with relative links: [playbook.md](playbook.md).>
+
+   ## Task
+
+   $ARGUMENTS
+   ```
+
+   The `## Task\n\n$ARGUMENTS` tail is how user-invoked args reach the skill body in Claude Code. Include it whenever `user-invocable: true`.
+
+4. **Write the Codex SKILL.md** at `~/.codex/skills/<name>/SKILL.md` — same ideas, adapted:
+
+   ```markdown
+   ---
+   name: <slug>
+   description: <same one-sentence description, or a slightly terser variant>
+   ---
+
+   # <Title Case Name>
+
+   <Body: same instructions, but:
+   - Drop references to Claude-specific tool names; use generic verbs ("search for", "read the file", "run this bash command").
+   - Drop the `$ARGUMENTS` placeholder — Codex passes args through conversation, not substitution.
+   - Drop the `## Task` tail section.
+   - Keep the tone terser and more imperative; Codex skills tend to be shorter.
+   - Reference aux files with relative links the same way: [playbook.md](playbook.md).>
+   ```
+
+5. **Write shared resource files to BOTH directories** (identical content). If you created a `playbook.md` or `api-reference.md`, write it to both `~/.claude/skills/<name>/` and `~/.codex/skills/<name>/`. If you created helper scripts, write them under `scripts/` in both. Each harness must be self-sufficient — never symlink across `.claude`/`.codex`.
+
+6. **Verify.** After writing, list both directories and show the user what was created. If the skill has a reference doc, confirm the link resolves in each location.
+
+## Writing good skill bodies
+
+- **Lead with when to invoke and what input looks like.** The router matches on the description; the body matches on the situation.
+- **Instructions, not narration.** Numbered steps, imperatives. Not "I will then..."
+- **Hardcode non-obvious constraints.** Rate limits, destructive-action confirmations, env vars to check first, format requirements.
+- **Reference aux files instead of inlining long content.** A 400-line API reference belongs in `api-reference.md`, loaded on demand.
+- **End with output format** if the skill produces structured output (tables, summaries, commit messages).
+
+## Secrets and credentials
+
+Any skill that needs an API key, bot token, or other credential follows this
+pattern. Do not ask the user to export credentials in their shell startup files,
+and do not store credentials in broad agent config that every subprocess can
+inherit.
+
+1. **Storage layout** — scoped credential files at `chmod 600`, one per service:
+   - Claude Code: `$CLAUDE_HOME/<service>.env` or `$HOME/.claude/<service>.env`
+   - Codex: `$CODEX_HOME/<service>.env` or `$HOME/.codex/<service>.env`
+
+   Both contain plain `NAME=value` lines, one line per required variable. Example:
+   ```
+   # Written by setup_<service>_api_key.sh. chmod 600.
+   # Sourced on demand by the /<service> skill; NOT auto-loaded into the shell.
+   SERVICE_CREDENTIAL=...
+   ```
+
+2. **Setup script** — if setup is non-trivial, write a companion script that:
+   - Reads required values from the current environment or a hidden prompt.
+   - Writes both scoped credential files at 0600.
+   - Strips any prior `export <VAR>=` lines from `~/.zshenv`, `.zprofile`, `.zshrc`, `.bash_profile`, `.bashrc`, `.profile`.
+   - Runs `launchctl unsetenv <VAR>` and removes any matching LaunchAgent plist.
+
+   **zsh gotcha:** inside functions, `local path="..."` silently clobbers `$PATH` because zsh aliases `$path` to the `$PATH` array. Use `target`, `env_path`, or similar.
+
+3. **Runtime loading** — the skill accesses credentials only through a
+   `scripts/<service>-api.sh` wrapper that sources the scoped file for the
+   duration of each call. Never inline credential values in commands, examples,
+   logs, or error messages. Generic loader block:
+
+   ```bash
+   script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+   claude_home="${CLAUDE_HOME:-$HOME/.claude}"
+   codex_home="${CODEX_HOME:-$HOME/.codex}"
+   case "$script_dir" in
+     */codex/*) candidates=("$codex_home/<service>.env" "$claude_home/<service>.env") ;;
+     *)         candidates=("$claude_home/<service>.env" "$codex_home/<service>.env") ;;
+   esac
+   env_file=""
+   for f in "${candidates[@]}"; do
+     [[ -r "$f" ]] && { env_file="$f"; break; }
+   done
+   [[ -z "$env_file" ]] && { echo "Credential file not found for <service>." >&2; exit 1; }
+   set -a; source "$env_file"; set +a
+   ```
+
+   The harness-match ordering means a skill invoked from Codex prefers the Codex-scoped file and falls back to Claude's copy (and vice versa), so either harness is self-sufficient even if the user only migrated once.
+
+4. **SKILL.md must document the credential layout:** a `## Credentials` section
+   naming the two generic file paths, noting the `chmod 600` requirement, and
+   instructing the skill to use the wrapper rather than inline commands. Forbid
+   echoing or logging credential values.
+
+5. **MCP-server skills are the exception.** If the skill only configures an MCP
+   server, follow that server's official scoped configuration guidance. Do not
+   use broad config storage for skills that call REST APIs directly.
+
+## Adaptation rules (Claude → Codex)
+
+| Claude Code | Codex equivalent |
+|---|---|
+| `Glob`, `Grep`, `Read`, `Edit`, `Write` tools | "search for", "read", "edit", "write" (generic) |
+| `TaskCreate` for progress tracking | drop — Codex doesn't have equivalent; just execute |
+| `$ARGUMENTS` placeholder | drop — user message carries the arg |
+| `## Task\n\n$ARGUMENTS` trailing section | drop |
+| `allowed-tools:` frontmatter | drop |
+| `user-invocable: true` frontmatter | drop |
+| `argument-hint:` frontmatter | drop |
+| Links like `[playbook.md](playbook.md)` | keep — both harnesses resolve them |
+| Bash commands | keep verbatim — both harnesses run bash |
+
+## Common pitfalls
+
+- **Don't symlink across harnesses.** Copy. A user may have only one harness installed, or the two paths may diverge.
+- **Don't forget `user-invocable: true` on Claude side** if the user will type `/<name>`. Without it, the skill exists but isn't reachable by slash command.
+- **Keep the description trigger-rich.** Both harnesses route by description. "Use when..." or "Use whenever..." phrasing helps.
+- **Don't write the same skill twice from scratch.** Draft the body once (mentally or in a scratch), then mechanically apply the adaptation rules for the Codex version.
+
+## Output
+
+After creating the files, report:
+
+- The two SKILL.md paths written
+- Any aux files written (to both locations)
+- The slash command the user can now type in Claude Code (`/<name>`)
+- How Codex will invoke it (by description match, no slash prefix needed in Codex)
+
+## Task
+
+$ARGUMENTS

--- a/skills/claude/no-edits/SKILL.md
+++ b/skills/claude/no-edits/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: no-edits
+description: Switch into conversation-only mode — answer questions, discuss, explain, but make no file edits or other mutating changes. Use when the user wants to talk through the code/problem without changes being made.
+argument-hint: "[optional: topic or question to discuss]"
+allowed-tools: Read Glob Grep Bash WebFetch WebSearch
+user-invocable: true
+---
+
+# No Edits
+
+Conversation-only mode. For the remainder of this session (until the user explicitly lifts the mode), do not modify any files or shared state.
+
+## Rules
+
+1. **Do not use mutating tools.** Forbidden: `Edit`, `Write`, `NotebookEdit`, and any Bash command that changes files, runs migrations, pushes to remotes, sends messages, or otherwise produces side effects outside the local read-only filesystem.
+2. **Read-only tools are fine.** `Read`, `Glob`, `Grep`, read-only `Bash` (`ls`, `git status`, `git log`, `git diff`, `cat`-equivalent lookups), `WebFetch`, `WebSearch`. Use them freely to inform your answers.
+3. **Answer the question.** Explain, discuss, sketch approaches, compare tradeoffs, walk through code. If the user asks "how would you fix X", describe the fix in prose or a code block — do not apply it.
+4. **If the user asks for an edit anyway**, pause and confirm: remind them no-edits mode is active and ask whether they want to lift it for this change. Only proceed with edits after explicit confirmation.
+5. **No memory writes, no commits, no pushes, no PRs, no external messages.** Even if a default behavior would normally persist something, skip it while this mode is active.
+
+## How to exit
+
+The user lifts no-edits mode by saying something like "ok go ahead and edit", "you can make the change now", "edits are fine", or by invoking a skill/command that implies edits (e.g. `/git-update`). Treat that as explicit consent for the specific action they described, not a blanket lift — if unsure, ask.
+
+## Task
+
+$ARGUMENTS

--- a/skills/claude/transcribe-ig/SKILL.md
+++ b/skills/claude/transcribe-ig/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: transcribe-ig
+description: Transcribe an Instagram video (Reel, post, story) to text. Use when the user asks to transcribe, get captions, or extract text from an Instagram video.
+argument-hint: <instagram-url> [output-file] [--format text|json|srt] [--model tiny|base|small|medium|large] [--language en]
+allowed-tools: Bash Read Write
+user-invocable: true
+---
+
+# Instagram Video Transcription
+
+Transcribe an Instagram video using only trusted, audited tools: yt-dlp (download), ffmpeg (audio extraction), and openai-whisper (transcription). No third-party Instagram scrapers.
+
+## Setup
+
+The script requires `openai-whisper` installed in a Python environment. Use a
+dedicated virtual environment inside the installed skill directory.
+
+### First-time setup (run once if venv doesn't exist):
+
+```bash
+SKILL_DIR="${CLAUDE_HOME:-$HOME/.claude}/skills/transcribe-ig"
+if [ ! -d "$SKILL_DIR/.venv" ]; then
+  python3 -m venv "$SKILL_DIR/.venv"
+  "$SKILL_DIR/.venv/bin/pip" install --upgrade pip
+  "$SKILL_DIR/.venv/bin/pip" install openai-whisper
+fi
+```
+
+### Required system tools (must already be installed):
+- `yt-dlp`
+- `ffmpeg`
+
+Supported wherever `yt-dlp` can read Chrome cookies: macOS, Linux, and Windows.
+
+### Instagram authentication:
+- yt-dlp uses `--cookies-from-browser chrome` to read Instagram session cookies from Chrome
+- The user must be logged into Instagram in Chrome
+- Cookie extraction depends on browser and OS support in `yt-dlp`
+- On first run, macOS may prompt for Keychain access
+
+## Usage
+
+```bash
+SKILL_DIR="${CLAUDE_HOME:-$HOME/.claude}/skills/transcribe-ig"
+"$SKILL_DIR/.venv/bin/python3" "$SKILL_DIR/scripts/transcribe.py" <URL> [OPTIONS]
+```
+
+## Arguments from user
+
+Parse `$ARGUMENTS` as: `<instagram-url> [output-file] [--format text|json|srt] [--model tiny|base|small|medium|large] [--language <code>]`
+
+- If the user provides an output file path, use `-o <path>`
+- If no output file is specified, save to the current directory as `ig_transcript.txt`
+- Default format is `text`. Use `--format json` for timestamped segments, `--format srt` for subtitles
+- Default model is `base`. For better accuracy use `small` or `medium` (slower but more accurate)
+- Use `--language` to force a language (e.g., `en`, `es`). If omitted, Whisper auto-detects
+
+## Steps
+
+1. Check if the venv exists; if not, create it and install `openai-whisper`
+2. Extract the Instagram URL from `$ARGUMENTS`
+3. Determine the output file path (from args or default to `ig_transcript.txt`)
+4. Run the transcription script with the appropriate arguments
+5. Report the result to the user (file path, segment count, character count, detected language)
+
+## Error handling
+
+- If the venv or `openai-whisper` is missing, run the setup commands above
+- If yt-dlp fails with "login required", remind the user to log into Instagram in Chrome
+- If yt-dlp fails with other errors, suggest updating yt-dlp: `yt-dlp -U`
+- If Whisper is slow, suggest using a smaller model (`tiny` or `base`)
+
+## Task
+
+$ARGUMENTS

--- a/skills/claude/transcribe-ig/scripts/transcribe.py
+++ b/skills/claude/transcribe-ig/scripts/transcribe.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Transcribe an Instagram video using yt-dlp + ffmpeg + whisper.
+
+Uses only trusted, widely-audited tools:
+- yt-dlp: downloads video with Chrome cookies for IG auth
+- ffmpeg: extracts audio
+- whisper: transcribes audio to text
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+
+def _export_ig_cookies(cookie_file: str) -> None:
+    """Export only .instagram.com cookies from Chrome to a Netscape cookie file."""
+    # yt-dlp's own cookie decryption handles the encryption, so we use yt-dlp
+    # to dump cookies then filter. This avoids reimplementing Chrome's keychain decryption.
+    dump_cmd = [
+        "yt-dlp",
+        "--cookies-from-browser", "chrome",
+        "--cookies", cookie_file,
+        "--skip-download",
+        "https://www.instagram.com",
+    ]
+    result = subprocess.run(dump_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Cookie export warning: {result.stderr}", file=sys.stderr)
+        return
+
+    # Now filter the cookie file to only .instagram.com domains
+    if os.path.exists(cookie_file):
+        with open(cookie_file, "r") as f:
+            lines = f.readlines()
+
+        with open(cookie_file, "w") as f:
+            for line in lines:
+                if line.startswith("#") or line.strip() == "":
+                    f.write(line)
+                    continue
+                if "\t" not in line:
+                    continue
+                domain = line.split("\t", 1)[0]
+                if domain == ".instagram.com" or domain.endswith(".instagram.com"):
+                    f.write(line)
+
+
+def download_video(url: str, output_path: str) -> str:
+    """Download Instagram video using yt-dlp with filtered IG-only cookies."""
+    # Create a filtered cookie file containing only .instagram.com cookies
+    cookie_file = os.path.join(os.path.dirname(output_path), "ig_cookies.txt")
+    _export_ig_cookies(cookie_file)
+
+    if os.path.exists(cookie_file) and os.path.getsize(cookie_file) > 0:
+        cmd = [
+            "yt-dlp",
+            "--cookies", cookie_file,
+            "--no-playlist",
+            "--merge-output-format", "mp4",
+            "-o", output_path,
+            url,
+        ]
+    else:
+        # Fallback if cookie export failed
+        print("Warning: filtered cookie export failed, falling back to --cookies-from-browser", file=sys.stderr)
+        cmd = [
+            "yt-dlp",
+            "--cookies-from-browser", "chrome",
+            "--no-playlist",
+            "--merge-output-format", "mp4",
+            "-o", output_path,
+            url,
+        ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"yt-dlp error:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    # Clean up cookie file immediately after use
+    if os.path.exists(cookie_file):
+        os.remove(cookie_file)
+
+    return output_path
+
+
+def extract_audio(video_path: str, audio_path: str) -> str:
+    """Extract audio from video using ffmpeg."""
+    cmd = [
+        "ffmpeg", "-y",
+        "-i", video_path,
+        "-vn",
+        "-acodec", "pcm_s16le",
+        "-ar", "16000",
+        "-ac", "1",
+        audio_path,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ffmpeg error:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return audio_path
+
+
+def transcribe_audio(audio_path: str, model_name: str = "base", language: str | None = None) -> dict:
+    """Transcribe audio using openai-whisper."""
+    import whisper
+
+    model = whisper.load_model(model_name)
+    options = {}
+    if language:
+        options["language"] = language
+
+    result = model.transcribe(audio_path, **options)
+
+    segments = []
+    for seg in result.get("segments", []):
+        segments.append({
+            "text": seg["text"].strip(),
+            "start": seg["start"],
+            "end": seg["end"],
+        })
+
+    full_text = " ".join(s["text"] for s in segments)
+
+    return {
+        "text": full_text,
+        "segment_count": len(segments),
+        "char_count": len(full_text),
+        "language": result.get("language", "unknown"),
+        "segments": segments,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transcribe an Instagram video")
+    parser.add_argument("url", help="Instagram URL (reel, post, story)")
+    parser.add_argument("-o", "--output", help="Output file path (default: stdout)")
+    parser.add_argument("-f", "--format", choices=["text", "json", "srt"], default="text",
+                        help="Output format (default: text)")
+    parser.add_argument("-m", "--model", default="base",
+                        choices=["tiny", "base", "small", "medium", "large"],
+                        help="Whisper model size (default: base)")
+    parser.add_argument("-l", "--language", default=None,
+                        help="Language code (e.g., en, es)")
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        video_path = os.path.join(tmpdir, "video.mp4")
+        audio_path = os.path.join(tmpdir, "audio.wav")
+
+        print("Downloading Instagram video...", file=sys.stderr)
+        download_video(args.url, video_path)
+
+        print("Extracting audio...", file=sys.stderr)
+        extract_audio(video_path, audio_path)
+
+        print(f"Transcribing with Whisper ({args.model} model)...", file=sys.stderr)
+        result = transcribe_audio(audio_path, model_name=args.model, language=args.language)
+
+    print(f"Detected language: {result['language']}", file=sys.stderr)
+
+    if args.format == "json":
+        output = json.dumps(result, indent=2, ensure_ascii=False)
+    elif args.format == "srt":
+        lines = []
+        for i, s in enumerate(result["segments"], 1):
+            def fmt(t):
+                h = int(t // 3600)
+                m = int((t % 3600) // 60)
+                sec = int(t % 60)
+                ms = int((t % 1) * 1000)
+                return f"{h:02d}:{m:02d}:{sec:02d},{ms:03d}"
+            lines.append(f"{i}")
+            lines.append(f"{fmt(s['start'])} --> {fmt(s['end'])}")
+            lines.append(s["text"])
+            lines.append("")
+        output = "\n".join(lines)
+    else:
+        output = result["text"]
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(output)
+        print(f"Saved {result['segment_count']} segments ({result['char_count']} chars) to {args.output}",
+              file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/claude/transcribe-yt/SKILL.md
+++ b/skills/claude/transcribe-yt/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: transcribe-yt
+description: Transcribe a YouTube video to text. Use when the user asks to transcribe, get captions, or extract text from a YouTube video.
+argument-hint: <youtube-url-or-video-id> [output-file] [--format text|json|srt] [--languages en es ...]
+allowed-tools: Bash Read Write
+user-invocable: true
+---
+
+# YouTube Video Transcription
+
+Transcribe a YouTube video using the `youtube-transcript-api` Python library.
+
+## Setup
+
+The script requires `youtube-transcript-api` in a Python environment. Prefer a
+project-local `.venv` when available; otherwise use any Python that can import
+the package.
+
+## Usage
+
+Run the transcription script:
+
+```bash
+# Find a working Python environment with youtube-transcript-api.
+PYTHON_BIN=""
+for candidate in .venv/bin/python3 python3; do
+  if command -v "$candidate" >/dev/null 2>&1 || [ -x "$candidate" ]; then
+    if "$candidate" -c "import youtube_transcript_api" 2>/dev/null; then
+      PYTHON_BIN="$candidate"
+      break
+    fi
+  fi
+done
+
+if [ -z "$PYTHON_BIN" ]; then
+  python3 -m pip install youtube-transcript-api
+  PYTHON_BIN=python3
+fi
+
+SKILL_DIR="${CLAUDE_HOME:-$HOME/.claude}/skills/transcribe-yt"
+"$PYTHON_BIN" "$SKILL_DIR/scripts/transcribe.py" <URL_OR_ID> [OPTIONS]
+```
+
+## Arguments from user
+
+Parse `$ARGUMENTS` as: `<youtube-url-or-id> [output-file] [--format text|json|srt] [--languages ...]`
+
+- If the user provides an output file path, use `-o <path>`
+- If no output file is specified, save to the current directory as `<video_id>_transcript.txt`
+- Default format is `text`. Use `--format json` for timestamped data, `--format srt` for subtitle format
+
+## Steps
+
+1. Extract the YouTube URL or video ID from `$ARGUMENTS`
+2. Determine the output file path (from args or default to `<video_id>_transcript.txt` in the current directory)
+3. Run the transcription script with the appropriate arguments
+4. Report the result to the user (file path, snippet count, character count)
+
+## Error handling
+
+- If `youtube-transcript-api` is not installed, install it in a virtual environment when possible.
+- If the video has no captions available, inform the user and suggest alternatives (e.g., downloading audio + Whisper)
+- If a specific language is not available, try without language filter to get whatever is available
+
+## Task
+
+$ARGUMENTS

--- a/skills/claude/transcribe-yt/scripts/transcribe.py
+++ b/skills/claude/transcribe-yt/scripts/transcribe.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Transcribe a YouTube video using youtube-transcript-api."""
+
+import argparse
+import json
+import re
+import sys
+
+
+def extract_video_id(url_or_id: str) -> str:
+    """Extract video ID from a YouTube URL or return as-is if already an ID."""
+    patterns = [
+        r'(?:youtu\.be/|youtube\.com/watch\?v=|youtube\.com/embed/|youtube\.com/v/)([a-zA-Z0-9_-]{11})',
+        r'^([a-zA-Z0-9_-]{11})$',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, url_or_id)
+        if match:
+            return match.group(1)
+    return url_or_id
+
+
+def transcribe(video_id: str, languages: list[str] | None = None) -> dict:
+    """Fetch transcript and return structured data."""
+    from youtube_transcript_api import YouTubeTranscriptApi
+
+    api = YouTubeTranscriptApi()
+    kwargs = {}
+    if languages:
+        kwargs["languages"] = languages
+
+    transcript = api.fetch(video_id, **kwargs)
+
+    snippets = []
+    for entry in transcript.snippets:
+        snippets.append({
+            'text': entry.text,
+            'start': entry.start,
+            'duration': entry.duration,
+        })
+
+    full_text = '\n'.join(s['text'] for s in snippets)
+
+    return {
+        'video_id': video_id,
+        'snippet_count': len(snippets),
+        'char_count': len(full_text),
+        'text': full_text,
+        'snippets': snippets,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Transcribe a YouTube video')
+    parser.add_argument('url', help='YouTube URL or video ID')
+    parser.add_argument('-o', '--output', help='Output file path (default: stdout)')
+    parser.add_argument('-f', '--format', choices=['text', 'json', 'srt'], default='text',
+                        help='Output format (default: text)')
+    parser.add_argument('-l', '--languages', nargs='+', default=None,
+                        help='Preferred languages (e.g., en es)')
+    args = parser.parse_args()
+
+    video_id = extract_video_id(args.url)
+    result = transcribe(video_id, args.languages)
+
+    if args.format == 'json':
+        output = json.dumps(result, indent=2, ensure_ascii=False)
+    elif args.format == 'srt':
+        lines = []
+        for i, s in enumerate(result['snippets'], 1):
+            start = s['start']
+            end = start + s['duration']
+            def fmt(t):
+                h = int(t // 3600)
+                m = int((t % 3600) // 60)
+                sec = int(t % 60)
+                ms = int((t % 1) * 1000)
+                return f'{h:02d}:{m:02d}:{sec:02d},{ms:03d}'
+            lines.append(f'{i}')
+            lines.append(f'{fmt(start)} --> {fmt(end)}')
+            lines.append(s['text'])
+            lines.append('')
+        output = '\n'.join(lines)
+    else:
+        output = result['text']
+
+    if args.output:
+        with open(args.output, 'w', encoding='utf-8') as f:
+            f.write(output)
+        print(f"Saved {result['snippet_count']} snippets ({result['char_count']} chars) to {args.output}",
+              file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/claude/word-docx-redlines/SKILL.md
+++ b/skills/claude/word-docx-redlines/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: word-docx-redlines
+description: >-
+  Create, read, validate, and compare Word (.docx) documents with Track Changes.
+  Write real Track Changes XML (w:ins/w:del) into .docx files for native
+  accept/reject in Word. Validate that a redlined .docx correctly implements
+  a change specification by extracting and auditing existing tracked changes.
+  Generate redline comparison documents from two versions. Use when the user
+  asks to work with Word documents, .docx files, tracked changes, redlines,
+  document comparison, validating redlines, auditing changes, or modifying
+  Word files programmatically.
+argument-hint: "[docx task, document paths, or redline validation request]"
+allowed-tools: Bash Read Write Edit Glob Grep
+user-invocable: true
+---
+
+# Word Document Redlines & Track Changes
+
+## Prerequisites
+
+```bash
+brew install pandoc
+pip install python-docx   # or: python3 -m venv .venv && source .venv/bin/activate && pip install python-docx
+```
+
+## Core Capabilities
+
+### 1. Extract text from .docx
+
+Use pandoc for clean text extraction (better than python-docx `.text` which misses field codes):
+
+```bash
+pandoc document.docx -t plain --wrap=none
+```
+
+python-docx `.text` misses content in Word field codes, bookmarks, and complex formatting. To get ALL text from a paragraph:
+
+```python
+def full_text(para):
+    return "".join(t.text or "" for t in para._element.findall(".//" + qn("w:t")))
+```
+
+### 2. Iterate paragraphs in document order
+
+Body paragraphs and table cell paragraphs are separate in python-docx:
+
+```python
+from docx.oxml.ns import qn
+from docx.text.paragraph import Paragraph
+
+body = doc.element.body
+for child in body:
+    if child.tag == qn("w:p"):
+        para = Paragraph(child, body)
+    elif child.tag == qn("w:tbl"):
+        # table - iterate rows/cells separately
+        pass
+```
+
+### 3. Write real Track Changes XML
+
+Use `w:del` for deletions and `w:ins` for insertions. These produce native accept/reject buttons in Word.
+
+See `scripts/track_changes_helpers.py` for ready-to-use helper functions: `make_del()`, `make_ins()`, `replace_para()`, `delete_para()`, `insert_para_after()`.
+
+### 4. Generate a redline comparison document
+
+**Recommended workflow:**
+
+1. Extract text from original .docx via pandoc
+2. Normalize both versions (strip markdown, fix unicode, collapse whitespace)
+3. Diff with `difflib.SequenceMatcher` (line-level alignment, word-level diff for changes)
+4. Apply changes as Track Changes XML into a copy of the original .docx
+
+For step 4, use **targeted search** (find paragraphs by unique text snippet) rather than index-based or fuzzy alignment. See the "Targeted Approach" section below.
+
+## Key Lessons / Gotchas
+
+### Text normalization is critical
+
+The same text looks different depending on how you extract it. Always normalize before comparing:
+
+```python
+def norm(text):
+    text = text.replace("\xa0", " ")          # non-breaking spaces (VERY common in .docx)
+    text = text.replace("\u2013", "-")         # en-dash
+    text = text.replace("\u2014", " - ")       # em-dash
+    text = text.replace("\u201c", '"')         # smart quotes
+    text = text.replace("\u201d", '"')
+    text = text.replace("\u2018", "'")
+    text = text.replace("\u2019", "'")
+    text = re.sub(r"[ \t]+", " ", text)        # collapse whitespace
+    return text.strip()
+```
+
+### pandoc text != python-docx text
+
+- pandoc renders Word field codes (e.g., `[INSERT DATE]`); python-docx shows raw XML (e.g., `]`)
+- pandoc joins table cells into one line per row; python-docx gives each cell as a separate paragraph
+- pandoc includes table separator lines (`---`); filter these out
+
+### Paragraph matching strategy
+
+**DO NOT** rely on fuzzy alignment between pandoc-extracted text and python-docx paragraphs. Instead:
+
+1. **Targeted search**: Find paragraphs by unique text snippets using `full_text()`:
+   ```python
+   def find_para(paras, snippet, start=0):
+       for i in range(start, len(paras)):
+           if snippet in full_text(paras[i]):
+               return i
+       return None
+   ```
+
+2. **Section-heading anchored**: Find the section heading first, then search nearby paragraphs.
+
+3. **Refresh after inserts**: Call `get_body_paras(doc)` again after inserting/deleting paragraphs.
+
+### Track Changes XML structure
+
+Deleted text uses `w:delText` (not `w:t`):
+```xml
+<w:del w:id="1" w:author="Author" w:date="2026-01-01T00:00:00Z">
+  <w:r><w:delText xml:space="preserve">old text</w:delText></w:r>
+</w:del>
+```
+
+Inserted text uses `w:ins` wrapping a normal run:
+```xml
+<w:ins w:id="2" w:author="Author" w:date="2026-01-01T00:00:00Z">
+  <w:r><w:t xml:space="preserve">new text</w:t></w:r>
+</w:ins>
+```
+
+### Preserving formatting
+
+When rewriting a paragraph's content, capture the reference `rPr` (run properties) from the first run BEFORE clearing, then apply it to new runs. This preserves font, size, bold, etc.
+
+## Targeted Approach (recommended for known changes)
+
+When you know exactly what changed (e.g., from a change log), the most reliable method is:
+
+1. Copy the original .docx
+2. For each change, search for a unique text snippet to find the paragraph
+3. Apply the specific Track Change (delete, insert, or word-level diff)
+
+This avoids all fuzzy matching problems and produces clean, accurate results.
+
+## Validating Track Changes (auditing an existing redline)
+
+When the user asks you to **validate**, **verify**, or **audit** a .docx that already contains Track Changes against a change specification, ground truth document, or list of expected changes, use the raw XML inspection approach below. python-docx does NOT expose existing `w:ins`/`w:del` elements through its API — you must work with the XML directly.
+
+### Raw XML extraction
+
+A .docx is a ZIP archive. Extract `word/document.xml` without writing to disk:
+
+```bash
+unzip -p "Document.docx" word/document.xml | python3 -c "
+import sys
+xml = sys.stdin.read()
+print(f'Size: {len(xml)} chars')
+"
+```
+
+### Counting track changes
+
+```bash
+unzip -p "Document.docx" word/document.xml | python3 -c "
+import sys, re
+xml = sys.stdin.read()
+print(f'Insertions (w:ins): {len(re.findall(r\"<w:ins \", xml))}')
+print(f'Deletions (w:del): {len(re.findall(r\"<w:del \", xml))}')
+"
+```
+
+### Section-anchored extraction
+
+The core validation technique: find a section heading in the raw XML, grab a character window around it, then extract all `w:ins` and `w:del` elements within that window.
+
+```python
+import re, html as html_mod
+
+def extract_text_from_xml(xml_fragment):
+    """Extract text from w:t tags in an XML fragment."""
+    texts = re.findall(r'<w:t[^>]*>(.*?)</w:t>', xml_fragment, re.DOTALL)
+    return ''.join(html_mod.unescape(t) for t in texts)
+
+def extract_del_text(xml_fragment):
+    """Extract text from w:delText tags in an XML fragment."""
+    texts = re.findall(r'<w:delText[^>]*>(.*?)</w:delText>', xml_fragment, re.DOTALL)
+    return ''.join(html_mod.unescape(t) for t in texts)
+
+def extract_tracked_changes_near(xml, section_pattern, context_after=8000):
+    """Find a section heading and extract all tracked changes nearby."""
+    matches = list(re.finditer(section_pattern, xml))
+    if not matches:
+        return None
+
+    results = []
+    for m in matches:
+        start = max(0, m.start() - 500)
+        end = min(len(xml), m.end() + context_after)
+        chunk = xml[start:end]
+
+        insertions = re.findall(r'<w:ins\b[^>]*>(.*?)</w:ins>', chunk, re.DOTALL)
+        deletions = re.findall(r'<w:del\b[^>]*>(.*?)</w:del>', chunk, re.DOTALL)
+
+        ins_texts = [extract_text_from_xml(i) for i in insertions]
+        del_texts = [extract_del_text(d) for d in deletions]
+
+        results.append({
+            'offset': m.start(),
+            'insertions': [t for t in ins_texts if t.strip()],
+            'deletions': [t for t in del_texts if t.strip()],
+        })
+    return results
+```
+
+### Checking if specific text is tracked as an insertion
+
+Search for the text in the XML, then walk backwards to see if it's enclosed in a `w:ins` tag:
+
+```python
+def is_text_tracked_as_insertion(xml, search_text):
+    """Check whether search_text appears inside a w:ins element."""
+    m = re.search(re.escape(search_text), xml)
+    if not m:
+        return False
+    chunk = xml[max(0, m.start() - 3000):m.end()]
+    ins_opens = list(re.finditer(r'<w:ins\b[^>]*>', chunk))
+    ins_closes = list(re.finditer(r'</w:ins>', chunk))
+    if ins_opens:
+        last_open = ins_opens[-1]
+        last_close = ins_closes[-1] if ins_closes else None
+        if last_close is None or last_open.start() > last_close.start():
+            return True
+    return False
+```
+
+### Detecting specific text patterns (quote fixes, double periods, typos)
+
+When validating typographical fixes, compare the deleted text against the inserted text for the specific pattern:
+
+```python
+def check_pattern_fix(xml, section_pattern, bad_pattern, context_after=8000):
+    """Check if bad_pattern appears in a deletion near section_pattern,
+    and confirm the corresponding insertion does not contain it."""
+    results = extract_tracked_changes_near(xml, section_pattern, context_after)
+    if not results:
+        return {'found': False}
+
+    for r in results:
+        for dt in r['deletions']:
+            if bad_pattern in dt:
+                in_any_insertion = any(bad_pattern in it for it in r['insertions'])
+                return {
+                    'found': True,
+                    'deleted': True,
+                    'still_in_insertion': in_any_insertion,
+                    'pass': not in_any_insertion,
+                }
+    return {'found': False}
+```
+
+**Common patterns to check:**
+- Double periods: `'..'` in deleted text, `'.'` (single) in insertion
+- Missing quotes: `the Defined Term")` (no opening quote) → `the "Defined Term")`
+- Single → double quotes: `('Example Term')` → `("Example Term")`
+- Ellipsis: `'Section 1.1…,'` → `'Section 1.1,'`
+- Typos: `'Section 2.1shall'` → `'Section 2.1 shall'`
+
+### Validation methodology
+
+When validating a redlined .docx against a change specification:
+
+1. **Extract XML** from both the baseline .docx and the output .docx using `unzip -p`.
+2. **Count track changes** in both to understand the baseline (the original may already contain changes from a prior redline round).
+3. **For each change in the spec**, use section-anchored extraction to find the relevant tracked changes:
+   - Identify the section heading pattern (e.g., `'Section A - Acceptance'`).
+   - Extract all `w:ins` and `w:del` elements near that heading.
+   - Compare deleted text against what the spec says should have been removed.
+   - Compare inserted text against what the spec (or ground truth document) says should be present.
+4. **For each change, report a verdict:**
+   - **PASS**: The tracked change is present and correct (deletion matches what should be removed, insertion matches what should be added).
+   - **FAIL**: The change is missing, incomplete, or incorrect (explain what's wrong).
+   - **SKIP**: The change was already correct in the baseline document (no modification needed).
+5. **Produce a summary table** with pass/fail/skip counts.
+
+### Comparing baseline vs. output
+
+When the baseline document already contains track changes from a prior round, you need to distinguish between inherited changes and new changes. Compare both documents:
+
+```bash
+# Count changes in baseline
+unzip -p "baseline.docx" word/document.xml | python3 -c "
+import sys, re; xml = sys.stdin.read()
+print(f'Baseline - ins: {len(re.findall(r\"<w:ins \", xml))}, del: {len(re.findall(r\"<w:del \", xml))}')
+"
+
+# Count changes in output
+unzip -p "output.docx" word/document.xml | python3 -c "
+import sys, re; xml = sys.stdin.read()
+print(f'Output - ins: {len(re.findall(r\"<w:ins \", xml))}, del: {len(re.findall(r\"<w:del \", xml))}')
+"
+```
+
+If both have similar counts, verify that specific changes from the spec are present in the output but not in the baseline. Use the `w:author` attribute on track change elements to distinguish authors when multiple redline rounds exist.
+
+### Adjusting context window size
+
+The `context_after` parameter controls how much XML to scan after the section heading. Defaults to 8000 characters, which covers most sections. For long sections (e.g., a section with multiple bullet points), increase to 12000–18000. For short sections (e.g., a single-line fix), 3000–5000 is sufficient.
+
+## Utility Scripts
+
+- **`scripts/track_changes_helpers.py`**: Core helper functions for writing Track Changes XML into .docx files. Use as a library or read for reference.
+- **`scripts/validate_track_changes.py`**: Functions for extracting and auditing existing Track Changes from .docx files via raw XML inspection. Use for validation workflows.
+
+## Task
+
+$ARGUMENTS

--- a/skills/claude/word-docx-redlines/scripts/track_changes_helpers.py
+++ b/skills/claude/word-docx-redlines/scripts/track_changes_helpers.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Track Changes helpers for python-docx.
+Provides functions to write real Word Track Changes (w:ins / w:del) into .docx files.
+
+Usage:
+    from track_changes_helpers import (
+        full_text, find_para, get_body_paras, get_ref_rPr,
+        clear_para_content, make_run, make_del, make_ins,
+        replace_para, delete_para, insert_para_after, word_diff,
+        apply_word_diff_to_para
+    )
+"""
+
+import re
+import copy
+import difflib
+from lxml import etree
+from docx import Document
+from docx.text.paragraph import Paragraph
+from docx.oxml.ns import qn
+from docx.oxml import OxmlElement
+
+_rid = [0]
+AUTHOR = "Author"
+DATE = "2026-01-01T00:00:00Z"
+
+
+def set_author(author, date=None):
+    global AUTHOR, DATE
+    AUTHOR = author
+    if date:
+        DATE = date
+
+
+def _nid():
+    _rid[0] += 1
+    return str(_rid[0])
+
+
+def full_text(para):
+    """Get ALL text from a paragraph, including field codes and complex runs."""
+    return "".join(t.text or "" for t in para._element.findall(".//" + qn("w:t")))
+
+
+def norm(text):
+    """Normalize text for comparison."""
+    text = text.replace("\xa0", " ")
+    text = text.replace("\u2011", "-").replace("\u2013", "-").replace("\u2014", " - ")
+    text = text.replace("\u201c", '"').replace("\u201d", '"')
+    text = text.replace("\u2018", "'").replace("\u2019", "'")
+    text = re.sub(r"[ \t]+", " ", text)
+    return text.strip()
+
+
+def get_body_paras(doc):
+    """Get all body-level paragraphs (excludes table cells)."""
+    body = doc.element.body
+    return [Paragraph(c, body) for c in body if c.tag == qn("w:p")]
+
+
+def find_para(paras, snippet, start=0):
+    """Find first paragraph containing snippet (using full_text)."""
+    for i in range(start, len(paras)):
+        if snippet in full_text(paras[i]):
+            return i
+    return None
+
+
+def get_ref_rPr(para):
+    """Extract formatting properties from first run, stripping color/strike/highlight."""
+    for r_elem in para._element.findall(qn("w:r")):
+        rPr = r_elem.find(qn("w:rPr"))
+        if rPr is not None:
+            rPr_copy = copy.deepcopy(rPr)
+            for tag in (qn("w:color"), qn("w:strike"), qn("w:highlight"), qn("w:rStyle")):
+                for el in rPr_copy.findall(tag):
+                    rPr_copy.remove(el)
+            return rPr_copy
+    return None
+
+
+def clear_para_content(para):
+    """Remove all runs/tracked changes from paragraph, keeping pPr."""
+    for child in list(para._element):
+        if child.tag != qn("w:pPr"):
+            para._element.remove(child)
+
+
+def make_run(text, rPr=None):
+    """Create a w:r element."""
+    r = OxmlElement("w:r")
+    if rPr is not None:
+        r.append(copy.deepcopy(rPr))
+    t = OxmlElement("w:t")
+    t.set(qn("xml:space"), "preserve")
+    t.text = text
+    r.append(t)
+    return r
+
+
+def make_del(text, rPr=None):
+    """Create a w:del element (tracked deletion)."""
+    d = OxmlElement("w:del")
+    d.set(qn("w:id"), _nid())
+    d.set(qn("w:author"), AUTHOR)
+    d.set(qn("w:date"), DATE)
+    r = OxmlElement("w:r")
+    if rPr is not None:
+        r.append(copy.deepcopy(rPr))
+    dt = OxmlElement("w:delText")
+    dt.set(qn("xml:space"), "preserve")
+    dt.text = text
+    r.append(dt)
+    d.append(r)
+    return d
+
+
+def make_ins(text, rPr=None):
+    """Create a w:ins element (tracked insertion)."""
+    ins = OxmlElement("w:ins")
+    ins.set(qn("w:id"), _nid())
+    ins.set(qn("w:author"), AUTHOR)
+    ins.set(qn("w:date"), DATE)
+    ins.append(make_run(text, rPr))
+    return ins
+
+
+def replace_para(para, new_text):
+    """Delete old content, insert new content (both tracked)."""
+    old_text = full_text(para)
+    rPr = get_ref_rPr(para)
+    clear_para_content(para)
+    if old_text.strip():
+        para._element.append(make_del(old_text, rPr))
+    para._element.append(make_ins(new_text, rPr))
+
+
+def delete_para(para):
+    """Mark entire paragraph content as deleted."""
+    text = full_text(para)
+    if not text.strip():
+        return
+    rPr = get_ref_rPr(para)
+    clear_para_content(para)
+    para._element.append(make_del(text, rPr))
+
+
+def insert_para_after(para, text):
+    """Insert a new tracked-insertion paragraph after the given one."""
+    rPr = get_ref_rPr(para)
+    p = OxmlElement("w:p")
+    if para._element.pPr is not None:
+        p.append(copy.deepcopy(para._element.pPr))
+    p.append(make_ins(text, rPr))
+    para._element.addnext(p)
+    return Paragraph(p, para._element.getparent())
+
+
+def word_diff(old_text, new_text):
+    """Compute word-level diff. Returns list of (op, text) tuples."""
+    old_w = old_text.split()
+    new_w = new_text.split()
+    sm = difflib.SequenceMatcher(None, old_w, new_w, autojunk=False)
+    ops = []
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        if tag == "equal":
+            ops.append(("equal", " ".join(old_w[i1:i2])))
+        elif tag == "delete":
+            ops.append(("delete", " ".join(old_w[i1:i2])))
+        elif tag == "insert":
+            ops.append(("insert", " ".join(new_w[j1:j2])))
+        elif tag == "replace":
+            ops.append(("delete", " ".join(old_w[i1:i2])))
+            ops.append(("insert", " ".join(new_w[j1:j2])))
+    return ops
+
+
+def apply_word_diff_to_para(para, old_text, new_text):
+    """Rewrite paragraph with word-level Track Changes markup."""
+    rPr = get_ref_rPr(para)
+    clear_para_content(para)
+    ops = word_diff(old_text, new_text)
+    for i, (op, text) in enumerate(ops):
+        prefix = " " if i > 0 else ""
+        content = prefix + text
+        if op == "equal":
+            para._element.append(make_run(content, rPr))
+        elif op == "delete":
+            para._element.append(make_del(content, rPr))
+        elif op == "insert":
+            para._element.append(make_ins(content, rPr))

--- a/skills/claude/word-docx-redlines/scripts/validate_track_changes.py
+++ b/skills/claude/word-docx-redlines/scripts/validate_track_changes.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Validate Track Changes in .docx files.
+
+Extract and audit existing w:ins/w:del elements from Word documents
+by inspecting the raw XML. Use for verifying that a redlined document
+correctly implements a change specification.
+
+Usage (as a library):
+    from validate_track_changes import DocxTrackChangeReader
+
+    reader = DocxTrackChangeReader("output.docx")
+    reader.summary()
+    changes = reader.changes_near("Section A - Acceptance")
+    reader.print_changes(changes)
+
+Usage (CLI):
+    python validate_track_changes.py output.docx
+    python validate_track_changes.py output.docx --section "Section A - Acceptance"
+    python validate_track_changes.py output.docx --check-pattern "Section A - Acceptance" ".."
+    python validate_track_changes.py output.docx --compare baseline.docx
+"""
+
+import re
+import sys
+import html as html_mod
+import subprocess
+import argparse
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TrackedChange:
+    change_type: str  # "insertion" or "deletion"
+    text: str
+    offset: int
+    author: str = ""
+    date: str = ""
+
+
+@dataclass
+class SectionChanges:
+    section_pattern: str
+    offset: int
+    insertions: list = field(default_factory=list)
+    deletions: list = field(default_factory=list)
+
+
+class DocxTrackChangeReader:
+    """Read and audit Track Changes from a .docx file via raw XML."""
+
+    def __init__(self, docx_path):
+        self.path = docx_path
+        self.xml = self._extract_xml()
+
+    def _extract_xml(self):
+        result = subprocess.run(
+            ["unzip", "-p", self.path, "word/document.xml"],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to extract XML from {self.path}: {result.stderr}")
+        return result.stdout
+
+    @staticmethod
+    def _extract_wt_text(xml_fragment):
+        """Extract text from w:t tags."""
+        texts = re.findall(r'<w:t[^>]*>(.*?)</w:t>', xml_fragment, re.DOTALL)
+        return ''.join(html_mod.unescape(t) for t in texts)
+
+    @staticmethod
+    def _extract_del_text(xml_fragment):
+        """Extract text from w:delText tags."""
+        texts = re.findall(r'<w:delText[^>]*>(.*?)</w:delText>', xml_fragment, re.DOTALL)
+        return ''.join(html_mod.unescape(t) for t in texts)
+
+    @staticmethod
+    def _extract_author(tag_xml):
+        m = re.search(r'w:author="([^"]*)"', tag_xml)
+        return m.group(1) if m else ""
+
+    @staticmethod
+    def _extract_date(tag_xml):
+        m = re.search(r'w:date="([^"]*)"', tag_xml)
+        return m.group(1) if m else ""
+
+    def count(self):
+        """Count total insertions and deletions."""
+        ins = len(re.findall(r'<w:ins ', self.xml))
+        dels = len(re.findall(r'<w:del ', self.xml))
+        return {"insertions": ins, "deletions": dels}
+
+    def summary(self):
+        """Print a summary of track changes."""
+        c = self.count()
+        print(f"Document: {self.path}")
+        print(f"  Insertions (w:ins): {c['insertions']}")
+        print(f"  Deletions  (w:del): {c['deletions']}")
+        print(f"  XML size: {len(self.xml):,} chars")
+
+    def all_changes(self):
+        """Extract all tracked changes from the document."""
+        changes = []
+        for m in re.finditer(r'<w:ins\b([^>]*)>(.*?)</w:ins>', self.xml, re.DOTALL):
+            text = self._extract_wt_text(m.group(2))
+            if text.strip():
+                changes.append(TrackedChange(
+                    change_type="insertion", text=text,
+                    offset=m.start(),
+                    author=self._extract_author(m.group(1)),
+                    date=self._extract_date(m.group(1)),
+                ))
+        for m in re.finditer(r'<w:del\b([^>]*)>(.*?)</w:del>', self.xml, re.DOTALL):
+            text = self._extract_del_text(m.group(2))
+            if text.strip():
+                changes.append(TrackedChange(
+                    change_type="deletion", text=text,
+                    offset=m.start(),
+                    author=self._extract_author(m.group(1)),
+                    date=self._extract_date(m.group(1)),
+                ))
+        changes.sort(key=lambda c: c.offset)
+        return changes
+
+    def changes_near(self, section_pattern, context_after=8000, context_before=500):
+        """Find tracked changes near a section heading pattern."""
+        matches = list(re.finditer(section_pattern, self.xml))
+        if not matches:
+            return []
+
+        results = []
+        for m in matches:
+            start = max(0, m.start() - context_before)
+            end = min(len(self.xml), m.end() + context_after)
+            chunk = self.xml[start:end]
+
+            ins_texts = []
+            for ins_m in re.finditer(r'<w:ins\b[^>]*>(.*?)</w:ins>', chunk, re.DOTALL):
+                text = self._extract_wt_text(ins_m.group(1))
+                if text.strip():
+                    ins_texts.append(text)
+
+            del_texts = []
+            for del_m in re.finditer(r'<w:del\b[^>]*>(.*?)</w:del>', chunk, re.DOTALL):
+                text = self._extract_del_text(del_m.group(1))
+                if text.strip():
+                    del_texts.append(text)
+
+            results.append(SectionChanges(
+                section_pattern=section_pattern,
+                offset=m.start(),
+                insertions=ins_texts,
+                deletions=del_texts,
+            ))
+        return results
+
+    def is_tracked_insertion(self, search_text):
+        """Check if search_text appears inside a w:ins element."""
+        m = re.search(re.escape(search_text[:80]), self.xml)
+        if not m:
+            return False
+        lookback = self.xml[max(0, m.start() - 3000):m.end()]
+        ins_opens = list(re.finditer(r'<w:ins\b[^>]*>', lookback))
+        ins_closes = list(re.finditer(r'</w:ins>', lookback))
+        if ins_opens:
+            last_open = ins_opens[-1]
+            last_close = ins_closes[-1] if ins_closes else None
+            if last_close is None or last_open.start() > last_close.start():
+                return True
+        return False
+
+    def check_pattern_fix(self, section_pattern, bad_pattern, context_after=8000):
+        """Verify that bad_pattern was deleted and not re-introduced near a section."""
+        sections = self.changes_near(section_pattern, context_after)
+        if not sections:
+            return {"found": False, "section_exists": False}
+
+        for sec in sections:
+            for dt in sec.deletions:
+                if bad_pattern in dt:
+                    still_present = any(bad_pattern in it for it in sec.insertions)
+                    return {
+                        "found": True,
+                        "section_exists": True,
+                        "deleted": True,
+                        "still_in_insertion": still_present,
+                        "pass": not still_present,
+                    }
+        return {"found": False, "section_exists": True}
+
+    def find_text(self, search_text):
+        """Find all occurrences of search_text in the XML, returning context."""
+        results = []
+        for m in re.finditer(re.escape(search_text), self.xml):
+            chunk = self.xml[max(0, m.start() - 1000):min(len(self.xml), m.end() + 500)]
+            lookback = self.xml[max(0, m.start() - 3000):m.start()]
+            ins_open = lookback.rfind("<w:ins")
+            ins_close = lookback.rfind("</w:ins>")
+            del_open = lookback.rfind("<w:del")
+            del_close = lookback.rfind("</w:del>")
+            results.append({
+                "offset": m.start(),
+                "in_insertion": ins_open > ins_close,
+                "in_deletion": del_open > del_close,
+                "context": chunk,
+            })
+        return results
+
+    @staticmethod
+    def print_changes(section_changes_list, max_text=300):
+        """Pretty-print extracted section changes."""
+        for sec in section_changes_list:
+            print(f"\n  Section '{sec.section_pattern}' at offset {sec.offset}:")
+            print(f"  Insertions ({len(sec.insertions)}):")
+            for i, text in enumerate(sec.insertions):
+                display = text[:max_text] + ("..." if len(text) > max_text else "")
+                print(f"    INS[{i}]: \"{display}\"")
+            print(f"  Deletions ({len(sec.deletions)}):")
+            for i, text in enumerate(sec.deletions):
+                display = text[:max_text] + ("..." if len(text) > max_text else "")
+                print(f"    DEL[{i}]: \"{display}\"")
+
+
+def compare_documents(baseline_path, output_path):
+    """Compare track change counts between baseline and output."""
+    baseline = DocxTrackChangeReader(baseline_path)
+    output = DocxTrackChangeReader(output_path)
+
+    bc = baseline.count()
+    oc = output.count()
+
+    print(f"Baseline ({baseline_path}):")
+    print(f"  Insertions: {bc['insertions']}, Deletions: {bc['deletions']}")
+    print(f"Output ({output_path}):")
+    print(f"  Insertions: {oc['insertions']}, Deletions: {oc['deletions']}")
+    print(f"Delta:")
+    print(f"  Insertions: {oc['insertions'] - bc['insertions']:+d}")
+    print(f"  Deletions:  {oc['deletions'] - bc['deletions']:+d}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate Track Changes in .docx files")
+    parser.add_argument("docx", help="Path to the .docx file to inspect")
+    parser.add_argument("--section", help="Section heading pattern to search near")
+    parser.add_argument("--context", type=int, default=8000, help="XML chars after heading (default: 8000)")
+    parser.add_argument("--check-pattern", nargs=2, metavar=("SECTION", "PATTERN"),
+                        help="Check if PATTERN was fixed (deleted, not re-inserted) near SECTION")
+    parser.add_argument("--compare", metavar="BASELINE", help="Compare against a baseline .docx")
+    parser.add_argument("--all", action="store_true", help="Print all tracked changes")
+    args = parser.parse_args()
+
+    reader = DocxTrackChangeReader(args.docx)
+    reader.summary()
+
+    if args.compare:
+        print()
+        compare_documents(args.compare, args.docx)
+
+    if args.section:
+        changes = reader.changes_near(args.section, context_after=args.context)
+        if changes:
+            reader.print_changes(changes)
+        else:
+            print(f"\n  Section '{args.section}' not found in document.")
+
+    if args.check_pattern:
+        section, pattern = args.check_pattern
+        result = reader.check_pattern_fix(section, pattern, context_after=args.context)
+        print(f"\n  Pattern check: '{pattern}' near '{section}'")
+        if result.get("pass"):
+            print(f"  PASS: Pattern found in deletion and not in insertion.")
+        elif result.get("found"):
+            print(f"  FAIL: Pattern found in deletion but STILL present in insertion.")
+        elif result.get("section_exists"):
+            print(f"  NOT FOUND: Pattern not found in any deletion near this section.")
+        else:
+            print(f"  NOT FOUND: Section heading not found in document.")
+
+    if args.all:
+        changes = reader.all_changes()
+        print(f"\nAll tracked changes ({len(changes)} total):")
+        for c in changes:
+            tag = "INS" if c.change_type == "insertion" else "DEL"
+            display = c.text[:200] + ("..." if len(c.text) > 200 else "")
+            print(f"  [{tag}] @{c.offset} by {c.author}: \"{display}\"")
+
+    if not any([args.section, args.check_pattern, args.compare, args.all]):
+        print("\nUse --section, --check-pattern, --compare, or --all for detailed output.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/codex/calendar-create-event/SKILL.md
+++ b/skills/codex/calendar-create-event/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: calendar-create-event
+description: Create calendar events, reminders, recurring series, or .ics fallback files for Calendar workflows. Use when the user asks to create calendar events, reminders, invites, recurring reminders, or importable .ics files.
+---
+
+# Calendar Create Event
+
+Use this skill when the user wants calendar events created, especially reminders, guest invites, recurring schedules, or a local `.ics` file they can import.
+
+1. Extract the actual scheduling intent first:
+   - calendar/account to use
+   - title
+   - date and time
+   - timezone
+   - duration
+   - attendees
+   - recurrence
+   - reminders/alarms
+   - whether the user wants direct creation or an `.ics` file
+
+2. Prefer direct calendar creation if the available account/auth path supports it.
+   - For Google Workspace service-account flows, verify the needed Calendar scope works before doing deeper work.
+   - If the Calendar API scope is blocked or undelegated, stop retrying and switch to `.ics` fallback.
+
+3. When a user wants many reminders for the same obligation, default to one recurring event rather than many separate events.
+   - Example: monthly reminders for 10 months should usually be one recurring series with 10 occurrences.
+   - Only create separate standalone events if the user explicitly asks for separate events.
+
+4. If using `.ics` fallback:
+   - Create a valid iCalendar file with explicit timezone data.
+   - Use one `VEVENT` plus `RRULE` for recurring series whenever possible.
+   - Include `UID`, `DTSTAMP`, `SUMMARY`, `DESCRIPTION`, `ORGANIZER`, attendee lines when requested, and `VALARM` if the user wants reminders.
+   - Put the file somewhere easy to access, usually `~/Downloads`, unless the user asked for a different location.
+
+5. Keep the workflow efficient.
+   - Do not probe APIs repeatedly once you know the auth path is blocked.
+   - Do not create 10 separate events when one recurring rule solves the problem.
+   - Verify the final dates, recurrence count, and timezone before finishing.
+
+6. Call out the import caveat when using `.ics`.
+   - Importing an `.ics` usually adds the events locally.
+   - Guest invitations may not be emailed automatically by the calendar provider after import.
+
+7. Use the shared guidance in [playbook.md](playbook.md) for recurrence, `.ics` structure, and Google Workspace Calendar fallback behavior.
+
+Output format:
+- Say whether the result was direct calendar creation or `.ics` fallback.
+- Report the event title, first occurrence, recurrence rule or count, attendees, and final file path if applicable.

--- a/skills/codex/calendar-create-event/playbook.md
+++ b/skills/codex/calendar-create-event/playbook.md
@@ -1,0 +1,85 @@
+# Calendar Create Event Playbook
+
+Use this playbook for creating reminders, recurring events, and `.ics` fallback files.
+
+## Decision order
+
+1. Prefer direct event creation if the auth path actually supports Calendar writes.
+2. If the direct Calendar API path fails due to missing delegation or blocked auth, switch to `.ics` fallback immediately.
+3. If the user wants repeated reminders for one obligation, prefer one recurring event instead of many separate events.
+
+## Google Workspace Calendar fallback
+
+- The Google Workspace helper may support Gmail or Admin SDK tasks while Calendar remains undelegated.
+- If `https://www.googleapis.com/auth/calendar` returns `401 unauthorized_client`, do not keep retrying.
+- In that case, create an importable `.ics` file instead.
+
+## Recurrence defaults
+
+For repeated reminders about the same deadline:
+
+- Monthly reminders should usually be one `VEVENT` with:
+  - `RRULE:FREQ=MONTHLY;COUNT=<n>`
+- Use separate events only if the user explicitly wants separate acceptances, different descriptions, different attendees, or irregular dates.
+
+Example:
+
+```ics
+BEGIN:VEVENT
+UID:example-1@local
+DTSTAMP:20260422T000000Z
+DTSTART;TZID=America/New_York:20300915T090000
+DTEND;TZID=America/New_York:20300915T091500
+SUMMARY:Example recurring reminder
+RRULE:FREQ=MONTHLY;COUNT=10
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:Example recurring reminder
+TRIGGER:-PT0M
+END:VALARM
+END:VEVENT
+```
+
+## `.ics` minimum structure
+
+```ics
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Local Skill//Calendar Create Event//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+BEGIN:VEVENT
+...
+END:VEVENT
+END:VCALENDAR
+```
+
+Recommended event fields:
+
+- `UID`
+- `DTSTAMP`
+- `DTSTART`
+- `DTEND`
+- `SUMMARY`
+- `DESCRIPTION`
+- `RRULE` when recurring
+- `ORGANIZER`
+- `ATTENDEE` lines when the user wants guests
+- `VALARM` when a reminder should appear on import
+
+## Attendee caveat
+
+Including attendees in an `.ics` file is useful, but importing the file does not always cause Google Calendar or other providers to send invitation emails automatically.
+
+Tell the user this plainly when you use `.ics` fallback.
+
+## Output checklist
+
+Before finishing, confirm:
+
+- title is correct
+- timezone is correct
+- first occurrence is correct
+- recurrence count/rule is correct
+- attendees are correct
+- file path is easy to access

--- a/skills/codex/git-update/SKILL.md
+++ b/skills/codex/git-update/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: git-update
+description: >-
+  Stage, commit, and push the current git work safely. Use when the user asks
+  to "git update", commit current changes, ship the current branch, or stage,
+  commit, and push a set of completed edits to the remote repository.
+---
+
+# Git Update
+
+Determine the active repository first. If the current working directory is inside a nested repository, operate on that repository; otherwise operate on the parent repository. Confirm with `git rev-parse --show-toplevel`.
+
+Inspect the current state before changing anything. Run these in parallel when possible:
+
+```bash
+git status
+git diff --staged
+git diff
+git log --oneline -5
+```
+
+Stop if there is nothing relevant to commit. If the tree is clean, or only unrelated/generated noise is present, report that and do not create an empty commit.
+
+Stage only the files relevant to the recent work. Prefer explicit paths over `git add -A` or `git add .` so secrets, `.env` files, binaries, and unrelated churn do not get swept in accidentally.
+
+Write a concise commit message that explains the reason for the change, not a file-by-file summary. Match the repository's recent commit style when it is clear.
+
+Commit non-interactively. Prefer `git commit -F -` with piped message content or `git commit -m` for a short single-line message. Do not open an editor.
+
+Before pushing, inspect the branch and repository policy. Never force push. Do not push directly from `main`, `master`, or a branch that matches the repo's configured PR target. Stop and tell the user to create a feature branch and PR instead.
+
+Push only a non-trunk feature branch to the current branch's tracking remote. If no upstream is configured, detect the branch name and push with `git push -u origin <branch>`.
+
+If push fails because the environment blocks network access or needs approval, request escalation rather than stopping at the local commit.
+
+Report the result with the commit hash and whether the push succeeded.

--- a/skills/codex/git-update/agents/openai.yaml
+++ b/skills/codex/git-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git Update"
+  short_description: "Stage, commit, and push safely."
+  default_prompt: "Use $git-update to stage the relevant changed files, commit them with a concise why-focused message, and push the current branch to its tracking remote."

--- a/skills/codex/ls/SKILL.md
+++ b/skills/codex/ls/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: ls
+description: List files and directories in the current working directory or a specified path as a readable 3-column markdown table. Use when the user wants to see folder contents.
+---
+
+# List Directory Contents
+
+List the visible entries of a directory as a 3-column markdown table, sorted alphabetically. Directories are marked with a trailing `/`.
+
+Use the bundled helper:
+
+```bash
+python3 "${CODEX_HOME:-$HOME/.codex}/skills/ls/scripts/ls_table.py" [path]
+```
+
+## Rules
+
+1. If no path is provided, use the current working directory.
+2. If the target does not exist, report that instead of fabricating output.
+3. If the target is a file rather than a directory, say so instead of trying to list it.
+4. The output must be a markdown table with headers `| Name | Name | Name |`.
+5. Sort entries case-insensitively.
+6. Append `/` to directory names.
+7. Show a final count line in the form `**N items** (X files, Y directories)`.
+8. Match shell-style `*` behavior by excluding hidden entries unless the user explicitly asks for them.

--- a/skills/codex/ls/scripts/ls_table.py
+++ b/skills/codex/ls/scripts/ls_table.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Render a directory listing as a 3-column markdown table."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def chunk(items: list[str], size: int) -> list[list[str]]:
+    return [items[i:i + size] for i in range(0, len(items), size)]
+
+
+def main() -> int:
+    raw_target = sys.argv[1] if len(sys.argv) > 1 else "."
+    target = Path(raw_target).expanduser().resolve()
+
+    if not target.exists():
+        print(f"Path does not exist: {target}", file=sys.stderr)
+        return 1
+    if not target.is_dir():
+        print(f"Not a directory: {target}", file=sys.stderr)
+        return 1
+
+    entries: list[tuple[str, bool]] = []
+    for entry in os.scandir(target):
+        if entry.name.startswith("."):
+            continue
+        entries.append((entry.name, entry.is_dir()))
+
+    entries.sort(key=lambda item: item[0].lower())
+    display = [f"{name}/" if is_dir else name for name, is_dir in entries]
+    file_count = sum(1 for _, is_dir in entries if not is_dir)
+    dir_count = sum(1 for _, is_dir in entries if is_dir)
+
+    print("| Name | Name | Name |")
+    print("|---|---|---|")
+    for row in chunk(display, 3):
+        padded = row + [""] * (3 - len(row))
+        print(f"| {padded[0]} | {padded[1]} | {padded[2]} |")
+
+    print()
+    print(f"**{len(entries)} items** ({file_count} files, {dir_count} directories)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/codex/make-universal-skill/SKILL.md
+++ b/skills/codex/make-universal-skill/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: make-universal-skill
+description: Create a new skill that works in both Codex (~/.codex/skills/) and Claude Code (~/.claude/skills/) from a single request. Writes two adapted SKILL.md files plus any shared resource files. Use when the user asks to create, author, or scaffold a new skill and wants it available in both harnesses.
+---
+
+# Make Universal Skill
+
+Author a new skill that exists in **both** `~/.codex/skills/<name>/` and `~/.claude/skills/<name>/`. One logical skill, two harness-appropriate SKILL.md files, with any shared resource files (reference docs, playbooks, helper scripts) duplicated across both directories so either harness is self-sufficient.
+
+## When to invoke
+
+The user says "make a skill that...", "create a /foo skill", "I want a universal skill for X", or explicitly mentions "both harnesses" / "Claude and Codex."
+
+## Input handling
+
+The user message contains the skill request — a name and a purpose. If the name is unclear, derive a kebab-case slug from the purpose. If the purpose is too vague to write a useful skill, ask one focused clarifying question before proceeding. Don't demand a full spec.
+
+## Workflow
+
+1. Decide the name and shape. Pick a kebab-case slug. Decide whether the skill needs auxiliary files:
+   - Reference doc (`reference.md`, `playbook.md`, `api-reference.md`) — for reusable knowledge loaded on demand.
+   - Helper script (`scripts/*.py`, `scripts/*.sh`) — for deterministic work better done by code.
+   - Credential wrapper + migration setup script — whenever the skill needs an API key or bot token. See **Secrets and credentials** below.
+   - Just SKILL.md — most cases.
+
+2. Check for collisions. Before writing, look at `~/.codex/skills/<name>/` and `~/.claude/skills/<name>/`. If either exists, ask whether to overwrite, rename, or edit the existing skill.
+
+3. Write the Codex SKILL.md at `~/.codex/skills/<name>/SKILL.md`:
+
+   ```markdown
+   ---
+   name: <slug>
+   description: <one sentence: what it does + "Use when..." trigger phrasing>
+   ---
+
+   # <Title Case Name>
+
+   <Body: direct imperatives. Generic tool references ("read", "search", "write"). Reference aux files as [playbook.md](playbook.md). No $ARGUMENTS placeholder. No trailing ## Task section. Terser than the Claude version.>
+   ```
+
+4. Write the Claude Code SKILL.md at `~/.claude/skills/<name>/SKILL.md`:
+
+   ```markdown
+   ---
+   name: <slug>
+   description: <same description, optionally with richer trigger phrasing>
+   argument-hint: "[what the user types after /<slug>]"
+   allowed-tools: <space-separated tool names — Bash Read Write Edit Glob Grep etc.>
+   user-invocable: true
+   ---
+
+   # <Title Case Name>
+
+   <Body: same ideas, but reference Claude tools by name (Glob, Grep, Read, Edit, Write, Bash, TaskCreate). Reference aux files as [playbook.md](playbook.md).>
+
+   ## Task
+
+   $ARGUMENTS
+   ```
+
+   The `## Task\n\n$ARGUMENTS` tail is how user-invoked args reach the skill body in Claude Code. Include it whenever `user-invocable: true`.
+
+5. Write shared resource files to both directories with identical content. If you created a `playbook.md` or `api-reference.md`, write it to both locations. If you created helper scripts, write them under `scripts/` in both. Never symlink across `.codex`/`.claude` — copy.
+
+6. Verify. After writing, list both directories and show the user what was created.
+
+## Writing good skill bodies
+
+- Lead with when to invoke and what input looks like.
+- Numbered imperatives, not narration.
+- Hardcode non-obvious constraints: rate limits, destructive-action confirmations, env vars to check first.
+- Reference aux files instead of inlining long content.
+- End with output format if the skill produces structured output.
+
+## Secrets and credentials
+
+Any skill that needs an API key, bot token, or other credential uses this
+pattern. Do not ask the user to export credentials in shell startup files. Do
+not store credentials in broad agent config that every subprocess can inherit.
+
+1. Storage — scoped credential files at `chmod 600`, one per service:
+   - Codex: `$CODEX_HOME/<service>.env` or `$HOME/.codex/<service>.env`
+   - Claude Code: `$CLAUDE_HOME/<service>.env` or `$HOME/.claude/<service>.env`
+
+   Plain `NAME=value` lines, one per required variable.
+
+2. Setup script — if setup is non-trivial, write a companion script that:
+   - Reads required values from the current environment or a hidden prompt.
+   - Writes both scoped env files at 0600.
+   - Strips any `export <VAR>=` lines from `~/.zshenv`, `.zprofile`, `.zshrc`, `.bash_profile`, `.bashrc`, `.profile`.
+   - Runs `launchctl unsetenv <VAR>` and removes any matching LaunchAgent plist.
+
+   zsh gotcha: inside functions, `local path="..."` silently clobbers `$PATH` because zsh aliases `$path` to the `$PATH` array. Use `target`, `env_path`, or similar.
+
+3. Runtime loading — access credentials only through a
+   `scripts/<service>-api.sh` wrapper that sources the scoped file per call.
+   Never inline credential values in commands, examples, logs, or error
+   messages. Generic loader:
+
+   ```bash
+   script_dir="$(cd "$(dirname "$0")" && pwd -P)"
+   codex_home="${CODEX_HOME:-$HOME/.codex}"
+   claude_home="${CLAUDE_HOME:-$HOME/.claude}"
+   case "$script_dir" in
+     */codex/*) candidates=("$codex_home/<service>.env" "$claude_home/<service>.env") ;;
+     *)         candidates=("$claude_home/<service>.env" "$codex_home/<service>.env") ;;
+   esac
+   env_file=""
+   for f in "${candidates[@]}"; do
+     [[ -r "$f" ]] && { env_file="$f"; break; }
+   done
+   [[ -z "$env_file" ]] && { echo "Credential file not found for <service>." >&2; exit 1; }
+   set -a; source "$env_file"; set +a
+   ```
+
+   A Codex-installed skill prefers the Codex-scoped file and falls back to Claude's copy (vice versa for Claude), so either harness is self-sufficient.
+
+4. SKILL.md must include a `## Credentials` section listing both generic file
+   paths, the `chmod 600` requirement, and an instruction to use the wrapper
+   rather than inline commands. Forbid echoing or logging credential values.
+
+5. MCP-server skills are the exception. If the skill only configures an MCP
+   server, follow that server's official scoped configuration guidance. Do not
+   use broad config storage for skills that call REST APIs directly.
+
+## Adaptation rules (Codex → Claude)
+
+| Codex | Claude Code addition/change |
+|---|---|
+| generic "read", "search", "write" | can reference tools by name: Read, Grep, Glob, Edit, Write |
+| no frontmatter extras | add `argument-hint`, `allowed-tools`, `user-invocable: true` |
+| no $ARGUMENTS | add `## Task\n\n$ARGUMENTS` trailing section |
+| bash commands | keep verbatim |
+| aux file links `[playbook.md](playbook.md)` | keep verbatim |
+
+## Common pitfalls
+
+- Don't symlink across harnesses. Copy. A user may have only one harness installed.
+- Don't forget `user-invocable: true` on the Claude side if the user expects `/<name>` to work.
+- Keep the description trigger-rich — both harnesses route by description.
+- Draft the body once, then mechanically apply adaptation rules for the second version.
+
+## Output
+
+Report the two SKILL.md paths written, any aux files written to both locations, and how each harness reaches the skill (`/<name>` in Claude Code; description match in Codex).

--- a/skills/codex/no-edits/SKILL.md
+++ b/skills/codex/no-edits/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: no-edits
+description: Switch into conversation-only mode — answer questions, discuss, explain, but make no file edits or other mutating changes. Use when the user wants to talk through the code/problem without changes being made.
+---
+
+# No Edits
+
+Conversation-only mode. For the remainder of this session (until the user explicitly lifts the mode), do not modify any files or shared state.
+
+## Rules
+
+1. **No mutating actions.** Do not edit, write, or create files. Do not run bash commands that change files, push to remotes, run migrations, send messages, or otherwise produce side effects outside the local read-only filesystem.
+2. **Read-only actions are fine.** Search, read files, run read-only bash (`ls`, `git status`, `git log`, `git diff`), fetch web pages. Use them freely to inform your answers.
+3. **Answer the question.** Explain, discuss, sketch approaches, compare tradeoffs, walk through code. If the user asks "how would you fix X", describe the fix in prose or a code block — do not apply it.
+4. **If the user asks for an edit anyway**, pause and confirm: remind them no-edits mode is active and ask whether they want to lift it for this change. Only proceed after explicit confirmation.
+5. **No commits, pushes, PRs, or external messages.** Even if a default behavior would normally persist something, skip it while this mode is active.
+
+## How to exit
+
+The user lifts no-edits mode by saying something like "ok go ahead and edit", "you can make the change now", or "edits are fine". Treat that as explicit consent for the specific action they described, not a blanket lift — if unsure, ask.

--- a/skills/codex/transcribe-ig/SKILL.md
+++ b/skills/codex/transcribe-ig/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: transcribe-ig
+description: Transcribe an Instagram video such as a Reel, post, or story to text. Use when the user asks to transcribe, get captions, or extract text from an Instagram video.
+---
+
+# Instagram Video Transcription
+
+Transcribe an Instagram video using `yt-dlp`, `ffmpeg`, and `openai-whisper`.
+
+## Setup
+
+Use a dedicated venv inside the Codex skill directory:
+
+```bash
+SKILL_DIR="${CODEX_HOME:-$HOME/.codex}/skills/transcribe-ig"
+if [ ! -d "$SKILL_DIR/.venv" ]; then
+  python3 -m venv "$SKILL_DIR/.venv"
+  "$SKILL_DIR/.venv/bin/pip" install --upgrade pip
+  "$SKILL_DIR/.venv/bin/pip" install openai-whisper
+fi
+```
+
+Required system tools:
+- `yt-dlp`
+- `ffmpeg`
+
+Supported wherever `yt-dlp` can read Chrome cookies: macOS, Linux, and Windows.
+
+Instagram auth:
+- `yt-dlp` uses Chrome cookies
+- the user must be logged into Instagram in Chrome
+- macOS may prompt for Keychain access on first run
+
+## Usage
+
+```bash
+SKILL_DIR="${CODEX_HOME:-$HOME/.codex}/skills/transcribe-ig"
+"$SKILL_DIR/.venv/bin/python3" "$SKILL_DIR/scripts/transcribe.py" <URL> [OPTIONS]
+```
+
+## Arguments
+
+Parse the request as:
+
+```text
+<instagram-url> [output-file] [--format text|json|srt] [--model tiny|base|small|medium|large] [--language en]
+```
+
+- If the user provides an output path, pass `-o <path>`.
+- Otherwise save to `ig_transcript.txt` in the current directory.
+- Default format is `text`.
+- Default model is `base`.
+
+## Steps
+
+1. Ensure the venv and `openai-whisper` are available.
+2. Extract the Instagram URL.
+3. Determine the output path.
+4. Run the script.
+5. Report the output path, segment count, character count, and detected language.
+
+## Error Handling
+
+- If the venv or package is missing, create it and install `openai-whisper`.
+- If `yt-dlp` says login is required, remind the user to log into Instagram in Chrome.
+- If `yt-dlp` fails for other reasons, suggest updating it with `yt-dlp -U`.
+- If Whisper is too slow, suggest using `tiny` or `base`.

--- a/skills/codex/transcribe-ig/scripts/transcribe.py
+++ b/skills/codex/transcribe-ig/scripts/transcribe.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Transcribe an Instagram video using yt-dlp + ffmpeg + whisper.
+
+Uses only trusted, widely-audited tools:
+- yt-dlp: downloads video with Chrome cookies for IG auth
+- ffmpeg: extracts audio
+- whisper: transcribes audio to text
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+
+def _export_ig_cookies(cookie_file: str) -> None:
+    """Export only .instagram.com cookies from Chrome to a Netscape cookie file."""
+    # yt-dlp's own cookie decryption handles the encryption, so we use yt-dlp
+    # to dump cookies then filter. This avoids reimplementing Chrome's keychain decryption.
+    dump_cmd = [
+        "yt-dlp",
+        "--cookies-from-browser", "chrome",
+        "--cookies", cookie_file,
+        "--skip-download",
+        "https://www.instagram.com",
+    ]
+    result = subprocess.run(dump_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Cookie export warning: {result.stderr}", file=sys.stderr)
+        return
+
+    # Now filter the cookie file to only .instagram.com domains
+    if os.path.exists(cookie_file):
+        with open(cookie_file, "r") as f:
+            lines = f.readlines()
+
+        with open(cookie_file, "w") as f:
+            for line in lines:
+                if line.startswith("#") or line.strip() == "":
+                    f.write(line)
+                    continue
+                if "\t" not in line:
+                    continue
+                domain = line.split("\t", 1)[0]
+                if domain == ".instagram.com" or domain.endswith(".instagram.com"):
+                    f.write(line)
+
+
+def download_video(url: str, output_path: str) -> str:
+    """Download Instagram video using yt-dlp with filtered IG-only cookies."""
+    # Create a filtered cookie file containing only .instagram.com cookies
+    cookie_file = os.path.join(os.path.dirname(output_path), "ig_cookies.txt")
+    _export_ig_cookies(cookie_file)
+
+    if os.path.exists(cookie_file) and os.path.getsize(cookie_file) > 0:
+        cmd = [
+            "yt-dlp",
+            "--cookies", cookie_file,
+            "--no-playlist",
+            "--merge-output-format", "mp4",
+            "-o", output_path,
+            url,
+        ]
+    else:
+        # Fallback if cookie export failed
+        print("Warning: filtered cookie export failed, falling back to --cookies-from-browser", file=sys.stderr)
+        cmd = [
+            "yt-dlp",
+            "--cookies-from-browser", "chrome",
+            "--no-playlist",
+            "--merge-output-format", "mp4",
+            "-o", output_path,
+            url,
+        ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"yt-dlp error:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    # Clean up cookie file immediately after use
+    if os.path.exists(cookie_file):
+        os.remove(cookie_file)
+
+    return output_path
+
+
+def extract_audio(video_path: str, audio_path: str) -> str:
+    """Extract audio from video using ffmpeg."""
+    cmd = [
+        "ffmpeg", "-y",
+        "-i", video_path,
+        "-vn",
+        "-acodec", "pcm_s16le",
+        "-ar", "16000",
+        "-ac", "1",
+        audio_path,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ffmpeg error:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return audio_path
+
+
+def transcribe_audio(audio_path: str, model_name: str = "base", language: str | None = None) -> dict:
+    """Transcribe audio using openai-whisper."""
+    import whisper
+
+    model = whisper.load_model(model_name)
+    options = {}
+    if language:
+        options["language"] = language
+
+    result = model.transcribe(audio_path, **options)
+
+    segments = []
+    for seg in result.get("segments", []):
+        segments.append({
+            "text": seg["text"].strip(),
+            "start": seg["start"],
+            "end": seg["end"],
+        })
+
+    full_text = " ".join(s["text"] for s in segments)
+
+    return {
+        "text": full_text,
+        "segment_count": len(segments),
+        "char_count": len(full_text),
+        "language": result.get("language", "unknown"),
+        "segments": segments,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Transcribe an Instagram video")
+    parser.add_argument("url", help="Instagram URL (reel, post, story)")
+    parser.add_argument("-o", "--output", help="Output file path (default: stdout)")
+    parser.add_argument("-f", "--format", choices=["text", "json", "srt"], default="text",
+                        help="Output format (default: text)")
+    parser.add_argument("-m", "--model", default="base",
+                        choices=["tiny", "base", "small", "medium", "large"],
+                        help="Whisper model size (default: base)")
+    parser.add_argument("-l", "--language", default=None,
+                        help="Language code (e.g., en, es)")
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        video_path = os.path.join(tmpdir, "video.mp4")
+        audio_path = os.path.join(tmpdir, "audio.wav")
+
+        print("Downloading Instagram video...", file=sys.stderr)
+        download_video(args.url, video_path)
+
+        print("Extracting audio...", file=sys.stderr)
+        extract_audio(video_path, audio_path)
+
+        print(f"Transcribing with Whisper ({args.model} model)...", file=sys.stderr)
+        result = transcribe_audio(audio_path, model_name=args.model, language=args.language)
+
+    print(f"Detected language: {result['language']}", file=sys.stderr)
+
+    if args.format == "json":
+        output = json.dumps(result, indent=2, ensure_ascii=False)
+    elif args.format == "srt":
+        lines = []
+        for i, s in enumerate(result["segments"], 1):
+            def fmt(t):
+                h = int(t // 3600)
+                m = int((t % 3600) // 60)
+                sec = int(t % 60)
+                ms = int((t % 1) * 1000)
+                return f"{h:02d}:{m:02d}:{sec:02d},{ms:03d}"
+            lines.append(f"{i}")
+            lines.append(f"{fmt(s['start'])} --> {fmt(s['end'])}")
+            lines.append(s["text"])
+            lines.append("")
+        output = "\n".join(lines)
+    else:
+        output = result["text"]
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(output)
+        print(f"Saved {result['segment_count']} segments ({result['char_count']} chars) to {args.output}",
+              file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/codex/transcribe-yt/SKILL.md
+++ b/skills/codex/transcribe-yt/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: transcribe-yt
+description: Transcribe a YouTube video to text. Use when the user asks to transcribe, get captions, or extract text from a YouTube video.
+---
+
+# YouTube Video Transcription
+
+Transcribe a YouTube video with `youtube-transcript-api`.
+
+## Helper script
+
+```bash
+SKILL_DIR="${CODEX_HOME:-$HOME/.codex}/skills/transcribe-yt"
+PYTHON_BIN=""
+for p in .venv/bin/python3 python3; do
+  if command -v "$p" >/dev/null 2>&1 || [ -x "$p" ]; then
+    if "$p" -c "import youtube_transcript_api" 2>/dev/null; then
+      PYTHON_BIN="$p"
+      break
+    fi
+  fi
+done
+
+if [ -z "$PYTHON_BIN" ]; then
+  python3 -m pip install youtube-transcript-api
+  PYTHON_BIN=python3
+fi
+
+"$PYTHON_BIN" "$SKILL_DIR/scripts/transcribe.py" <URL_OR_ID> [OPTIONS]
+```
+
+## Arguments
+
+Parse the request as:
+
+```text
+<youtube-url-or-id> [output-file] [--format text|json|srt] [--languages en es ...]
+```
+
+- If the user provides an output path, pass `-o <path>`.
+- Otherwise save to `<video_id>_transcript.txt` in the current directory.
+- Default format is `text`.
+
+## Steps
+
+1. Extract the YouTube URL or video ID.
+2. Determine the output path.
+3. Run the script.
+4. Report the saved file path, snippet count, and character count.
+
+## Error Handling
+
+- If `youtube-transcript-api` is missing, install it in a usable Python environment.
+- If the video has no captions, say so and suggest audio-plus-Whisper as a fallback.
+- If a requested language is unavailable, retry without the language filter.

--- a/skills/codex/transcribe-yt/scripts/transcribe.py
+++ b/skills/codex/transcribe-yt/scripts/transcribe.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Transcribe a YouTube video using youtube-transcript-api."""
+
+import argparse
+import json
+import re
+import sys
+
+
+def extract_video_id(url_or_id: str) -> str:
+    """Extract video ID from a YouTube URL or return as-is if already an ID."""
+    patterns = [
+        r'(?:youtu\.be/|youtube\.com/watch\?v=|youtube\.com/embed/|youtube\.com/v/)([a-zA-Z0-9_-]{11})',
+        r'^([a-zA-Z0-9_-]{11})$',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, url_or_id)
+        if match:
+            return match.group(1)
+    return url_or_id
+
+
+def transcribe(video_id: str, languages: list[str] | None = None) -> dict:
+    """Fetch transcript and return structured data."""
+    from youtube_transcript_api import YouTubeTranscriptApi
+
+    api = YouTubeTranscriptApi()
+    kwargs = {}
+    if languages:
+        kwargs["languages"] = languages
+
+    transcript = api.fetch(video_id, **kwargs)
+
+    snippets = []
+    for entry in transcript.snippets:
+        snippets.append({
+            'text': entry.text,
+            'start': entry.start,
+            'duration': entry.duration,
+        })
+
+    full_text = '\n'.join(s['text'] for s in snippets)
+
+    return {
+        'video_id': video_id,
+        'snippet_count': len(snippets),
+        'char_count': len(full_text),
+        'text': full_text,
+        'snippets': snippets,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Transcribe a YouTube video')
+    parser.add_argument('url', help='YouTube URL or video ID')
+    parser.add_argument('-o', '--output', help='Output file path (default: stdout)')
+    parser.add_argument('-f', '--format', choices=['text', 'json', 'srt'], default='text',
+                        help='Output format (default: text)')
+    parser.add_argument('-l', '--languages', nargs='+', default=None,
+                        help='Preferred languages (e.g., en es)')
+    args = parser.parse_args()
+
+    video_id = extract_video_id(args.url)
+    result = transcribe(video_id, args.languages)
+
+    if args.format == 'json':
+        output = json.dumps(result, indent=2, ensure_ascii=False)
+    elif args.format == 'srt':
+        lines = []
+        for i, s in enumerate(result['snippets'], 1):
+            start = s['start']
+            end = start + s['duration']
+            def fmt(t):
+                h = int(t // 3600)
+                m = int((t % 3600) // 60)
+                sec = int(t % 60)
+                ms = int((t % 1) * 1000)
+                return f'{h:02d}:{m:02d}:{sec:02d},{ms:03d}'
+            lines.append(f'{i}')
+            lines.append(f'{fmt(start)} --> {fmt(end)}')
+            lines.append(s['text'])
+            lines.append('')
+        output = '\n'.join(lines)
+    else:
+        output = result['text']
+
+    if args.output:
+        with open(args.output, 'w', encoding='utf-8') as f:
+            f.write(output)
+        print(f"Saved {result['snippet_count']} snippets ({result['char_count']} chars) to {args.output}",
+              file=sys.stderr)
+    else:
+        print(output)
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/codex/word-docx-redlines/SKILL.md
+++ b/skills/codex/word-docx-redlines/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: word-docx-redlines
+description: >-
+  Create, read, validate, and compare Word (.docx) documents with Track Changes.
+  Write real Track Changes XML (w:ins/w:del) into .docx files for native
+  accept/reject in Word. Validate that a redlined .docx correctly implements
+  a change specification by extracting and auditing existing tracked changes.
+  Generate redline comparison documents from two versions. Use when the user
+  asks to work with Word documents, .docx files, tracked changes, redlines,
+  document comparison, validating redlines, auditing changes, or modifying
+  Word files programmatically.
+---
+
+# Word Document Redlines & Track Changes
+
+## Prerequisites
+
+```bash
+brew install pandoc
+pip install python-docx   # or: python3 -m venv .venv && source .venv/bin/activate && pip install python-docx
+```
+
+## Core Capabilities
+
+### 1. Extract text from .docx
+
+Use pandoc for clean text extraction (better than python-docx `.text` which misses field codes):
+
+```bash
+pandoc document.docx -t plain --wrap=none
+```
+
+python-docx `.text` misses content in Word field codes, bookmarks, and complex formatting. To get ALL text from a paragraph:
+
+```python
+def full_text(para):
+    return "".join(t.text or "" for t in para._element.findall(".//" + qn("w:t")))
+```
+
+### 2. Iterate paragraphs in document order
+
+Body paragraphs and table cell paragraphs are separate in python-docx:
+
+```python
+from docx.oxml.ns import qn
+from docx.text.paragraph import Paragraph
+
+body = doc.element.body
+for child in body:
+    if child.tag == qn("w:p"):
+        para = Paragraph(child, body)
+    elif child.tag == qn("w:tbl"):
+        # table - iterate rows/cells separately
+        pass
+```
+
+### 3. Write real Track Changes XML
+
+Use `w:del` for deletions and `w:ins` for insertions. These produce native accept/reject buttons in Word.
+
+See `scripts/track_changes_helpers.py` for ready-to-use helper functions: `make_del()`, `make_ins()`, `replace_para()`, `delete_para()`, `insert_para_after()`.
+
+### 4. Generate a redline comparison document
+
+**Recommended workflow:**
+
+1. Extract text from original .docx via pandoc
+2. Normalize both versions (strip markdown, fix unicode, collapse whitespace)
+3. Diff with `difflib.SequenceMatcher` (line-level alignment, word-level diff for changes)
+4. Apply changes as Track Changes XML into a copy of the original .docx
+
+For step 4, use **targeted search** (find paragraphs by unique text snippet) rather than index-based or fuzzy alignment. See the "Targeted Approach" section below.
+
+## Key Lessons / Gotchas
+
+### Text normalization is critical
+
+The same text looks different depending on how you extract it. Always normalize before comparing:
+
+```python
+def norm(text):
+    text = text.replace("\xa0", " ")          # non-breaking spaces (VERY common in .docx)
+    text = text.replace("\u2013", "-")         # en-dash
+    text = text.replace("\u2014", " - ")       # em-dash
+    text = text.replace("\u201c", '"')         # smart quotes
+    text = text.replace("\u201d", '"')
+    text = text.replace("\u2018", "'")
+    text = text.replace("\u2019", "'")
+    text = re.sub(r"[ \t]+", " ", text)        # collapse whitespace
+    return text.strip()
+```
+
+### pandoc text != python-docx text
+
+- pandoc renders Word field codes (e.g., `[INSERT DATE]`); python-docx shows raw XML (e.g., `]`)
+- pandoc joins table cells into one line per row; python-docx gives each cell as a separate paragraph
+- pandoc includes table separator lines (`---`); filter these out
+
+### Paragraph matching strategy
+
+**DO NOT** rely on fuzzy alignment between pandoc-extracted text and python-docx paragraphs. Instead:
+
+1. **Targeted search**: Find paragraphs by unique text snippets using `full_text()`:
+   ```python
+   def find_para(paras, snippet, start=0):
+       for i in range(start, len(paras)):
+           if snippet in full_text(paras[i]):
+               return i
+       return None
+   ```
+
+2. **Section-heading anchored**: Find the section heading first, then search nearby paragraphs.
+
+3. **Refresh after inserts**: Call `get_body_paras(doc)` again after inserting/deleting paragraphs.
+
+### Track Changes XML structure
+
+Deleted text uses `w:delText` (not `w:t`):
+```xml
+<w:del w:id="1" w:author="Author" w:date="2026-01-01T00:00:00Z">
+  <w:r><w:delText xml:space="preserve">old text</w:delText></w:r>
+</w:del>
+```
+
+Inserted text uses `w:ins` wrapping a normal run:
+```xml
+<w:ins w:id="2" w:author="Author" w:date="2026-01-01T00:00:00Z">
+  <w:r><w:t xml:space="preserve">new text</w:t></w:r>
+</w:ins>
+```
+
+### Preserving formatting
+
+When rewriting a paragraph's content, capture the reference `rPr` (run properties) from the first run BEFORE clearing, then apply it to new runs. This preserves font, size, bold, etc.
+
+## Targeted Approach (recommended for known changes)
+
+When you know exactly what changed (e.g., from a change log), the most reliable method is:
+
+1. Copy the original .docx
+2. For each change, search for a unique text snippet to find the paragraph
+3. Apply the specific Track Change (delete, insert, or word-level diff)
+
+This avoids all fuzzy matching problems and produces clean, accurate results.
+
+## Validating Track Changes (auditing an existing redline)
+
+When the user asks you to **validate**, **verify**, or **audit** a .docx that already contains Track Changes against a change specification, ground truth document, or list of expected changes, use the raw XML inspection approach below. python-docx does NOT expose existing `w:ins`/`w:del` elements through its API — you must work with the XML directly.
+
+### Raw XML extraction
+
+A .docx is a ZIP archive. Extract `word/document.xml` without writing to disk:
+
+```bash
+unzip -p "Document.docx" word/document.xml | python3 -c "
+import sys
+xml = sys.stdin.read()
+print(f'Size: {len(xml)} chars')
+"
+```
+
+### Counting track changes
+
+```bash
+unzip -p "Document.docx" word/document.xml | python3 -c "
+import sys, re
+xml = sys.stdin.read()
+print(f'Insertions (w:ins): {len(re.findall(r\"<w:ins \", xml))}')
+print(f'Deletions (w:del): {len(re.findall(r\"<w:del \", xml))}')
+"
+```
+
+### Section-anchored extraction
+
+The core validation technique: find a section heading in the raw XML, grab a character window around it, then extract all `w:ins` and `w:del` elements within that window.
+
+```python
+import re, html as html_mod
+
+def extract_text_from_xml(xml_fragment):
+    """Extract text from w:t tags in an XML fragment."""
+    texts = re.findall(r'<w:t[^>]*>(.*?)</w:t>', xml_fragment, re.DOTALL)
+    return ''.join(html_mod.unescape(t) for t in texts)
+
+def extract_del_text(xml_fragment):
+    """Extract text from w:delText tags in an XML fragment."""
+    texts = re.findall(r'<w:delText[^>]*>(.*?)</w:delText>', xml_fragment, re.DOTALL)
+    return ''.join(html_mod.unescape(t) for t in texts)
+
+def extract_tracked_changes_near(xml, section_pattern, context_after=8000):
+    """Find a section heading and extract all tracked changes nearby."""
+    matches = list(re.finditer(section_pattern, xml))
+    if not matches:
+        return None
+
+    results = []
+    for m in matches:
+        start = max(0, m.start() - 500)
+        end = min(len(xml), m.end() + context_after)
+        chunk = xml[start:end]
+
+        insertions = re.findall(r'<w:ins\b[^>]*>(.*?)</w:ins>', chunk, re.DOTALL)
+        deletions = re.findall(r'<w:del\b[^>]*>(.*?)</w:del>', chunk, re.DOTALL)
+
+        ins_texts = [extract_text_from_xml(i) for i in insertions]
+        del_texts = [extract_del_text(d) for d in deletions]
+
+        results.append({
+            'offset': m.start(),
+            'insertions': [t for t in ins_texts if t.strip()],
+            'deletions': [t for t in del_texts if t.strip()],
+        })
+    return results
+```
+
+### Checking if specific text is tracked as an insertion
+
+Search for the text in the XML, then walk backwards to see if it's enclosed in a `w:ins` tag:
+
+```python
+def is_text_tracked_as_insertion(xml, search_text):
+    """Check whether search_text appears inside a w:ins element."""
+    m = re.search(re.escape(search_text), xml)
+    if not m:
+        return False
+    chunk = xml[max(0, m.start() - 3000):m.end()]
+    ins_opens = list(re.finditer(r'<w:ins\b[^>]*>', chunk))
+    ins_closes = list(re.finditer(r'</w:ins>', chunk))
+    if ins_opens:
+        last_open = ins_opens[-1]
+        last_close = ins_closes[-1] if ins_closes else None
+        if last_close is None or last_open.start() > last_close.start():
+            return True
+    return False
+```
+
+### Detecting specific text patterns (quote fixes, double periods, typos)
+
+When validating typographical fixes, compare the deleted text against the inserted text for the specific pattern:
+
+```python
+def check_pattern_fix(xml, section_pattern, bad_pattern, context_after=8000):
+    """Check if bad_pattern appears in a deletion near section_pattern,
+    and confirm the corresponding insertion does not contain it."""
+    results = extract_tracked_changes_near(xml, section_pattern, context_after)
+    if not results:
+        return {'found': False}
+
+    for r in results:
+        for dt in r['deletions']:
+            if bad_pattern in dt:
+                in_any_insertion = any(bad_pattern in it for it in r['insertions'])
+                return {
+                    'found': True,
+                    'deleted': True,
+                    'still_in_insertion': in_any_insertion,
+                    'pass': not in_any_insertion,
+                }
+    return {'found': False}
+```
+
+**Common patterns to check:**
+- Double periods: `'..'` in deleted text, `'.'` (single) in insertion
+- Missing quotes: `the Defined Term")` (no opening quote) → `the "Defined Term")`
+- Single → double quotes: `('Example Term')` → `("Example Term")`
+- Ellipsis: `'Section 1.1…,'` → `'Section 1.1,'`
+- Typos: `'Section 2.1shall'` → `'Section 2.1 shall'`
+
+### Validation methodology
+
+When validating a redlined .docx against a change specification:
+
+1. **Extract XML** from both the baseline .docx and the output .docx using `unzip -p`.
+2. **Count track changes** in both to understand the baseline (the original may already contain changes from a prior redline round).
+3. **For each change in the spec**, use section-anchored extraction to find the relevant tracked changes:
+   - Identify the section heading pattern (e.g., `'Section A - Acceptance'`).
+   - Extract all `w:ins` and `w:del` elements near that heading.
+   - Compare deleted text against what the spec says should have been removed.
+   - Compare inserted text against what the spec (or ground truth document) says should be present.
+4. **For each change, report a verdict:**
+   - **PASS**: The tracked change is present and correct (deletion matches what should be removed, insertion matches what should be added).
+   - **FAIL**: The change is missing, incomplete, or incorrect (explain what's wrong).
+   - **SKIP**: The change was already correct in the baseline document (no modification needed).
+5. **Produce a summary table** with pass/fail/skip counts.
+
+### Comparing baseline vs. output
+
+When the baseline document already contains track changes from a prior round, you need to distinguish between inherited changes and new changes. Compare both documents:
+
+```bash
+# Count changes in baseline
+unzip -p "baseline.docx" word/document.xml | python3 -c "
+import sys, re; xml = sys.stdin.read()
+print(f'Baseline - ins: {len(re.findall(r\"<w:ins \", xml))}, del: {len(re.findall(r\"<w:del \", xml))}')
+"
+
+# Count changes in output
+unzip -p "output.docx" word/document.xml | python3 -c "
+import sys, re; xml = sys.stdin.read()
+print(f'Output - ins: {len(re.findall(r\"<w:ins \", xml))}, del: {len(re.findall(r\"<w:del \", xml))}')
+"
+```
+
+If both have similar counts, verify that specific changes from the spec are present in the output but not in the baseline. Use the `w:author` attribute on track change elements to distinguish authors when multiple redline rounds exist.
+
+### Adjusting context window size
+
+The `context_after` parameter controls how much XML to scan after the section heading. Defaults to 8000 characters, which covers most sections. For long sections (e.g., a section with multiple bullet points), increase to 12000–18000. For short sections (e.g., a single-line fix), 3000–5000 is sufficient.
+
+## Utility Scripts
+
+- **`scripts/track_changes_helpers.py`**: Core helper functions for writing Track Changes XML into .docx files. Use as a library or read for reference.
+- **`scripts/validate_track_changes.py`**: Functions for extracting and auditing existing Track Changes from .docx files via raw XML inspection. Use for validation workflows.

--- a/skills/codex/word-docx-redlines/scripts/track_changes_helpers.py
+++ b/skills/codex/word-docx-redlines/scripts/track_changes_helpers.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Track Changes helpers for python-docx.
+Provides functions to write real Word Track Changes (w:ins / w:del) into .docx files.
+
+Usage:
+    from track_changes_helpers import (
+        full_text, find_para, get_body_paras, get_ref_rPr,
+        clear_para_content, make_run, make_del, make_ins,
+        replace_para, delete_para, insert_para_after, word_diff,
+        apply_word_diff_to_para
+    )
+"""
+
+import re
+import copy
+import difflib
+from lxml import etree
+from docx import Document
+from docx.text.paragraph import Paragraph
+from docx.oxml.ns import qn
+from docx.oxml import OxmlElement
+
+_rid = [0]
+AUTHOR = "Author"
+DATE = "2026-01-01T00:00:00Z"
+
+
+def set_author(author, date=None):
+    global AUTHOR, DATE
+    AUTHOR = author
+    if date:
+        DATE = date
+
+
+def _nid():
+    _rid[0] += 1
+    return str(_rid[0])
+
+
+def full_text(para):
+    """Get ALL text from a paragraph, including field codes and complex runs."""
+    return "".join(t.text or "" for t in para._element.findall(".//" + qn("w:t")))
+
+
+def norm(text):
+    """Normalize text for comparison."""
+    text = text.replace("\xa0", " ")
+    text = text.replace("\u2011", "-").replace("\u2013", "-").replace("\u2014", " - ")
+    text = text.replace("\u201c", '"').replace("\u201d", '"')
+    text = text.replace("\u2018", "'").replace("\u2019", "'")
+    text = re.sub(r"[ \t]+", " ", text)
+    return text.strip()
+
+
+def get_body_paras(doc):
+    """Get all body-level paragraphs (excludes table cells)."""
+    body = doc.element.body
+    return [Paragraph(c, body) for c in body if c.tag == qn("w:p")]
+
+
+def find_para(paras, snippet, start=0):
+    """Find first paragraph containing snippet (using full_text)."""
+    for i in range(start, len(paras)):
+        if snippet in full_text(paras[i]):
+            return i
+    return None
+
+
+def get_ref_rPr(para):
+    """Extract formatting properties from first run, stripping color/strike/highlight."""
+    for r_elem in para._element.findall(qn("w:r")):
+        rPr = r_elem.find(qn("w:rPr"))
+        if rPr is not None:
+            rPr_copy = copy.deepcopy(rPr)
+            for tag in (qn("w:color"), qn("w:strike"), qn("w:highlight"), qn("w:rStyle")):
+                for el in rPr_copy.findall(tag):
+                    rPr_copy.remove(el)
+            return rPr_copy
+    return None
+
+
+def clear_para_content(para):
+    """Remove all runs/tracked changes from paragraph, keeping pPr."""
+    for child in list(para._element):
+        if child.tag != qn("w:pPr"):
+            para._element.remove(child)
+
+
+def make_run(text, rPr=None):
+    """Create a w:r element."""
+    r = OxmlElement("w:r")
+    if rPr is not None:
+        r.append(copy.deepcopy(rPr))
+    t = OxmlElement("w:t")
+    t.set(qn("xml:space"), "preserve")
+    t.text = text
+    r.append(t)
+    return r
+
+
+def make_del(text, rPr=None):
+    """Create a w:del element (tracked deletion)."""
+    d = OxmlElement("w:del")
+    d.set(qn("w:id"), _nid())
+    d.set(qn("w:author"), AUTHOR)
+    d.set(qn("w:date"), DATE)
+    r = OxmlElement("w:r")
+    if rPr is not None:
+        r.append(copy.deepcopy(rPr))
+    dt = OxmlElement("w:delText")
+    dt.set(qn("xml:space"), "preserve")
+    dt.text = text
+    r.append(dt)
+    d.append(r)
+    return d
+
+
+def make_ins(text, rPr=None):
+    """Create a w:ins element (tracked insertion)."""
+    ins = OxmlElement("w:ins")
+    ins.set(qn("w:id"), _nid())
+    ins.set(qn("w:author"), AUTHOR)
+    ins.set(qn("w:date"), DATE)
+    ins.append(make_run(text, rPr))
+    return ins
+
+
+def replace_para(para, new_text):
+    """Delete old content, insert new content (both tracked)."""
+    old_text = full_text(para)
+    rPr = get_ref_rPr(para)
+    clear_para_content(para)
+    if old_text.strip():
+        para._element.append(make_del(old_text, rPr))
+    para._element.append(make_ins(new_text, rPr))
+
+
+def delete_para(para):
+    """Mark entire paragraph content as deleted."""
+    text = full_text(para)
+    if not text.strip():
+        return
+    rPr = get_ref_rPr(para)
+    clear_para_content(para)
+    para._element.append(make_del(text, rPr))
+
+
+def insert_para_after(para, text):
+    """Insert a new tracked-insertion paragraph after the given one."""
+    rPr = get_ref_rPr(para)
+    p = OxmlElement("w:p")
+    if para._element.pPr is not None:
+        p.append(copy.deepcopy(para._element.pPr))
+    p.append(make_ins(text, rPr))
+    para._element.addnext(p)
+    return Paragraph(p, para._element.getparent())
+
+
+def word_diff(old_text, new_text):
+    """Compute word-level diff. Returns list of (op, text) tuples."""
+    old_w = old_text.split()
+    new_w = new_text.split()
+    sm = difflib.SequenceMatcher(None, old_w, new_w, autojunk=False)
+    ops = []
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        if tag == "equal":
+            ops.append(("equal", " ".join(old_w[i1:i2])))
+        elif tag == "delete":
+            ops.append(("delete", " ".join(old_w[i1:i2])))
+        elif tag == "insert":
+            ops.append(("insert", " ".join(new_w[j1:j2])))
+        elif tag == "replace":
+            ops.append(("delete", " ".join(old_w[i1:i2])))
+            ops.append(("insert", " ".join(new_w[j1:j2])))
+    return ops
+
+
+def apply_word_diff_to_para(para, old_text, new_text):
+    """Rewrite paragraph with word-level Track Changes markup."""
+    rPr = get_ref_rPr(para)
+    clear_para_content(para)
+    ops = word_diff(old_text, new_text)
+    for i, (op, text) in enumerate(ops):
+        prefix = " " if i > 0 else ""
+        content = prefix + text
+        if op == "equal":
+            para._element.append(make_run(content, rPr))
+        elif op == "delete":
+            para._element.append(make_del(content, rPr))
+        elif op == "insert":
+            para._element.append(make_ins(content, rPr))

--- a/skills/codex/word-docx-redlines/scripts/validate_track_changes.py
+++ b/skills/codex/word-docx-redlines/scripts/validate_track_changes.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Validate Track Changes in .docx files.
+
+Extract and audit existing w:ins/w:del elements from Word documents
+by inspecting the raw XML. Use for verifying that a redlined document
+correctly implements a change specification.
+
+Usage (as a library):
+    from validate_track_changes import DocxTrackChangeReader
+
+    reader = DocxTrackChangeReader("output.docx")
+    reader.summary()
+    changes = reader.changes_near("Section A - Acceptance")
+    reader.print_changes(changes)
+
+Usage (CLI):
+    python validate_track_changes.py output.docx
+    python validate_track_changes.py output.docx --section "Section A - Acceptance"
+    python validate_track_changes.py output.docx --check-pattern "Section A - Acceptance" ".."
+    python validate_track_changes.py output.docx --compare baseline.docx
+"""
+
+import re
+import sys
+import html as html_mod
+import subprocess
+import argparse
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TrackedChange:
+    change_type: str  # "insertion" or "deletion"
+    text: str
+    offset: int
+    author: str = ""
+    date: str = ""
+
+
+@dataclass
+class SectionChanges:
+    section_pattern: str
+    offset: int
+    insertions: list = field(default_factory=list)
+    deletions: list = field(default_factory=list)
+
+
+class DocxTrackChangeReader:
+    """Read and audit Track Changes from a .docx file via raw XML."""
+
+    def __init__(self, docx_path):
+        self.path = docx_path
+        self.xml = self._extract_xml()
+
+    def _extract_xml(self):
+        result = subprocess.run(
+            ["unzip", "-p", self.path, "word/document.xml"],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to extract XML from {self.path}: {result.stderr}")
+        return result.stdout
+
+    @staticmethod
+    def _extract_wt_text(xml_fragment):
+        """Extract text from w:t tags."""
+        texts = re.findall(r'<w:t[^>]*>(.*?)</w:t>', xml_fragment, re.DOTALL)
+        return ''.join(html_mod.unescape(t) for t in texts)
+
+    @staticmethod
+    def _extract_del_text(xml_fragment):
+        """Extract text from w:delText tags."""
+        texts = re.findall(r'<w:delText[^>]*>(.*?)</w:delText>', xml_fragment, re.DOTALL)
+        return ''.join(html_mod.unescape(t) for t in texts)
+
+    @staticmethod
+    def _extract_author(tag_xml):
+        m = re.search(r'w:author="([^"]*)"', tag_xml)
+        return m.group(1) if m else ""
+
+    @staticmethod
+    def _extract_date(tag_xml):
+        m = re.search(r'w:date="([^"]*)"', tag_xml)
+        return m.group(1) if m else ""
+
+    def count(self):
+        """Count total insertions and deletions."""
+        ins = len(re.findall(r'<w:ins ', self.xml))
+        dels = len(re.findall(r'<w:del ', self.xml))
+        return {"insertions": ins, "deletions": dels}
+
+    def summary(self):
+        """Print a summary of track changes."""
+        c = self.count()
+        print(f"Document: {self.path}")
+        print(f"  Insertions (w:ins): {c['insertions']}")
+        print(f"  Deletions  (w:del): {c['deletions']}")
+        print(f"  XML size: {len(self.xml):,} chars")
+
+    def all_changes(self):
+        """Extract all tracked changes from the document."""
+        changes = []
+        for m in re.finditer(r'<w:ins\b([^>]*)>(.*?)</w:ins>', self.xml, re.DOTALL):
+            text = self._extract_wt_text(m.group(2))
+            if text.strip():
+                changes.append(TrackedChange(
+                    change_type="insertion", text=text,
+                    offset=m.start(),
+                    author=self._extract_author(m.group(1)),
+                    date=self._extract_date(m.group(1)),
+                ))
+        for m in re.finditer(r'<w:del\b([^>]*)>(.*?)</w:del>', self.xml, re.DOTALL):
+            text = self._extract_del_text(m.group(2))
+            if text.strip():
+                changes.append(TrackedChange(
+                    change_type="deletion", text=text,
+                    offset=m.start(),
+                    author=self._extract_author(m.group(1)),
+                    date=self._extract_date(m.group(1)),
+                ))
+        changes.sort(key=lambda c: c.offset)
+        return changes
+
+    def changes_near(self, section_pattern, context_after=8000, context_before=500):
+        """Find tracked changes near a section heading pattern."""
+        matches = list(re.finditer(section_pattern, self.xml))
+        if not matches:
+            return []
+
+        results = []
+        for m in matches:
+            start = max(0, m.start() - context_before)
+            end = min(len(self.xml), m.end() + context_after)
+            chunk = self.xml[start:end]
+
+            ins_texts = []
+            for ins_m in re.finditer(r'<w:ins\b[^>]*>(.*?)</w:ins>', chunk, re.DOTALL):
+                text = self._extract_wt_text(ins_m.group(1))
+                if text.strip():
+                    ins_texts.append(text)
+
+            del_texts = []
+            for del_m in re.finditer(r'<w:del\b[^>]*>(.*?)</w:del>', chunk, re.DOTALL):
+                text = self._extract_del_text(del_m.group(1))
+                if text.strip():
+                    del_texts.append(text)
+
+            results.append(SectionChanges(
+                section_pattern=section_pattern,
+                offset=m.start(),
+                insertions=ins_texts,
+                deletions=del_texts,
+            ))
+        return results
+
+    def is_tracked_insertion(self, search_text):
+        """Check if search_text appears inside a w:ins element."""
+        m = re.search(re.escape(search_text[:80]), self.xml)
+        if not m:
+            return False
+        lookback = self.xml[max(0, m.start() - 3000):m.end()]
+        ins_opens = list(re.finditer(r'<w:ins\b[^>]*>', lookback))
+        ins_closes = list(re.finditer(r'</w:ins>', lookback))
+        if ins_opens:
+            last_open = ins_opens[-1]
+            last_close = ins_closes[-1] if ins_closes else None
+            if last_close is None or last_open.start() > last_close.start():
+                return True
+        return False
+
+    def check_pattern_fix(self, section_pattern, bad_pattern, context_after=8000):
+        """Verify that bad_pattern was deleted and not re-introduced near a section."""
+        sections = self.changes_near(section_pattern, context_after)
+        if not sections:
+            return {"found": False, "section_exists": False}
+
+        for sec in sections:
+            for dt in sec.deletions:
+                if bad_pattern in dt:
+                    still_present = any(bad_pattern in it for it in sec.insertions)
+                    return {
+                        "found": True,
+                        "section_exists": True,
+                        "deleted": True,
+                        "still_in_insertion": still_present,
+                        "pass": not still_present,
+                    }
+        return {"found": False, "section_exists": True}
+
+    def find_text(self, search_text):
+        """Find all occurrences of search_text in the XML, returning context."""
+        results = []
+        for m in re.finditer(re.escape(search_text), self.xml):
+            chunk = self.xml[max(0, m.start() - 1000):min(len(self.xml), m.end() + 500)]
+            lookback = self.xml[max(0, m.start() - 3000):m.start()]
+            ins_open = lookback.rfind("<w:ins")
+            ins_close = lookback.rfind("</w:ins>")
+            del_open = lookback.rfind("<w:del")
+            del_close = lookback.rfind("</w:del>")
+            results.append({
+                "offset": m.start(),
+                "in_insertion": ins_open > ins_close,
+                "in_deletion": del_open > del_close,
+                "context": chunk,
+            })
+        return results
+
+    @staticmethod
+    def print_changes(section_changes_list, max_text=300):
+        """Pretty-print extracted section changes."""
+        for sec in section_changes_list:
+            print(f"\n  Section '{sec.section_pattern}' at offset {sec.offset}:")
+            print(f"  Insertions ({len(sec.insertions)}):")
+            for i, text in enumerate(sec.insertions):
+                display = text[:max_text] + ("..." if len(text) > max_text else "")
+                print(f"    INS[{i}]: \"{display}\"")
+            print(f"  Deletions ({len(sec.deletions)}):")
+            for i, text in enumerate(sec.deletions):
+                display = text[:max_text] + ("..." if len(text) > max_text else "")
+                print(f"    DEL[{i}]: \"{display}\"")
+
+
+def compare_documents(baseline_path, output_path):
+    """Compare track change counts between baseline and output."""
+    baseline = DocxTrackChangeReader(baseline_path)
+    output = DocxTrackChangeReader(output_path)
+
+    bc = baseline.count()
+    oc = output.count()
+
+    print(f"Baseline ({baseline_path}):")
+    print(f"  Insertions: {bc['insertions']}, Deletions: {bc['deletions']}")
+    print(f"Output ({output_path}):")
+    print(f"  Insertions: {oc['insertions']}, Deletions: {oc['deletions']}")
+    print(f"Delta:")
+    print(f"  Insertions: {oc['insertions'] - bc['insertions']:+d}")
+    print(f"  Deletions:  {oc['deletions'] - bc['deletions']:+d}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate Track Changes in .docx files")
+    parser.add_argument("docx", help="Path to the .docx file to inspect")
+    parser.add_argument("--section", help="Section heading pattern to search near")
+    parser.add_argument("--context", type=int, default=8000, help="XML chars after heading (default: 8000)")
+    parser.add_argument("--check-pattern", nargs=2, metavar=("SECTION", "PATTERN"),
+                        help="Check if PATTERN was fixed (deleted, not re-inserted) near SECTION")
+    parser.add_argument("--compare", metavar="BASELINE", help="Compare against a baseline .docx")
+    parser.add_argument("--all", action="store_true", help="Print all tracked changes")
+    args = parser.parse_args()
+
+    reader = DocxTrackChangeReader(args.docx)
+    reader.summary()
+
+    if args.compare:
+        print()
+        compare_documents(args.compare, args.docx)
+
+    if args.section:
+        changes = reader.changes_near(args.section, context_after=args.context)
+        if changes:
+            reader.print_changes(changes)
+        else:
+            print(f"\n  Section '{args.section}' not found in document.")
+
+    if args.check_pattern:
+        section, pattern = args.check_pattern
+        result = reader.check_pattern_fix(section, pattern, context_after=args.context)
+        print(f"\n  Pattern check: '{pattern}' near '{section}'")
+        if result.get("pass"):
+            print(f"  PASS: Pattern found in deletion and not in insertion.")
+        elif result.get("found"):
+            print(f"  FAIL: Pattern found in deletion but STILL present in insertion.")
+        elif result.get("section_exists"):
+            print(f"  NOT FOUND: Pattern not found in any deletion near this section.")
+        else:
+            print(f"  NOT FOUND: Section heading not found in document.")
+
+    if args.all:
+        changes = reader.all_changes()
+        print(f"\nAll tracked changes ({len(changes)} total):")
+        for c in changes:
+            tag = "INS" if c.change_type == "insertion" else "DEL"
+            display = c.text[:200] + ("..." if len(c.text) > 200 else "")
+            print(f"  [{tag}] @{c.offset} by {c.author}: \"{display}\"")
+
+    if not any([args.section, args.check_pattern, args.compare, args.all]):
+        print("\nUse --section, --check-pattern, --compare, or --all for detailed output.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a public, portable set of local Claude Code and Codex skills to the repo, with matching harness-specific packages under:

- `skills/claude/<skill-name>/`
- `skills/codex/<skill-name>/`

Included skills:

- `no-edits` — conversation-only mode for analysis, review, and planning without file mutations
- `ls` — consistent markdown directory listings
- `git-update` — safe stage/commit/push workflow with trunk-push guardrails
- `make-universal-skill` — creates paired Claude/Codex skill packages from one request
- `calendar-create-event` — calendar/reminder creation workflow with `.ics` fallback guidance
- `transcribe-yt` — YouTube transcript extraction helper
- `transcribe-ig` — Instagram video transcription workflow using `yt-dlp`, `ffmpeg`, and Whisper
- `word-docx-redlines` — Word `.docx` Track Changes creation, inspection, validation, and comparison helpers

## Why

This gives the repo a reusable starting library of agent skills that work across both Claude Code and Codex instead of living only in one developer's local config. The skills were normalized for public use: examples use portable paths, helper scripts are bundled with the skills, generated runtime files are excluded, and harness-specific differences are explicit.

## Documentation

Updates the README's skill authoring guidance to document:

- the shared skill vs harness-specific skill layouts
- how to check for redundant skills before adding new ones
- Claude vs Codex frontmatter and invocation differences
- what files belong in a skill package
- what must stay out of git (`.venv`, `__pycache__`, env files, local state, generated output)
- privacy and portability checks before publishing
- manual copy behavior for harness-specific `SKILL.md` packages until installer support is added

## Validation

- Parsed all included Python helper scripts with `ast.parse`
- Ran `git diff --cached --check`
- Scanned added skill trees for generated artifacts
- Scanned added skill trees and staged diff for hardcoded local paths, credentials, private identifiers, and copied local prompt artifacts
- Ran two Claude Code review passes; final review returned `PUBLISH`
