### PR TITLE
fix(orch): runaway-comment safeguards (idempotency + verify-loop guard)

### DIFF
--- a/hooks/orch-lifecycle/01-gh-plan-sync.sh
+++ b/hooks/orch-lifecycle/01-gh-plan-sync.sh
@@ -23,13 +23,13 @@ shift 2
 
 CONFIG_FILE="${REPO_ROOT}/dega-core.yaml"
 if [[ ! -f "${CONFIG_FILE}" ]]; then
-	exit 0
+  exit 0
 fi
 
 SYNC_ENABLED=$(grep 'sync:' "${CONFIG_FILE}" 2>/dev/null |
-	head -1 | awk '{print $2}' | tr -d ' ')
+  head -1 | awk '{print $2}' | tr -d ' ')
 if [[ "${SYNC_ENABLED}" != "true" ]]; then
-	exit 0
+  exit 0
 fi
 
 # --- Resolve state file and issue number ---
@@ -38,30 +38,30 @@ ORCH_STATE_DIR="${REPO_ROOT}/.orchestrator"
 STATE_FILE="${ORCH_STATE_DIR}/plans/${SLUG}/state.json"
 
 if [[ ! -f "${STATE_FILE}" ]]; then
-	echo "01-gh-plan-sync: no state.json for ${SLUG} — skipping" >&2
-	exit 0
+  echo "01-gh-plan-sync: no state.json for ${SLUG} — skipping" >&2
+  exit 0
 fi
 
 ISSUE=$(jq -r '.issueNumber // empty' "${STATE_FILE}")
 
 # Fallback: read from plan-meta.json if state.json has no issue number
 if [[ -z "${ISSUE}" || "${ISSUE}" == "null" ]]; then
-	PLAN_META="${ORCH_STATE_DIR}/plans/${SLUG}/plan-meta.json"
-	if [[ -f "${PLAN_META}" ]]; then
-		ISSUE=$(jq -r '.issue_number // empty' "${PLAN_META}")
-	fi
+  PLAN_META="${ORCH_STATE_DIR}/plans/${SLUG}/plan-meta.json"
+  if [[ -f "${PLAN_META}" ]]; then
+    ISSUE=$(jq -r '.issue_number // empty' "${PLAN_META}")
+  fi
 fi
 
 # Last resort: check worktree copy of plan-meta.json
 if [[ -z "${ISSUE}" || "${ISSUE}" == "null" ]]; then
-	WT_META="${ORCH_STATE_DIR}/worktrees/${SLUG}/.orchestrator/plans/${SLUG}/plan-meta.json"
-	if [[ -f "${WT_META}" ]]; then
-		ISSUE=$(jq -r '.issue_number // empty' "${WT_META}")
-	fi
+  WT_META="${ORCH_STATE_DIR}/worktrees/${SLUG}/.orchestrator/plans/${SLUG}/plan-meta.json"
+  if [[ -f "${WT_META}" ]]; then
+    ISSUE=$(jq -r '.issue_number // empty' "${WT_META}")
+  fi
 fi
 
 if [[ -z "${ISSUE}" || "${ISSUE}" == "null" ]]; then
-	exit 0
+  exit 0
 fi
 
 # --- Idempotency: posted.json records keys for comments already posted ---
@@ -76,30 +76,30 @@ POSTED_JSON="${ORCH_STATE_DIR}/plans/${SLUG}/posted.json"
 POSTED_LOCK="${POSTED_JSON}.lock"
 
 posted_has_key() {
-	local key="$1"
-	[[ -f "${POSTED_JSON}" ]] || return 1
-	jq -e --arg k "${key}" 'has($k)' "${POSTED_JSON}" >/dev/null 2>&1
+  local key="$1"
+  [[ -f "${POSTED_JSON}" ]] || return 1
+  jq -e --arg k "${key}" 'has($k)' "${POSTED_JSON}" >/dev/null 2>&1
 }
 
 posted_record_key() {
-	local key="$1"
-	mkdir -p "$(dirname "${POSTED_JSON}")"
-	(
-		if command -v flock >/dev/null 2>&1; then
-			flock 9 || true
-		fi
-		local existing='{}'
-		if [[ -s "${POSTED_JSON}" ]]; then
-			existing=$(cat "${POSTED_JSON}")
-		fi
-		local now
-		now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-		printf '%s' "${existing}" |
-			jq --arg k "${key}" --arg t "${now}" \
-				'. + {($k): {"postedAt": $t}}' \
-				>"${POSTED_JSON}.tmp"
-		mv "${POSTED_JSON}.tmp" "${POSTED_JSON}"
-	) 9>"${POSTED_LOCK}"
+  local key="$1"
+  mkdir -p "$(dirname "${POSTED_JSON}")"
+  (
+    if command -v flock >/dev/null 2>&1; then
+      flock 9 || true
+    fi
+    local existing='{}'
+    if [[ -s "${POSTED_JSON}" ]]; then
+      existing=$(cat "${POSTED_JSON}")
+    fi
+    local now
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    printf '%s' "${existing}" |
+      jq --arg k "${key}" --arg t "${now}" \
+        '. + {($k): {"postedAt": $t}}' \
+        >"${POSTED_JSON}.tmp"
+    mv "${POSTED_JSON}.tmp" "${POSTED_JSON}"
+  ) 9>"${POSTED_LOCK}"
 }
 
 # --- Parse extra args passed by engine ---
@@ -111,31 +111,31 @@ FAILED=""
 ELAPSED=""
 
 while [[ $# -gt 0 ]]; do
-	case "$1" in
-	--items)
-		ITEMS="${2:-}"
-		shift 2
-		;;
-	--max-workers)
-		MAX_WORKERS="${2:-}"
-		shift 2
-		;;
-	--passed)
-		PASSED="${2:-}"
-		shift 2
-		;;
-	--failed)
-		FAILED="${2:-}"
-		shift 2
-		;;
-	--elapsed)
-		ELAPSED="${2:-}"
-		shift 2
-		;;
-	*)
-		shift
-		;;
-	esac
+  case "$1" in
+  --items)
+    ITEMS="${2:-}"
+    shift 2
+    ;;
+  --max-workers)
+    MAX_WORKERS="${2:-}"
+    shift 2
+    ;;
+  --passed)
+    PASSED="${2:-}"
+    shift 2
+    ;;
+  --failed)
+    FAILED="${2:-}"
+    shift 2
+    ;;
+  --elapsed)
+    ELAPSED="${2:-}"
+    shift 2
+    ;;
+  *)
+    shift
+    ;;
+  esac
 done
 
 # --- Dispatch by event ---
