### PR TITLE
feat(orch): make completion-criteria verification advisory by default

### DIFF
--- a/dega-core.yaml
+++ b/dega-core.yaml
@@ -6,6 +6,12 @@ max_iterations: 3
 budget:
   warn_at_iteration: 2
 check_command: bash scripts/ralph-check.sh
+
+# Completion-criteria verification mode.
+# - advisory (default): verify runs and records results, but does NOT gate SHIP.
+# - enforce: verify failure triggers REVISE (legacy behavior).
+verify:
+  mode: advisory
 poll_interval_seconds: 15
 review_poll_interval_seconds: 10
 verify_poll_interval_seconds: 10

--- a/docs/decisions/20260427-verify-advisory-default.md
+++ b/docs/decisions/20260427-verify-advisory-default.md
@@ -1,0 +1,63 @@
+# Decision: Completion-criteria verification is advisory by default
+
+**Date:** 2026-04-27
+**Status:** Accepted
+**Forensics:** Issue #241 (verify loop, 2026-04-25)
+**Related:** Plan A — runaway safeguards (iteration guard); this decision removes the cause that the safeguards were catching.
+
+## Context
+
+The orchestrator runs two independent quality gates after workers complete a plan:
+
+- **Reviewer** — reads each item's done-file and asks "does this match the item description and clauses?" Per-item, narrative, decides SHIP vs REVISE per item.
+- **Verifier** — runs the shell predicates in the plan's `## Completion criteria` block and asks "does each one exit 0?" Whole-plan, binary, runs in the worktree.
+
+On 2026-04-25, issue #241 produced a divergence the orchestrator could not resolve: the reviewer SHIP'd 8/8 items while the verifier FAIL'd repeatedly, sending the plan into a REVISE loop that the workers could not satisfy. Forensics showed the verifier predicates failed for reasons unrelated to whether the work was correct:
+
+- Tooling missing in the worktree env (e.g., `yq`, `fd` not always present)
+- TDD-induced transient failures — a typecheck predicate fails because the implementation arrives in a later item
+- Path mismatches — `cd canon/templates && …` failing the first run because the directory was created mid-plan
+- Tests that hit external services or networks unavailable in the worktree
+
+The reviewer was reading what shipped; the verifier was running predicates that answer a different question. Both signals are useful, but coupling SHIP to the verifier makes the orchestrator brittle in proportion to how thoroughly a planner writes their criteria — a perverse incentive that punishes good plans.
+
+## Decision
+
+**Make completion-criteria verification advisory by default.**
+
+The verifier still runs. It still records `verification.status` in `state.json`. It still posts a per-criterion results comment to the issue. It no longer flips `REVIEW_RESULT=REVISE` when a predicate fails.
+
+Behavior is controlled by a new `verify:` block in `dega-core.yaml`:
+
+```yaml
+verify:
+  mode: advisory   # default — verify runs, reports, does not gate SHIP
+  # mode: enforce  # opt-in — preserves prior behavior (REVISE on verify failure)
+```
+
+`enforce` mode preserves today's behavior bit-for-bit, bounded by the iteration guard from Plan A.
+
+## Why not alternatives
+
+| Alternative | Problem |
+|-------------|---------|
+| Default = enforce | Reproduces the issue #241 loop. Punishes thorough planners. |
+| Delete verify entirely | Loses the per-criterion checkbox surfacing that operators wanted; harder to reverse if we change our minds. |
+| Global env var (`ORCH_VERIFY_MODE`) | Doesn't match the existing per-project config pattern (`provider`, `github`, harness blocks all live in `dega-core.yaml`). |
+| Per-plan override | Premature — no operator has asked for it. Can be added later as `verify.mode` in plan frontmatter without breaking the project default. |
+| Suppress verify comments in advisory mode | The per-criterion data is the whole point of keeping verify around. Comment stays. |
+
+## Consequences
+
+- **Default behavior changes.** Existing operators who relied on REVISE-on-verify-failure must opt in by setting `verify.mode: enforce`. Documented in this decision and in the rules update accompanying it.
+- **Advisory mode can mask real regressions.** A plan that breaks the test suite would still SHIP. Mitigation: the verify comment still posts findings; reviewers and per-item `check_command` are the appropriate gating layer for hard failures.
+- **Plan A's iteration guard remains the universal safety belt.** It protects `enforce` users from re-encountering the issue #241 loop pattern, even with thorough criteria.
+- **Reversible.** Flipping the default back is a one-line change to `dega-core.yaml` and the engine default.
+
+## References
+
+- Issue #241 — verify loop forensics (2026-04-25)
+- Plan A — runaway safeguards (PR #245, merged 2026-04-27)
+- `scripts/orch-engine.sh` — verify gate dispatch
+- `scripts/orch-state.sh` — `orch_get_verify_mode`, `orch_verify_should_gate`
+- `rules/exec-plans.md` — "Shell-verifiable completion criteria" (advisory by default)

--- a/rules/exec-plans.md
+++ b/rules/exec-plans.md
@@ -92,6 +92,17 @@ must be rewritten before the issue is created.
 
 Every completion criterion must be a shell command a reviewer can run.
 
+**Completion criteria are advisory by default.** The orchestrator's verify
+phase runs them, records results in `state.json`, and posts a results comment
+to the issue, but does NOT gate SHIP on failure. To make verify failures
+block SHIP (the legacy behavior), set `verify.mode: enforce` in
+`dega-core.yaml`. See `docs/decisions/20260427-verify-advisory-default.md`
+for rationale.
+
+Even though verify is advisory, write criteria as concrete shell commands —
+the results comment is only useful when each criterion is independently
+runnable.
+
 ```markdown
 # WRONG — vague, not verifiable
 - [ ] Tests pass

--- a/scripts/orch-engine.sh
+++ b/scripts/orch-engine.sh
@@ -483,6 +483,13 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
   # --- Completion criteria gate ---
   CC_UNCHECKED=$(orch_count_unchecked_criteria "${PLAN_DIR}/plan.md")
 
+  # Forensics #241: completion-criteria verification is advisory by default.
+  # Resolve verify.mode from dega-core.yaml; only "enforce" gates SHIP on
+  # verify failure. Unknown / missing values are treated as advisory.
+  VERIFY_CONFIG_FILE="$(orch_resolve_config)"
+  verify_mode=$(orch_get_verify_mode "${VERIFY_CONFIG_FILE}")
+  echo "orch-engine: verify.mode=${verify_mode}"
+
   if [[ "${CC_UNCHECKED}" -gt 0 ]]; then
     echo "orch-engine: ${CC_UNCHECKED} unchecked completion criteria — spawning verifier"
 
@@ -512,7 +519,6 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
       # Verifier succeeded — re-check criteria
       CC_AFTER=$(orch_count_unchecked_criteria "${PLAN_DIR}/plan.md")
       if [[ "${CC_AFTER}" -gt 0 ]]; then
-        echo "orch-engine: verifier finished but ${CC_AFTER} criteria still unchecked — REVISE"
         now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
         updated=$(jq \
           --arg now "${now}" \
@@ -521,14 +527,19 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
 					 .verification.uncheckedCount = $count |
 					 .updatedAt = $now' "${ORCH_STATE_FILE}")
         orch_write_state "${SLUG}" "${updated}"
-        # Forensics #241: bound verify-failure REVISE re-execs by MAX_ITERATIONS
-        # so an unverifiable plan cannot loop indefinitely.
-        if orch_verify_iteration_exhausted "${SLUG}" "${MAX_ITERATIONS}"; then
-          orch_master_deregister "${SLUG}" "failed"
-          write_heartbeat
-          exit 1
+        if orch_verify_should_gate 1 "${verify_mode}"; then
+          echo "orch-engine: verifier finished but ${CC_AFTER} criteria still unchecked — REVISE (verify.mode=enforce)"
+          # Forensics #241: bound verify-failure REVISE re-execs by MAX_ITERATIONS
+          # so an unverifiable plan cannot loop indefinitely.
+          if orch_verify_iteration_exhausted "${SLUG}" "${MAX_ITERATIONS}"; then
+            orch_master_deregister "${SLUG}" "failed"
+            write_heartbeat
+            exit 1
+          fi
+          REVIEW_RESULT="REVISE"
+        else
+          echo "orch-engine: verifier finished but ${CC_AFTER} criteria still unchecked — advisory only, SHIP proceeds (verify.mode=${verify_mode})"
         fi
-        REVIEW_RESULT="REVISE"
       else
         echo "orch-engine: all completion criteria verified"
         now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -552,16 +563,24 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
       verify_timeout_secs=$(orch_phase_timeout_secs verify 300)
       orch_mark_phase_timeout "${SLUG}" verification \
         "${verify_timeout_secs}" "${verify_blocking}"
-      REVIEW_RESULT="REVISE"
+      if orch_verify_should_gate "${verify_rc}" "${verify_mode}"; then
+        REVIEW_RESULT="REVISE"
+      else
+        echo "orch-engine: verify timed out — advisory only, SHIP proceeds (verify.mode=${verify_mode})"
+      fi
     else
-      echo "orch-engine: verifier failed (rc=${verify_rc}) — REVISE"
       now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
       updated=$(jq \
         --arg now "${now}" \
         '.verification.status = "failed" |
 				 .updatedAt = $now' "${ORCH_STATE_FILE}")
       orch_write_state "${SLUG}" "${updated}"
-      REVIEW_RESULT="REVISE"
+      if orch_verify_should_gate "${verify_rc}" "${verify_mode}"; then
+        echo "orch-engine: verifier failed (rc=${verify_rc}) — REVISE (verify.mode=enforce)"
+        REVIEW_RESULT="REVISE"
+      else
+        echo "orch-engine: verifier failed (rc=${verify_rc}) — advisory only, SHIP proceeds (verify.mode=${verify_mode})"
+      fi
     fi
   else
     echo "orch-engine: all completion criteria already checked"

--- a/scripts/orch-state.sh
+++ b/scripts/orch-state.sh
@@ -62,6 +62,63 @@ orch_read_config() {
   printf '%s' "${value}"
 }
 
+# --- Verify-mode config (issue #241 advisory-by-default) ---
+
+# Read .verify.mode from a YAML config file. Returns "advisory" by default
+# (file missing, key absent, empty/unknown value); returns "enforce" only
+# when explicitly set. Uses yq when available, falls back to awk so the
+# orchestrator does not require yq as a hard dependency.
+#   Usage: mode=$(orch_get_verify_mode "${ORCH_REPO_ROOT}/dega-core.yaml")
+orch_get_verify_mode() {
+  local yaml_path="$1"
+  local mode=""
+
+  if [[ ! -f "${yaml_path}" ]]; then
+    printf 'advisory'
+    return 0
+  fi
+
+  if command -v yq >/dev/null 2>&1; then
+    mode=$(yq '.verify.mode // ""' "${yaml_path}" 2>/dev/null |
+      tr -d '"' | tr -d "'" | tr -d '[:space:]')
+  fi
+
+  if [[ -z "${mode}" || "${mode}" == "null" ]]; then
+    mode=$(awk '
+      /^verify:[[:space:]]*$/ { in_block = 1; next }
+      in_block && /^[[:space:]]+mode:/ {
+        sub(/^[[:space:]]+mode:[[:space:]]*/, "")
+        sub(/[[:space:]]*#.*$/, "")
+        gsub(/[[:space:]"\047]/, "")
+        print
+        exit
+      }
+      in_block && /^[^[:space:]#]/ { in_block = 0 }
+    ' "${yaml_path}")
+  fi
+
+  case "${mode}" in
+  advisory | enforce) printf '%s' "${mode}" ;;
+  *) printf 'advisory' ;;
+  esac
+}
+
+# Decide whether a verify failure should gate SHIP. Returns 0 (true → gate
+# → set REVIEW_RESULT=REVISE) only when verify_rc is non-zero AND mode is
+# "enforce". Returns 1 (false → SHIP proceeds) in every other case,
+# including advisory-on-failure, success-in-either-mode, and unknown
+# modes (treated as advisory for safety).
+#   Usage: if orch_verify_should_gate "$verify_rc" "$mode"; then ...
+orch_verify_should_gate() {
+  local verify_rc="$1"
+  local mode="$2"
+
+  if [[ "${verify_rc}" -ne 0 && "${mode}" == "enforce" ]]; then
+    return 0
+  fi
+  return 1
+}
+
 # --- Platform detection ---
 
 # Detect the current platform. Returns one of: macos, wsl, linux.

--- a/tests/orch/test_verify_advisory.bats
+++ b/tests/orch/test_verify_advisory.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+#
+# Tests for verify-advisory mode (issue #241 follow-up).
+#
+# Forensics: Issue #241 (2026-04-25) — strict completion-criteria gating
+# caused unbounded REVISE loops because the verifier and reviewer answer
+# different questions. This plan flips the default to advisory: verify
+# still runs, status is still recorded, but a non-zero verify_rc no
+# longer gates SHIP. `verify.mode: enforce` opts back into the old
+# behavior.
+#
+# Contract under test (added by item 3 of the plan to scripts/orch-state.sh
+# and called from scripts/orch-engine.sh):
+#
+#   orch_get_verify_mode <yaml_path>
+#     - Reads .verify.mode from the YAML config (yq if available, grep
+#       fallback otherwise).
+#     - Returns "advisory" if the file is missing, the verify block is
+#       absent, or the value is empty/unknown.
+#     - Returns "enforce" only when explicitly set to "enforce".
+#
+#   orch_verify_should_gate <verify_rc> <mode>
+#     - Returns 0 (gate → REVISE) when verify_rc != 0 AND mode == enforce.
+#     - Returns 1 (do not gate → SHIP) in every other case, including
+#       advisory-on-failure and any-mode-on-success.
+#     - Unknown modes are treated as advisory (safe default).
+#
+# These two helpers, together, encode the three behavioural cases the
+# plan calls out:
+#   (a) advisory + verify_rc=1 → SHIP, status recorded as failed
+#   (b) enforce  + verify_rc=1 → REVISE (current behaviour preserved)
+#   (c) advisory + verify_rc=0 → SHIP, status recorded as passed
+
+setup() {
+  TEST_TMP="$(mktemp -d -t orch-verify-adv-XXXXXX)"
+  export TEST_TMP
+  export ORCH_REPO_ROOT="${TEST_TMP}"
+  export ORCH_STATE_DIR="${TEST_TMP}/.orchestrator"
+  mkdir -p "${ORCH_STATE_DIR}"
+
+  REPO_ROOT_REAL="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  # shellcheck source=../../scripts/orch-state.sh disable=SC1091
+  source "${REPO_ROOT_REAL}/scripts/orch-state.sh"
+}
+
+teardown() {
+  if [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]]; then
+    rm -rf "${TEST_TMP}"
+  fi
+}
+
+# --- orch_get_verify_mode: config parsing ---
+
+@test "orch_get_verify_mode defaults to advisory when verify block is absent" {
+  cat >"${TEST_TMP}/dega-core.yaml" <<'YAML'
+github:
+  sync: true
+provider: github
+YAML
+  result="$(orch_get_verify_mode "${TEST_TMP}/dega-core.yaml")"
+  [ "${result}" = "advisory" ]
+}
+
+@test "orch_get_verify_mode returns advisory when explicitly set" {
+  cat >"${TEST_TMP}/dega-core.yaml" <<'YAML'
+verify:
+  mode: advisory
+YAML
+  [ "$(orch_get_verify_mode "${TEST_TMP}/dega-core.yaml")" = "advisory" ]
+}
+
+@test "orch_get_verify_mode returns enforce when explicitly set" {
+  cat >"${TEST_TMP}/dega-core.yaml" <<'YAML'
+verify:
+  mode: enforce
+YAML
+  [ "$(orch_get_verify_mode "${TEST_TMP}/dega-core.yaml")" = "enforce" ]
+}
+
+@test "orch_get_verify_mode tolerates surrounding config keys" {
+  cat >"${TEST_TMP}/dega-core.yaml" <<'YAML'
+provider: github
+github:
+  sync: true
+verify:
+  mode: enforce
+check_command: bash
+YAML
+  [ "$(orch_get_verify_mode "${TEST_TMP}/dega-core.yaml")" = "enforce" ]
+}
+
+@test "orch_get_verify_mode defaults to advisory when file is missing" {
+  [ "$(orch_get_verify_mode "${TEST_TMP}/nonexistent.yaml")" = "advisory" ]
+}
+
+@test "orch_get_verify_mode treats unknown mode value as advisory" {
+  cat >"${TEST_TMP}/dega-core.yaml" <<'YAML'
+verify:
+  mode: bogus
+YAML
+  [ "$(orch_get_verify_mode "${TEST_TMP}/dega-core.yaml")" = "advisory" ]
+}
+
+# --- orch_verify_should_gate: gating decision ---
+#
+# Return-code semantics: 0 means "gate SHIP → set REVIEW_RESULT=REVISE";
+# 1 means "do not gate → SHIP proceeds". This matches the bash idiom
+# `if orch_verify_should_gate "$rc" "$mode"; then REVIEW_RESULT=REVISE; fi`.
+
+@test "advisory mode + verify_rc=1 does not gate (case a: SHIP on failure)" {
+  set +e
+  orch_verify_should_gate 1 advisory
+  rc=$?
+  set -e
+  [ "${rc}" -eq 1 ]
+}
+
+@test "enforce mode + verify_rc=1 gates (case b: REVISE preserves old behavior)" {
+  set +e
+  orch_verify_should_gate 1 enforce
+  rc=$?
+  set -e
+  [ "${rc}" -eq 0 ]
+}
+
+@test "advisory mode + verify_rc=0 does not gate (case c: SHIP on success)" {
+  set +e
+  orch_verify_should_gate 0 advisory
+  rc=$?
+  set -e
+  [ "${rc}" -eq 1 ]
+}
+
+@test "enforce mode + verify_rc=0 does not gate (success ships in either mode)" {
+  set +e
+  orch_verify_should_gate 0 enforce
+  rc=$?
+  set -e
+  [ "${rc}" -eq 1 ]
+}
+
+@test "advisory mode + verify_rc=124 (timeout) does not gate" {
+  set +e
+  orch_verify_should_gate 124 advisory
+  rc=$?
+  set -e
+  [ "${rc}" -eq 1 ]
+}
+
+@test "enforce mode + verify_rc=124 (timeout) gates" {
+  set +e
+  orch_verify_should_gate 124 enforce
+  rc=$?
+  set -e
+  [ "${rc}" -eq 0 ]
+}
+
+@test "unknown mode + verify_rc=1 treated as advisory (no gate)" {
+  set +e
+  orch_verify_should_gate 1 bogus
+  rc=$?
+  set -e
+  [ "${rc}" -eq 1 ]
+}


### PR DESCRIPTION
## Summary

- New \`verify:\` block in \`dega-core.yaml\` with \`mode: advisory\` default. \`enforce\` is opt-in.
- \`scripts/orch-engine.sh\` reads the mode (yq with grep fallback). In advisory mode, verify failure records \`verification.status = "failed"\` and continues to SHIP — no REVISE re-exec.
- \`docs/decisions/20260427-verify-advisory-default.md\` captures the rationale (issue #241 forensics, reviewer/verifier divergence).
- \`rules/exec-plans.md\` updated to note completion criteria are advisory by default.
- bats coverage for advisory + enforce paths.

Plan: #244. Forensics: #241. Builds on #245 (Plan A safeguards) plus the follow-up guard fix (\`200cf2b5\`) that hoists the iteration guard to every verify-failure branch.

## Test plan

- [ ] \`yq '.verify.mode' dega-core.yaml\` returns \`advisory\` (or grep fallback equivalent)
- [ ] \`shellcheck scripts/orch-engine.sh\` exits 0
- [ ] \`shfmt -d scripts/orch-engine.sh\` exits 0
- [ ] \`bats tests/orch/test_verify_advisory.bats\` exits 0
- [ ] \`bats tests/orch/\` (full suite) exits 0
- [ ] Manual smoke: deliberate failing criterion in advisory mode → SHIP; same criterion in enforce mode → REVISE bounded by MAX_ITERATIONS.

## Notes for reviewer

- Plan B's own orch run hit the verify-loop bug because the running engine was still on the partial #245 guard. Idempotency held (41 comments, vs 2500 on #241). Killed manually; \`200cf2b5\` (already on develop) closes the gap.
- Reviewer SHIP'd 6/6 items in iteration 0 during that run. The work in this PR was authored under review pressure and is unaffected by the loop bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)