@@ -145,198 +145,198 @@ VERIFY_ITERATION=$(jq -r '.verification.iteration // 0' "${STATE_FILE}" 2>/dev/n
 
 case "${EVENT}" in
 start)
-	START_KEY="start:plan:${PLAN_ITERATION}"
-	if posted_has_key "${START_KEY}"; then
-		exit 0
-	fi
-	ARGS=(start "${SLUG}" --issue "${ISSUE}")
-	if [[ -n "${ITEMS}" ]]; then
-		ARGS+=(--items "${ITEMS}")
-	fi
-	if [[ -n "${MAX_WORKERS}" ]]; then
-		ARGS+=(--max-workers "${MAX_WORKERS}")
-	fi
-	if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
-		posted_record_key "${START_KEY}"
-	fi
-	;;
+  START_KEY="start:plan:${PLAN_ITERATION}"
+  if posted_has_key "${START_KEY}"; then
+    exit 0
+  fi
+  ARGS=(start "${SLUG}" --issue "${ISSUE}")
+  if [[ -n "${ITEMS}" ]]; then
+    ARGS+=(--items "${ITEMS}")
+  fi
+  if [[ -n "${MAX_WORKERS}" ]]; then
+    ARGS+=(--max-workers "${MAX_WORKERS}")
+  fi
+  if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
+    posted_record_key "${START_KEY}"
+  fi
+  ;;
 
 review)
-	# Post per-item review comments by reading state.json.
-	# Each item with a lastResult gets a comment with its iteration count.
-	ITEM_COUNT=$(jq '.items | length' "${STATE_FILE}")
-	DONE_DIR="${ORCH_STATE_DIR}/plans/${SLUG}/done"
-	REVIEW_DIR="${ORCH_STATE_DIR}/plans/${SLUG}/reviews"
+  # Post per-item review comments by reading state.json.
+  # Each item with a lastResult gets a comment with its iteration count.
+  ITEM_COUNT=$(jq '.items | length' "${STATE_FILE}")
+  DONE_DIR="${ORCH_STATE_DIR}/plans/${SLUG}/done"
+  REVIEW_DIR="${ORCH_STATE_DIR}/plans/${SLUG}/reviews"
 
-	# Identify items that failed review (rework list from finalReview).
-	REWORK_IDS=$(jq -r '.finalReview.reworkItems // [] | .[]' "${STATE_FILE}")
+  # Identify items that failed review (rework list from finalReview).
+  REWORK_IDS=$(jq -r '.finalReview.reworkItems // [] | .[]' "${STATE_FILE}")
 
-	for ((i = 0; i < ITEM_COUNT; i++)); do
-		ITEM_RESULT=$(jq -r ".items[${i}].lastResult // empty" "${STATE_FILE}")
-		if [[ -z "${ITEM_RESULT}" || "${ITEM_RESULT}" == "null" ]]; then
-			continue
-		fi
-		ITEM_ID=$(jq -r ".items[${i}].id" "${STATE_FILE}")
-		ITEM_DESC=$(jq -r ".items[${i}].description" "${STATE_FILE}")
-		ITEM_ITER=$(jq -r ".items[${i}].iteration // 1" "${STATE_FILE}")
+  for ((i = 0; i < ITEM_COUNT; i++)); do
+    ITEM_RESULT=$(jq -r ".items[${i}].lastResult // empty" "${STATE_FILE}")
+    if [[ -z "${ITEM_RESULT}" || "${ITEM_RESULT}" == "null" ]]; then
+      continue
+    fi
+    ITEM_ID=$(jq -r ".items[${i}].id" "${STATE_FILE}")
+    ITEM_DESC=$(jq -r ".items[${i}].description" "${STATE_FILE}")
+    ITEM_ITER=$(jq -r ".items[${i}].iteration // 1" "${STATE_FILE}")
 
-		ITEM_KEY="review:${ITEM_ID}:${ITEM_ITER}"
-		if posted_has_key "${ITEM_KEY}"; then
-			continue
-		fi
+    ITEM_KEY="review:${ITEM_ID}:${ITEM_ITER}"
+    if posted_has_key "${ITEM_KEY}"; then
+      continue
+    fi
 
-		# Read per-item work summary: try done-file first, then
-		# worktree plan-level work-summary.txt as fallback.
-		WORK_SUMMARY=""
-		DONE_FILE="${DONE_DIR}/item-${ITEM_ID}.txt"
-		if [[ -f "${DONE_FILE}" ]]; then
-			WORK_SUMMARY=$(cat "${DONE_FILE}")
-		else
-			for ws_path in \
-				"${ORCH_STATE_DIR}/worktrees/${SLUG}/docs/exec-plans/active/${SLUG}/work-summary.txt" \
-				"${ORCH_STATE_DIR}/worktrees/${SLUG}/.orchestrator/plans/${SLUG}/work-summary.txt"; do
-				if [[ -f "${ws_path}" ]]; then
-					WORK_SUMMARY=$(cat "${ws_path}")
-					break
-				fi
-			done
-		fi
+    # Read per-item work summary: try done-file first, then
+    # worktree plan-level work-summary.txt as fallback.
+    WORK_SUMMARY=""
+    DONE_FILE="${DONE_DIR}/item-${ITEM_ID}.txt"
+    if [[ -f "${DONE_FILE}" ]]; then
+      WORK_SUMMARY=$(cat "${DONE_FILE}")
+    else
+      for ws_path in \
+        "${ORCH_STATE_DIR}/worktrees/${SLUG}/docs/exec-plans/active/${SLUG}/work-summary.txt" \
+        "${ORCH_STATE_DIR}/worktrees/${SLUG}/.orchestrator/plans/${SLUG}/work-summary.txt"; do
+        if [[ -f "${ws_path}" ]]; then
+          WORK_SUMMARY=$(cat "${ws_path}")
+          break
+        fi
+      done
+    fi
 
-		# Read review feedback for items that failed review.
-		FEEDBACK=""
-		if echo "${REWORK_IDS}" | grep -qw "${ITEM_ID}"; then
-			ITEM_RESULT="REVISE"
-			REVIEW_FILE="${REVIEW_DIR}/item-${ITEM_ID}-review.txt"
-			if [[ -f "${REVIEW_FILE}" ]]; then
-				FEEDBACK=$(tail -n +2 "${REVIEW_FILE}")
-			fi
-		fi
+    # Read review feedback for items that failed review.
+    FEEDBACK=""
+    if echo "${REWORK_IDS}" | grep -qw "${ITEM_ID}"; then
+      ITEM_RESULT="REVISE"
+      REVIEW_FILE="${REVIEW_DIR}/item-${ITEM_ID}-review.txt"
+      if [[ -f "${REVIEW_FILE}" ]]; then
+        FEEDBACK=$(tail -n +2 "${REVIEW_FILE}")
+      fi
+    fi
 
-		ARGS=(review "${SLUG}" --issue "${ISSUE}")
-		ARGS+=(--item-id "${ITEM_ID}")
-		ARGS+=(--item-desc "${ITEM_DESC}")
-		ARGS+=(--item-result "${ITEM_RESULT}")
-		ARGS+=(--iterations "${ITEM_ITER}")
-		if [[ -n "${WORK_SUMMARY}" ]]; then
-			ARGS+=(--work-summary "${WORK_SUMMARY}")
-		fi
-		if [[ -n "${FEEDBACK}" ]]; then
-			ARGS+=(--feedback "${FEEDBACK}")
-		fi
+    ARGS=(review "${SLUG}" --issue "${ISSUE}")
+    ARGS+=(--item-id "${ITEM_ID}")
+    ARGS+=(--item-desc "${ITEM_DESC}")
+    ARGS+=(--item-result "${ITEM_RESULT}")
+    ARGS+=(--iterations "${ITEM_ITER}")
+    if [[ -n "${WORK_SUMMARY}" ]]; then
+      ARGS+=(--work-summary "${WORK_SUMMARY}")
+    fi
+    if [[ -n "${FEEDBACK}" ]]; then
+      ARGS+=(--feedback "${FEEDBACK}")
+    fi
 
-		if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
-			posted_record_key "${ITEM_KEY}"
-		fi
-	done
-	;;
+    if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
+      posted_record_key "${ITEM_KEY}"
+    fi
+  done
+  ;;
 
 ship)
-	# Compute rework-count and total-reviews from per-item iterations.
-	REWORK_COUNT=$(jq '[.items[] | select((.iteration // 0) > 0)] | length' \
-		"${STATE_FILE}")
-	TOTAL_REVIEWS=$(jq '[.items[].iteration // 0] | add // 0' \
-		"${STATE_FILE}")
+  # Compute rework-count and total-reviews from per-item iterations.
+  REWORK_COUNT=$(jq '[.items[] | select((.iteration // 0) > 0)] | length' \
+    "${STATE_FILE}")
+  TOTAL_REVIEWS=$(jq '[.items[].iteration // 0] | add // 0' \
+    "${STATE_FILE}")
 
-	ARGS=(ship "${SLUG}" --issue "${ISSUE}")
-	if [[ -n "${ITEMS}" ]]; then
-		ARGS+=(--items "${ITEMS}")
-	fi
-	if [[ -n "${PASSED}" ]]; then
-		ARGS+=(--passed "${PASSED}")
-	fi
-	if [[ "${REWORK_COUNT}" -gt 0 ]]; then
-		ARGS+=(--rework-count "${REWORK_COUNT}")
-		ARGS+=(--total-reviews "${TOTAL_REVIEWS}")
-	fi
-	if [[ -n "${ELAPSED}" ]]; then
-		ARGS+=(--elapsed "${ELAPSED}")
-	fi
-	SHIP_KEY="ship:plan:${PLAN_ITERATION}"
-	if posted_has_key "${SHIP_KEY}"; then
-		exit 0
-	fi
-	if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
-		posted_record_key "${SHIP_KEY}"
-	fi
-	;;
+  ARGS=(ship "${SLUG}" --issue "${ISSUE}")
+  if [[ -n "${ITEMS}" ]]; then
+    ARGS+=(--items "${ITEMS}")
+  fi
+  if [[ -n "${PASSED}" ]]; then
+    ARGS+=(--passed "${PASSED}")
+  fi
+  if [[ "${REWORK_COUNT}" -gt 0 ]]; then
+    ARGS+=(--rework-count "${REWORK_COUNT}")
+    ARGS+=(--total-reviews "${TOTAL_REVIEWS}")
+  fi
+  if [[ -n "${ELAPSED}" ]]; then
+    ARGS+=(--elapsed "${ELAPSED}")
+  fi
+  SHIP_KEY="ship:plan:${PLAN_ITERATION}"
+  if posted_has_key "${SHIP_KEY}"; then
+    exit 0
+  fi
+  if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
+    posted_record_key "${SHIP_KEY}"
+  fi
+  ;;
 
 revise)
-	# Build failed-details from state.json.
-	FAILED_DETAILS=$(jq -r \
-		'[.items[] | select(.status == "failed") | "Item \(.id) (\(.lastResult // "unknown"))"] | join(", ")' \
-		"${STATE_FILE}")
+  # Build failed-details from state.json.
+  FAILED_DETAILS=$(jq -r \
+    '[.items[] | select(.status == "failed") | "Item \(.id) (\(.lastResult // "unknown"))"] | join(", ")' \
+    "${STATE_FILE}")
 
-	ARGS=(revise "${SLUG}" --issue "${ISSUE}")
-	if [[ -n "${ITEMS}" ]]; then
-		ARGS+=(--items "${ITEMS}")
-	fi
-	if [[ -n "${PASSED}" ]]; then
-		ARGS+=(--passed "${PASSED}")
-	fi
-	if [[ -n "${FAILED}" ]]; then
-		ARGS+=(--failed "${FAILED}")
-	fi
-	if [[ -n "${FAILED_DETAILS}" ]]; then
-		ARGS+=(--failed-details "${FAILED_DETAILS}")
-	fi
-	if [[ -n "${ELAPSED}" ]]; then
-		ARGS+=(--elapsed "${ELAPSED}")
-	fi
-	REVISE_KEY="revise:plan:${PLAN_ITERATION}"
-	if posted_has_key "${REVISE_KEY}"; then
-		exit 0
-	fi
-	if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
-		posted_record_key "${REVISE_KEY}"
-	fi
-	;;
+  ARGS=(revise "${SLUG}" --issue "${ISSUE}")
+  if [[ -n "${ITEMS}" ]]; then
+    ARGS+=(--items "${ITEMS}")
+  fi
+  if [[ -n "${PASSED}" ]]; then
+    ARGS+=(--passed "${PASSED}")
+  fi
+  if [[ -n "${FAILED}" ]]; then
+    ARGS+=(--failed "${FAILED}")
+  fi
+  if [[ -n "${FAILED_DETAILS}" ]]; then
+    ARGS+=(--failed-details "${FAILED_DETAILS}")
+  fi
+  if [[ -n "${ELAPSED}" ]]; then
+    ARGS+=(--elapsed "${ELAPSED}")
+  fi
+  REVISE_KEY="revise:plan:${PLAN_ITERATION}"
+  if posted_has_key "${REVISE_KEY}"; then
+    exit 0
+  fi
+  if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
+    posted_record_key "${REVISE_KEY}"
+  fi
+  ;;
 
 verify)
-	# Read verification status from state.json.
-	VERIFY_STATUS=$(jq -r '.verification.status // empty' "${STATE_FILE}")
-	if [[ -z "${VERIFY_STATUS}" || "${VERIFY_STATUS}" == "null" ]]; then
-		echo "01-gh-plan-sync: no verification status in state.json — skipping" >&2
-		exit 0
-	fi
+  # Read verification status from state.json.
+  VERIFY_STATUS=$(jq -r '.verification.status // empty' "${STATE_FILE}")
+  if [[ -z "${VERIFY_STATUS}" || "${VERIFY_STATUS}" == "null" ]]; then
+    echo "01-gh-plan-sync: no verification status in state.json — skipping" >&2
+    exit 0
+  fi
 
-	VERIFY_RESULT="FAIL"
-	if [[ "${VERIFY_STATUS}" == "passed" ]]; then
-		VERIFY_RESULT="PASS"
-	fi
+  VERIFY_RESULT="FAIL"
+  if [[ "${VERIFY_STATUS}" == "passed" ]]; then
+    VERIFY_RESULT="PASS"
+  fi
 
-	# Extract completion criteria from plan.md as details text.
-	VERIFY_DETAILS=""
-	for plan_path in \
-		"${ORCH_STATE_DIR}/worktrees/${SLUG}/docs/exec-plans/active/${SLUG}/plan.md" \
-		"${ORCH_STATE_DIR}/worktrees/${SLUG}/.orchestrator/plans/${SLUG}/plan.md" \
-		"${REPO_ROOT}/docs/exec-plans/active/${SLUG}/plan.md"; do
-		if [[ -f "${plan_path}" ]]; then
-			VERIFY_DETAILS=$(awk '
+  # Extract completion criteria from plan.md as details text.
+  VERIFY_DETAILS=""
+  for plan_path in \
+    "${ORCH_STATE_DIR}/worktrees/${SLUG}/docs/exec-plans/active/${SLUG}/plan.md" \
+    "${ORCH_STATE_DIR}/worktrees/${SLUG}/.orchestrator/plans/${SLUG}/plan.md" \
+    "${REPO_ROOT}/docs/exec-plans/active/${SLUG}/plan.md"; do
+    if [[ -f "${plan_path}" ]]; then
+      VERIFY_DETAILS=$(awk '
 				/^```/ { fence = !fence; next }
 				fence { next }
 				/^## Completion criteria/ { capturing = 1; next }
 				capturing && /^## / { exit }
 				capturing && /^- \[/ { print }
 			' "${plan_path}")
-			break
-		fi
-	done
+      break
+    fi
+  done
 
-	ARGS=(verify "${SLUG}" --issue "${ISSUE}")
-	ARGS+=(--verify-result "${VERIFY_RESULT}")
-	if [[ -n "${VERIFY_DETAILS}" ]]; then
-		ARGS+=(--verify-details "${VERIFY_DETAILS}")
-	fi
-	VERIFY_KEY="verify:plan:${VERIFY_ITERATION}"
-	if posted_has_key "${VERIFY_KEY}"; then
-		exit 0
-	fi
-	if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
-		posted_record_key "${VERIFY_KEY}"
-	fi
-	;;
+  ARGS=(verify "${SLUG}" --issue "${ISSUE}")
+  ARGS+=(--verify-result "${VERIFY_RESULT}")
+  if [[ -n "${VERIFY_DETAILS}" ]]; then
+    ARGS+=(--verify-details "${VERIFY_DETAILS}")
+  fi
+  VERIFY_KEY="verify:plan:${VERIFY_ITERATION}"
+  if posted_has_key "${VERIFY_KEY}"; then
+    exit 0
+  fi
+  if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
+    posted_record_key "${VERIFY_KEY}"
+  fi
+  ;;
 
 *)
-	echo "01-gh-plan-sync: unknown event: ${EVENT} — skipping" >&2
-	;;
+  echo "01-gh-plan-sync: unknown event: ${EVENT} — skipping" >&2
+  ;;
 esac

--- a/hooks/orch-lifecycle/01-gh-plan-sync.sh
+++ b/hooks/orch-lifecycle/01-gh-plan-sync.sh
@@ -64,6 +64,44 @@ if [[ -z "${ISSUE}" || "${ISSUE}" == "null" ]]; then
 	exit 0
 fi
 
+# --- Idempotency: posted.json records keys for comments already posted ---
+#
+# Layout: .orchestrator/plans/<slug>/posted.json — JSON object keyed by
+# "${event}:${item_id_or_plan}:${iteration}". Lock file lives next to it
+# at posted.json.lock. The hook writes a key only after the sync script
+# exits 0, so a transient gh failure leaves the key absent and the next
+# poll retries.
+
+POSTED_JSON="${ORCH_STATE_DIR}/plans/${SLUG}/posted.json"
+POSTED_LOCK="${POSTED_JSON}.lock"
+
+posted_has_key() {
+	local key="$1"
+	[[ -f "${POSTED_JSON}" ]] || return 1
+	jq -e --arg k "${key}" 'has($k)' "${POSTED_JSON}" >/dev/null 2>&1
+}
+
+posted_record_key() {
+	local key="$1"
+	mkdir -p "$(dirname "${POSTED_JSON}")"
+	(
+		if command -v flock >/dev/null 2>&1; then
+			flock 9 || true
+		fi
+		local existing='{}'
+		if [[ -s "${POSTED_JSON}" ]]; then
+			existing=$(cat "${POSTED_JSON}")
+		fi
+		local now
+		now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+		printf '%s' "${existing}" |
+			jq --arg k "${key}" --arg t "${now}" \
+				'. + {($k): {"postedAt": $t}}' \
+				>"${POSTED_JSON}.tmp"
+		mv "${POSTED_JSON}.tmp" "${POSTED_JSON}"
+	) 9>"${POSTED_LOCK}"
+}
+
 # --- Parse extra args passed by engine ---
 
 ITEMS=""
@@ -102,8 +140,15 @@ done
 
 # --- Dispatch by event ---
 
+PLAN_ITERATION=$(jq -r '.iteration // 0' "${STATE_FILE}" 2>/dev/null || echo 0)
+VERIFY_ITERATION=$(jq -r '.verification.iteration // 0' "${STATE_FILE}" 2>/dev/null || echo 0)
+
 case "${EVENT}" in
 start)
+	START_KEY="start:plan:${PLAN_ITERATION}"
+	if posted_has_key "${START_KEY}"; then
+		exit 0
+	fi
 	ARGS=(start "${SLUG}" --issue "${ISSUE}")
 	if [[ -n "${ITEMS}" ]]; then
 		ARGS+=(--items "${ITEMS}")
@@ -111,7 +156,9 @@ start)
 	if [[ -n "${MAX_WORKERS}" ]]; then
 		ARGS+=(--max-workers "${MAX_WORKERS}")
 	fi
-	"${SYNC_SCRIPT}" "${ARGS[@]}"
+	if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
+		posted_record_key "${START_KEY}"
+	fi
 	;;
 
 review)
@@ -132,6 +179,11 @@ review)
 		ITEM_ID=$(jq -r ".items[${i}].id" "${STATE_FILE}")
 		ITEM_DESC=$(jq -r ".items[${i}].description" "${STATE_FILE}")
 		ITEM_ITER=$(jq -r ".items[${i}].iteration // 1" "${STATE_FILE}")
+
+		ITEM_KEY="review:${ITEM_ID}:${ITEM_ITER}"
+		if posted_has_key "${ITEM_KEY}"; then
+			continue
+		fi
 
 		# Read per-item work summary: try done-file first, then
 		# worktree plan-level work-summary.txt as fallback.
@@ -172,7 +224,9 @@ review)
 			ARGS+=(--feedback "${FEEDBACK}")
 		fi
 
-		"${SYNC_SCRIPT}" "${ARGS[@]}" || true
+		if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
+			posted_record_key "${ITEM_KEY}"
+		fi
 	done
 	;;
 
@@ -197,7 +251,13 @@ ship)
 	if [[ -n "${ELAPSED}" ]]; then
 		ARGS+=(--elapsed "${ELAPSED}")
 	fi
-	"${SYNC_SCRIPT}" "${ARGS[@]}"
+	SHIP_KEY="ship:plan:${PLAN_ITERATION}"
+	if posted_has_key "${SHIP_KEY}"; then
+		exit 0
+	fi
+	if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
+		posted_record_key "${SHIP_KEY}"
+	fi
 	;;
 
 revise)
@@ -222,7 +282,13 @@ revise)
 	if [[ -n "${ELAPSED}" ]]; then
 		ARGS+=(--elapsed "${ELAPSED}")
 	fi
-	"${SYNC_SCRIPT}" "${ARGS[@]}"
+	REVISE_KEY="revise:plan:${PLAN_ITERATION}"
+	if posted_has_key "${REVISE_KEY}"; then
+		exit 0
+	fi
+	if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
+		posted_record_key "${REVISE_KEY}"
+	fi
 	;;
 
 verify)
@@ -261,7 +327,13 @@ verify)
 	if [[ -n "${VERIFY_DETAILS}" ]]; then
 		ARGS+=(--verify-details "${VERIFY_DETAILS}")
 	fi
-	"${SYNC_SCRIPT}" "${ARGS[@]}"
+	VERIFY_KEY="verify:plan:${VERIFY_ITERATION}"
+	if posted_has_key "${VERIFY_KEY}"; then
+		exit 0
+	fi
+	if "${SYNC_SCRIPT}" "${ARGS[@]}"; then
+		posted_record_key "${VERIFY_KEY}"
+	fi
 	;;
 
 *)

--- a/scripts/orch-engine.sh
+++ b/scripts/orch-engine.sh
@@ -517,6 +517,13 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
 					 .verification.uncheckedCount = $count |
 					 .updatedAt = $now' "${ORCH_STATE_FILE}")
         orch_write_state "${SLUG}" "${updated}"
+        # Forensics #241: bound verify-failure REVISE re-execs by MAX_ITERATIONS
+        # so an unverifiable plan cannot loop indefinitely.
+        if orch_verify_iteration_exhausted "${SLUG}" "${MAX_ITERATIONS}"; then
+          orch_master_deregister "${SLUG}" "failed"
+          write_heartbeat
+          exit 1
+        fi
         REVIEW_RESULT="REVISE"
       else
         echo "orch-engine: all completion criteria verified"

--- a/scripts/orch-watchdog.sh
+++ b/scripts/orch-watchdog.sh
@@ -72,3 +72,45 @@ orch_mark_phase_timeout() {
   orch_write_state "${slug}" "${updated}"
   echo "orch-watchdog: ${state_path} marked failed (phase_timeout after ${timeout_secs}s)${blocking:+; blocking: ${blocking}}" >&2
 }
+
+# Bound verify-failure REVISE re-execs by MAX_ITERATIONS.
+# Usage: orch_verify_iteration_exhausted <slug> <max_iterations>
+#   - Reads .verification.iteration from the plan's state.json.
+#   - iteration < max_iterations: returns 1 (not exhausted, no state mutation).
+#   - iteration >= max_iterations: writes terminal failure to state and
+#     returns 0. Sets:
+#         .status                     = "failed"
+#         .verification.status        = "failed"
+#         .verification.reason        = "verify_iteration_exhausted"
+#         .verification.maxIterations = <max_iterations>
+#         .updatedAt                  = now (RFC3339 UTC)
+#     .verification.iteration is preserved.
+orch_verify_iteration_exhausted() {
+  local slug="$1" max="$2"
+  local state_file
+  state_file=$(orch_plan_state_file "${slug}")
+  if [[ ! -f "${state_file}" ]]; then
+    echo "orch-watchdog: state file not found for slug ${slug}" >&2
+    return 1
+  fi
+  local iter
+  iter=$(jq -r '.verification.iteration // 0' "${state_file}")
+  if [[ "${iter}" -lt "${max}" ]]; then
+    return 1
+  fi
+  local now
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local updated
+  updated=$(jq \
+    --arg now "${now}" \
+    --arg reason "verify_iteration_exhausted" \
+    --argjson max "${max}" \
+    '.status = "failed" |
+     .verification.status = "failed" |
+     .verification.reason = $reason |
+     .verification.maxIterations = $max |
+     .updatedAt = $now' "${state_file}")
+  orch_write_state "${slug}" "${updated}"
+  echo "orch-watchdog: verify-iteration exhausted (iteration=${iter}, max=${max}) — plan ${slug} marked failed" >&2
+  return 0
+}

--- a/tests/orch/test_hook_idempotent_posting.bats
+++ b/tests/orch/test_hook_idempotent_posting.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+#
+# Idempotency tests for hooks/orch-lifecycle/01-gh-plan-sync.sh.
+#
+# The hook must maintain a per-plan posted.json keyed by
+# "${event}:${item_id_or_plan}:${iteration}". On duplicate keys it
+# skips invoking gh-plan-sync.sh; on new keys it invokes the sync
+# script and records the key only after gh exits 0.
+#
+# Test strategy: copy the real hook to a tempdir so SCRIPT_DIR resolves
+# to the tempdir, then plant a stub gh-plan-sync.sh next to it. The
+# stub records each invocation in $STUB_LOG and exits with the code in
+# $STUB_EXIT (default 0). This isolates the hook's idempotency logic
+# from the real sync script's gh + provider stack.
+
+REPO_ROOT_REAL="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+HOOK_SRC="${REPO_ROOT_REAL}/hooks/orch-lifecycle/01-gh-plan-sync.sh"
+
+setup() {
+  TEST_TMP="$(mktemp -d -t orch-hook-idem-XXXXXX)"
+  export TEST_TMP
+  SLUG="idem-plan"
+  export SLUG
+
+  # Layout: tempdir mirrors the real repo's hook + sync-script tree
+  # so the copied hook's relative SYNC_SCRIPT path resolves to the stub.
+  mkdir -p "${TEST_TMP}/hooks/orch-lifecycle"
+  mkdir -p "${TEST_TMP}/scripts"
+  cp "${HOOK_SRC}" "${TEST_TMP}/hooks/orch-lifecycle/01-gh-plan-sync.sh"
+  chmod +x "${TEST_TMP}/hooks/orch-lifecycle/01-gh-plan-sync.sh"
+
+  STUB_LOG="${TEST_TMP}/sync-calls.log"
+  export STUB_LOG
+  : >"${STUB_LOG}"
+  STUB_EXIT_FILE="${TEST_TMP}/sync-exit"
+  export STUB_EXIT_FILE
+  echo 0 >"${STUB_EXIT_FILE}"
+
+  cat >"${TEST_TMP}/scripts/gh-plan-sync.sh" <<'STUB'
+#!/usr/bin/env bash
+# Stub sync script — records every invocation and exits with the code
+# in $STUB_EXIT_FILE (default 0).
+printf '%s\n' "$*" >>"${STUB_LOG}"
+exit "$(cat "${STUB_EXIT_FILE}" 2>/dev/null || echo 0)"
+STUB
+  chmod +x "${TEST_TMP}/scripts/gh-plan-sync.sh"
+
+  # dega-core.yaml with github.sync enabled (the hook greps "sync:").
+  cat >"${TEST_TMP}/dega-core.yaml" <<'YAML'
+github:
+  sync: true
+YAML
+
+  # Plan state with an issue number and two review-ready items.
+  PLAN_DIR="${TEST_TMP}/.orchestrator/plans/${SLUG}"
+  mkdir -p "${PLAN_DIR}/done" "${PLAN_DIR}/reviews"
+  cat >"${PLAN_DIR}/state.json" <<'JSON'
+{
+  "issueNumber": 4242,
+  "items": [
+    {"id": 1, "description": "first item", "iteration": 1, "lastResult": "SHIP"},
+    {"id": 2, "description": "second item", "iteration": 1, "lastResult": "SHIP"}
+  ],
+  "finalReview": {"reworkItems": []}
+}
+JSON
+
+  # Make the tempdir a git repo so `git rev-parse --show-toplevel`
+  # resolves REPO_ROOT to TEST_TMP.
+  git -C "${TEST_TMP}" init --quiet --initial-branch=main
+  git -C "${TEST_TMP}" config user.email "test@example.com"
+  git -C "${TEST_TMP}" config user.name "Test"
+
+  HOOK="${TEST_TMP}/hooks/orch-lifecycle/01-gh-plan-sync.sh"
+  export HOOK
+  POSTED_JSON="${PLAN_DIR}/posted.json"
+  export POSTED_JSON
+}
+
+teardown() {
+  if [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]]; then
+    rm -rf "${TEST_TMP}"
+  fi
+}
+
+# Count the number of invocations the stub recorded.
+sync_call_count() {
+  if [[ -s "${STUB_LOG}" ]]; then
+    wc -l <"${STUB_LOG}" | tr -d ' '
+  else
+    echo 0
+  fi
+}
+
+# True iff posted.json exists and contains the given key.
+posted_has_key() {
+  local key="$1"
+  [[ -f "${POSTED_JSON}" ]] || return 1
+  jq -e --arg k "${key}" 'has($k)' "${POSTED_JSON}" >/dev/null 2>&1
+}
+
+# --- new-post: first call posts and records the key ---
+
+@test "review event posts when posted.json is absent and records the key" {
+  cd "${TEST_TMP}"
+  run "${HOOK}" review "${SLUG}"
+  [ "${status}" -eq 0 ]
+
+  # Both items should have triggered exactly one sync invocation.
+  [ "$(sync_call_count)" -eq 2 ]
+
+  # posted.json must exist and contain a key for each item at iter 1.
+  [ -f "${POSTED_JSON}" ]
+  posted_has_key "review:1:1"
+  posted_has_key "review:2:1"
+}
+
+# --- duplicate-skip: pre-seeded keys cause the sync script to be skipped ---
+
+@test "review event skips items whose key is already in posted.json" {
+  cd "${TEST_TMP}"
+
+  # Pre-seed posted.json with item 1's key only — item 2 should still post.
+  printf '%s\n' '{"review:1:1": {"postedAt": "2026-04-27T00:00:00Z"}}' \
+    >"${POSTED_JSON}"
+
+  run "${HOOK}" review "${SLUG}"
+  [ "${status}" -eq 0 ]
+
+  # Only item 2 should have triggered a sync call.
+  [ "$(sync_call_count)" -eq 1 ]
+  grep -q -- '--item-id 2' "${STUB_LOG}"
+  ! grep -q -- '--item-id 1' "${STUB_LOG}"
+
+  # Both keys must now be present.
+  posted_has_key "review:1:1"
+  posted_has_key "review:2:1"
+}
+
+@test "review event with all keys pre-seeded performs zero sync calls" {
+  cd "${TEST_TMP}"
+
+  printf '%s\n' \
+    '{"review:1:1": {"postedAt": "x"}, "review:2:1": {"postedAt": "y"}}' \
+    >"${POSTED_JSON}"
+
+  run "${HOOK}" review "${SLUG}"
+  [ "${status}" -eq 0 ]
+  [ "$(sync_call_count)" -eq 0 ]
+}
+
+# --- gh-failure-no-record: a failed sync call must NOT record the key ---
+
+@test "review event does not record key when sync script exits nonzero" {
+  cd "${TEST_TMP}"
+
+  # Force the stub to fail so the hook's gh path returns nonzero.
+  echo 1 >"${STUB_EXIT_FILE}"
+
+  run "${HOOK}" review "${SLUG}"
+  # Hook is best-effort — it should still exit 0 even if a post failed.
+  [ "${status}" -eq 0 ]
+
+  # The stub WAS invoked (twice — one per item) but no key may be recorded
+  # because the sync script reported failure. A subsequent run must retry.
+  [ "$(sync_call_count)" -eq 2 ]
+
+  if [[ -f "${POSTED_JSON}" ]]; then
+    run jq -e 'has("review:1:1")' "${POSTED_JSON}"
+    [ "${status}" -ne 0 ]
+    run jq -e 'has("review:2:1")' "${POSTED_JSON}"
+    [ "${status}" -ne 0 ]
+  fi
+
+  # Subsequent run with stub now succeeding must repost and record.
+  echo 0 >"${STUB_EXIT_FILE}"
+  : >"${STUB_LOG}"
+  run "${HOOK}" review "${SLUG}"
+  [ "${status}" -eq 0 ]
+  [ "$(sync_call_count)" -eq 2 ]
+  posted_has_key "review:1:1"
+  posted_has_key "review:2:1"
+}
+
+# --- iteration bump: a new iteration is a new key ---
+
+@test "review event posts again when item iteration advances" {
+  cd "${TEST_TMP}"
+
+  # First pass at iteration 1 records keys.
+  run "${HOOK}" review "${SLUG}"
+  [ "${status}" -eq 0 ]
+  posted_has_key "review:1:1"
+
+  # Bump item 1 to iteration 2 in state.json. The new key must not be
+  # in posted.json yet, so the hook must repost for that item.
+  jq '.items[0].iteration = 2' "${TEST_TMP}/.orchestrator/plans/${SLUG}/state.json" \
+    >"${TEST_TMP}/state.tmp"
+  mv "${TEST_TMP}/state.tmp" "${TEST_TMP}/.orchestrator/plans/${SLUG}/state.json"
+
+  : >"${STUB_LOG}"
+  run "${HOOK}" review "${SLUG}"
+  [ "${status}" -eq 0 ]
+
+  # Item 1 reposts at iter 2; item 2 still at iter 1, already recorded → skipped.
+  [ "$(sync_call_count)" -eq 1 ]
+  grep -q -- '--item-id 1' "${STUB_LOG}"
+  posted_has_key "review:1:2"
+}

--- a/tests/orch/test_verify_loop_guard.bats
+++ b/tests/orch/test_verify_loop_guard.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+#
+# Unit tests for the verify-iteration guard.
+#
+# Forensics: Issue #241 (2026-04-25) — verify-failure REVISE re-execs were
+# unbounded because verification.iteration was incremented but never compared
+# to MAX_ITERATIONS. The guard `orch_verify_iteration_exhausted` short-circuits
+# the REVISE/exec path once verification.iteration >= MAX_ITERATIONS.
+#
+# Contract (added in scripts/orch-watchdog.sh by item 4 of the plan):
+#   orch_verify_iteration_exhausted <slug> <max_iterations>
+#     - Reads .verification.iteration from the plan's state.json.
+#     - If iteration < max_iterations: returns 1 (not exhausted, no state change).
+#     - If iteration >= max_iterations: writes terminal failure to state and
+#       returns 0 (exhausted).
+#         .status                   = "failed"
+#         .verification.status      = "failed"
+#         .verification.reason      = "verify_iteration_exhausted"
+#         .verification.maxIterations = <max_iterations>
+#         .updatedAt                = now (RFC3339 UTC)
+
+setup() {
+  TEST_TMP=$(mktemp -d)
+  export TEST_TMP
+  export ORCH_STATE_DIR="${TEST_TMP}/.orchestrator"
+  export ORCH_REPO_ROOT="${TEST_TMP}"
+  mkdir -p "${ORCH_STATE_DIR}"
+
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  # shellcheck source=../../scripts/orch-state.sh disable=SC1091
+  source "${REPO_ROOT}/scripts/orch-state.sh"
+  # shellcheck source=../../scripts/orch-watchdog.sh disable=SC1091
+  source "${REPO_ROOT}/scripts/orch-watchdog.sh"
+
+  SLUG="test-plan"
+  PLAN_DIR="${ORCH_STATE_DIR}/plans/${SLUG}"
+  STATE_FILE="${PLAN_DIR}/state.json"
+  mkdir -p "${PLAN_DIR}"
+}
+
+teardown() {
+  rm -rf "${TEST_TMP}"
+}
+
+# Write a state.json with verification.iteration = $1.
+write_state_with_iter() {
+  local iter="$1"
+  jq -n \
+    --argjson iter "${iter}" \
+    '{
+      status: "verifying",
+      verification: {
+        status: "failed",
+        uncheckedCount: 1,
+        iteration: $iter
+      },
+      updatedAt: "2026-04-27T00:00:00Z"
+    }' >"${STATE_FILE}"
+}
+
+# --- iteration < MAX_ITERATIONS: not exhausted, no state mutation ---
+
+@test "orch_verify_iteration_exhausted returns 1 when iteration is 2 and max is 3" {
+  write_state_with_iter 2
+  set +e
+  orch_verify_iteration_exhausted "${SLUG}" 3
+  rc=$?
+  set -e
+  [ "${rc}" -eq 1 ]
+}
+
+@test "orch_verify_iteration_exhausted does not mutate state when iteration is below max" {
+  write_state_with_iter 2
+  before=$(cat "${STATE_FILE}")
+  set +e
+  orch_verify_iteration_exhausted "${SLUG}" 3
+  set -e
+  after=$(cat "${STATE_FILE}")
+  [ "${before}" = "${after}" ]
+  # Plan status remains the engine's pre-guard value (verifying).
+  [ "$(jq -r '.status' "${STATE_FILE}")" = "verifying" ]
+}
+
+# --- iteration >= MAX_ITERATIONS: exhausted, terminal failure written ---
+
+@test "orch_verify_iteration_exhausted returns 0 when iteration equals max" {
+  write_state_with_iter 3
+  set +e
+  orch_verify_iteration_exhausted "${SLUG}" 3
+  rc=$?
+  set -e
+  [ "${rc}" -eq 0 ]
+}
+
+@test "orch_verify_iteration_exhausted writes terminal failed status when exhausted" {
+  write_state_with_iter 3
+  orch_verify_iteration_exhausted "${SLUG}" 3 || true
+  [ "$(jq -r '.status' "${STATE_FILE}")" = "failed" ]
+  [ "$(jq -r '.verification.status' "${STATE_FILE}")" = "failed" ]
+  [ "$(jq -r '.verification.reason' "${STATE_FILE}")" = "verify_iteration_exhausted" ]
+  [ "$(jq -r '.verification.maxIterations' "${STATE_FILE}")" = "3" ]
+}
+
+@test "orch_verify_iteration_exhausted refreshes updatedAt when exhausted" {
+  write_state_with_iter 3
+  orch_verify_iteration_exhausted "${SLUG}" 3 || true
+  updated_at=$(jq -r '.updatedAt' "${STATE_FILE}")
+  [ -n "${updated_at}" ]
+  [ "${updated_at}" != "2026-04-27T00:00:00Z" ]
+  # RFC3339 UTC shape.
+  [[ "${updated_at}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+@test "orch_verify_iteration_exhausted treats iteration > max as exhausted" {
+  write_state_with_iter 5
+  set +e
+  orch_verify_iteration_exhausted "${SLUG}" 3
+  rc=$?
+  set -e
+  [ "${rc}" -eq 0 ]
+  [ "$(jq -r '.status' "${STATE_FILE}")" = "failed" ]
+}
+
+# --- preserves prior verification fields when marking exhausted ---
+
+@test "orch_verify_iteration_exhausted preserves verification.iteration when exhausted" {
+  write_state_with_iter 3
+  orch_verify_iteration_exhausted "${SLUG}" 3 || true
+  [ "$(jq -r '.verification.iteration' "${STATE_FILE}")" = "3" ]
+}


### PR DESCRIPTION
## Summary

- Hook idempotency in \`hooks/orch-lifecycle/01-gh-plan-sync.sh\`: per-plan \`posted.json\` keyed by event/item/iteration, \`flock\`-protected, written only after \`gh\` exits 0.
- Verify-iteration guard in \`scripts/orch-engine.sh\`: when \`verify_rc != 0\` and \`verification.iteration\` reaches \`MAX_ITERATIONS\`, mark plan failed instead of re-execing.
- Bats coverage for both fixes (\`tests/orch/test_hook_idempotent_posting.bats\`, \`tests/orch/test_verify_loop_guard.bats\`).

Plan: #243. Forensics: #241 (2500-comment runaway, 2026-04-25). Plan B (#244) addresses the deeper cause by making verify advisory; this PR is the safety belt.

## Test plan

- [ ] \`shellcheck hooks/orch-lifecycle/01-gh-plan-sync.sh scripts/orch-engine.sh\` exits 0
- [ ] \`shfmt -d hooks/orch-lifecycle/01-gh-plan-sync.sh scripts/orch-engine.sh\` exits 0
- [ ] \`bats tests/orch/test_hook_idempotent_posting.bats\` exits 0
- [ ] \`bats tests/orch/test_verify_loop_guard.bats\` exits 0
- [ ] \`bats tests/orch/\` (full suite) exits 0
- [ ] Manual smoke: trigger a plan with a deliberately failing verify criterion, observe plan marked failed at \`MAX_ITERATIONS\` (default 3) instead of looping.

## Notes for reviewer

- Reviewer SHIP'd 5/5 items in iteration 0 during the orch run that produced these commits. Verify failed in that run with \`rg: command not found\` in the verify subshell — every other criterion passed. That is exactly the case Plan B (#244) addresses; this PR was killed manually before the loop bug fired.
- Branch was authored against \`develop@3e7d019e\`; rebase / merge over the prompt-file fix (\`47fb9d74\`) should be a no-op (different file regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)