### PR TITLE
feat(orch): Stop-hook agent-bump for plan completion

### DIFF
--- a/docs/orch-agent-notifications.md
+++ b/docs/orch-agent-notifications.md
@@ -1,0 +1,77 @@
+# Orchestrator Agent Notifications
+
+The orchestrator surfaces terminal plan events back to the agent without
+requiring the user to ask. When a plan ships, fails verification, or
+exhausts its review iterations, a notification file is written to disk.
+The next time Claude Code finishes a turn, a `Stop` hook reads any unseen
+notifications and injects them into the agent's context as a
+`system-reminder`, so the agent can announce "plan X completed: PR Y" on
+its own.
+
+## Trigger events
+
+The lifecycle hook `hooks/orch-lifecycle/02-agent-notify.sh` fires on
+three events emitted by `orch-engine.sh`:
+
+| Event    | When a notification is written                                   | Resulting `status`  |
+|----------|------------------------------------------------------------------|---------------------|
+| `ship`   | Plan was merged — PR url/number persisted in `state.finalReview` | `completed`         |
+| `verify` | Only when `verification.status == "failed"`                      | `failed`            |
+| `revise` | Only when the engine bailed (`state.status == "failed"`)         | `in_progress`       |
+
+Mid-loop `revise` events and successful `verify` runs are silent — the
+hook exits 0 without writing a file.
+
+## File location
+
+Notifications live at:
+
+```
+.orchestrator/notifications/<slug>.json
+```
+
+The entire `.orchestrator/` directory is gitignored, so notifications
+never leak into commits. One file per plan slug; subsequent events
+overwrite the file atomically (tmp + `mv`).
+
+## Schema
+
+```json
+{
+  "slug": "20260428-stop-hook-agent-bump",
+  "status": "completed",
+  "summary": "Plan <slug> shipped (6/6 items, 12m) — PR <url>",
+  "createdAt": "2026-04-28T18:42:11Z",
+  "seen": false,
+  "issueNumber": 258,
+  "prUrl": "https://github.com/DEGAorg/claude-code-config/pull/260",
+  "prNumber": 260
+}
+```
+
+`prUrl` and `prNumber` are present only on `ship`. `issueNumber` is
+present whenever `state.json` carries it. The schema is shared with
+Canon TUI per `docs/specs/canon-tui-plan-completion.md`.
+
+## Stop hook behavior
+
+`hooks/stop/01-orch-notify.sh` is registered in `settings.json` under
+`hooks.Stop`. On each Stop event it:
+
+1. Exits 0 silently if `${CLAUDE_PROJECT_DIR}/.orchestrator/notifications/`
+   does not exist (so it is a no-op outside this repo).
+2. Scans `*.json` for entries where `seen: false`.
+3. Builds a single human-readable message — up to 6 detailed entries,
+   any remainder summarized as a count plus the directory path.
+4. Marks each reported entry `seen: true` via atomic rewrite, so the
+   same notification is never injected twice.
+5. Emits `{"decision": "block", "reason": "<message>"}` on stdout. Claude
+   Code surfaces the `reason` as a system-reminder for the next turn.
+
+## How to disable
+
+Remove the `01-orch-notify.sh` entry from the `hooks.Stop` array in
+`settings.json` (or `.claude/settings.local.json`). The lifecycle hook
+will keep writing files for Canon TUI to consume, but the agent will
+no longer be auto-notified at Stop time. To also stop writing files,
+remove `02-agent-notify.sh` from the orch lifecycle hooks directory.

--- a/hooks/orch-lifecycle/02-agent-notify.sh
+++ b/hooks/orch-lifecycle/02-agent-notify.sh
@@ -14,8 +14,7 @@ set -euo pipefail
 #
 # Skips silently for non-terminal events or when state.json is absent.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 EVENT="${1:?usage: 02-agent-notify.sh <event> <slug> [options]}"
 SLUG="${2:?usage: 02-agent-notify.sh <event> <slug> [options]}"
@@ -137,6 +136,7 @@ JQ_ARGS=(
   --arg summary "${SUMMARY}"
   --arg createdAt "${CREATED_AT}"
 )
+# shellcheck disable=SC2016 # jq filter — $vars are jq refs, not shell expansion
 JQ_FILTER='{slug: $slug, status: $status, summary: $summary, createdAt: $createdAt, seen: false}'
 
 if [[ -n "${ISSUE_NUMBER}" ]]; then

--- a/hooks/orch-lifecycle/02-agent-notify.sh
+++ b/hooks/orch-lifecycle/02-agent-notify.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lifecycle hook: write agent-bump notifications on terminal events.
+#
+# Called by orch-engine.sh at milestones with (event, slug, ...extra args).
+# On ship, verify (failed only), and revise (engine-bailout only), reads
+# state.json and writes .orchestrator/notifications/<slug>.json describing
+# the outcome. The companion Stop hook (hooks/stop/01-orch-notify.sh) reads
+# these notifications and surfaces them to the agent.
+#
+# Schema:
+#   { slug, status, prUrl?, prNumber?, issueNumber, summary, createdAt, seen }
+#
+# Skips silently for non-terminal events or when state.json is absent.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+EVENT="${1:?usage: 02-agent-notify.sh <event> <slug> [options]}"
+SLUG="${2:?usage: 02-agent-notify.sh <event> <slug> [options]}"
+shift 2
+
+ORCH_STATE_DIR="${REPO_ROOT}/.orchestrator"
+STATE_FILE="${ORCH_STATE_DIR}/plans/${SLUG}/state.json"
+NOTIF_DIR="${ORCH_STATE_DIR}/notifications"
+NOTIF_FILE="${NOTIF_DIR}/${SLUG}.json"
+
+if [[ ! -f "${STATE_FILE}" ]]; then
+  echo "02-agent-notify: no state.json for ${SLUG} — skipping" >&2
+  exit 0
+fi
+
+# --- Parse extra args passed by engine ---
+
+ITEMS=""
+PASSED=""
+FAILED=""
+ELAPSED=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --items)
+    ITEMS="${2:-}"
+    shift 2
+    ;;
+  --max-workers)
+    shift 2
+    ;;
+  --passed)
+    PASSED="${2:-}"
+    shift 2
+    ;;
+  --failed)
+    FAILED="${2:-}"
+    shift 2
+    ;;
+  --elapsed)
+    ELAPSED="${2:-}"
+    shift 2
+    ;;
+  *)
+    shift
+    ;;
+  esac
+done
+
+ISSUE_NUMBER=$(jq -r '.issueNumber // empty' "${STATE_FILE}")
+
+# Determine notification fields per event. STATUS empty means "skip".
+STATUS=""
+SUMMARY=""
+PR_URL=""
+PR_NUMBER=""
+
+case "${EVENT}" in
+ship)
+  STATUS="completed"
+  PR_URL=$(jq -r '.finalReview.prUrl // empty' "${STATE_FILE}")
+  PR_NUMBER=$(jq -r '.finalReview.prNumber // empty' "${STATE_FILE}")
+  SUMMARY="Plan ${SLUG} shipped"
+  if [[ -n "${ITEMS}" && -n "${PASSED}" ]]; then
+    SUMMARY="${SUMMARY} (${PASSED}/${ITEMS} items"
+    if [[ -n "${ELAPSED}" ]]; then
+      SUMMARY="${SUMMARY}, ${ELAPSED}"
+    fi
+    SUMMARY="${SUMMARY})"
+  fi
+  if [[ -n "${PR_URL}" ]]; then
+    SUMMARY="${SUMMARY} — PR ${PR_URL}"
+  fi
+  ;;
+
+verify)
+  VERIFY_STATUS=$(jq -r '.verification.status // empty' "${STATE_FILE}")
+  if [[ "${VERIFY_STATUS}" != "failed" ]]; then
+    exit 0
+  fi
+  STATUS="failed"
+  UNCHECKED=$(jq -r '.verification.uncheckedCount // 0' "${STATE_FILE}")
+  SUMMARY="Plan ${SLUG} verification failed (${UNCHECKED} unchecked criteria)"
+  ;;
+
+revise)
+  # Only write when the engine has bailed: state.json.status == "failed".
+  # In normal mid-loop revise, the engine continues iterating and we stay
+  # silent. The bailout case means the engine gave up after exhausting its
+  # iteration budget.
+  PLAN_STATUS=$(jq -r '.status // empty' "${STATE_FILE}")
+  if [[ "${PLAN_STATUS}" != "failed" ]]; then
+    exit 0
+  fi
+  STATUS="in_progress"
+  SUMMARY="Plan ${SLUG} stopped after exhausting review iterations"
+  if [[ -n "${FAILED}" && -n "${ITEMS}" ]]; then
+    SUMMARY="${SUMMARY} (${FAILED}/${ITEMS} items still failing)"
+  fi
+  ;;
+
+*)
+  exit 0
+  ;;
+esac
+
+if [[ -z "${STATUS}" ]]; then
+  exit 0
+fi
+
+mkdir -p "${NOTIF_DIR}"
+
+CREATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Build JSON. Optional fields are omitted when empty.
+JQ_ARGS=(
+  --arg slug "${SLUG}"
+  --arg status "${STATUS}"
+  --arg summary "${SUMMARY}"
+  --arg createdAt "${CREATED_AT}"
+)
+JQ_FILTER='{slug: $slug, status: $status, summary: $summary, createdAt: $createdAt, seen: false}'
+
+if [[ -n "${ISSUE_NUMBER}" ]]; then
+  JQ_ARGS+=(--argjson issueNumber "${ISSUE_NUMBER}")
+  JQ_FILTER="${JQ_FILTER} + {issueNumber: \$issueNumber}"
+fi
+
+if [[ -n "${PR_URL}" ]]; then
+  JQ_ARGS+=(--arg prUrl "${PR_URL}")
+  JQ_FILTER="${JQ_FILTER} + {prUrl: \$prUrl}"
+fi
+
+if [[ -n "${PR_NUMBER}" ]]; then
+  JQ_ARGS+=(--argjson prNumber "${PR_NUMBER}")
+  JQ_FILTER="${JQ_FILTER} + {prNumber: \$prNumber}"
+fi
+
+TMP_FILE="${NOTIF_FILE}.tmp.$$"
+jq -n "${JQ_ARGS[@]}" "${JQ_FILTER}" >"${TMP_FILE}"
+mv "${TMP_FILE}" "${NOTIF_FILE}"
+
+echo "02-agent-notify: wrote ${NOTIF_FILE} (event=${EVENT} status=${STATUS})" >&2

--- a/hooks/stop/01-orch-notify.sh
+++ b/hooks/stop/01-orch-notify.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Stop hook: surfaces unseen orch plan notifications to the agent.
+#
+# Reads ${CLAUDE_PROJECT_DIR}/.orchestrator/notifications/*.json, finds
+# entries with `seen: false`, builds a single human-readable message,
+# marks them seen via atomic rewrite, and emits a Claude Code Stop-hook
+# block JSON ({"decision": "block", "reason": "..."}) on stdout so the
+# agent surfaces the outcome on the next turn.
+#
+# No-op (exit 0 silently) when the notifications dir is absent or empty,
+# making this safe to run from any repo.
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-${PWD}}"
+NOTIF_DIR="${PROJECT_DIR}/.orchestrator/notifications"
+
+[[ -d "${NOTIF_DIR}" ]] || exit 0
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Drain stdin so the harness doesn't see SIGPIPE when it pipes hook input.
+cat >/dev/null 2>&1 || true
+
+shopt -s nullglob
+files=("${NOTIF_DIR}"/*.json)
+shopt -u nullglob
+
+[[ ${#files[@]} -gt 0 ]] || exit 0
+
+unseen=()
+for f in "${files[@]}"; do
+  if jq -e '.seen == false' "${f}" >/dev/null 2>&1; then
+    unseen+=("${f}")
+  fi
+done
+
+[[ ${#unseen[@]} -gt 0 ]] || exit 0
+
+MAX_DETAIL=6
+total=${#unseen[@]}
+detail_count=$((total < MAX_DETAIL ? total : MAX_DETAIL))
+
+format_one() {
+  local file="$1"
+  jq -r '
+    def fmt:
+      "- plan \(.slug // "?") — \(.status // "?")"
+      + (if .prUrl then " — PR: \(.prUrl)"
+         elif .prNumber then " — PR #\(.prNumber)"
+         else "" end)
+      + (if .issueNumber then " (issue #\(.issueNumber))" else "" end)
+      + (if .summary then ": \(.summary)" else "" end);
+    fmt
+  ' "${file}"
+}
+
+lines=()
+lines+=("Orchestrator plan notifications (${total} unseen):")
+for ((i = 0; i < detail_count; i++)); do
+  lines+=("$(format_one "${unseen[$i]}")")
+done
+
+if ((total > MAX_DETAIL)); then
+  remaining=$((total - MAX_DETAIL))
+  lines+=("…and ${remaining} more — see ${NOTIF_DIR}")
+fi
+
+message=""
+for line in "${lines[@]}"; do
+  message="${message}${line}"$'\n'
+done
+message="${message%$'\n'}"
+
+# Mark each unseen entry seen via atomic rewrite.
+for f in "${unseen[@]}"; do
+  tmp="${f}.tmp.$$"
+  if jq '.seen = true' "${f}" >"${tmp}" 2>/dev/null; then
+    mv -f "${tmp}" "${f}"
+  else
+    rm -f "${tmp}"
+  fi
+done
+
+jq -nc --arg reason "${message}" '{decision: "block", reason: $reason}'
+
+exit 0

--- a/settings.json
+++ b/settings.json
@@ -138,6 +138,10 @@
           {
             "type": "command",
             "command": "bash ~/.degacore/scripts/hooks/play-sound.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/hooks/stop/01-orch-notify.sh"
           }
         ]
       }

--- a/tests/orch/test_notify_lifecycle.bats
+++ b/tests/orch/test_notify_lifecycle.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+#
+# Tests for hooks/orch-lifecycle/02-agent-notify.sh.
+#
+# The lifecycle hook reads .orchestrator/plans/<slug>/state.json and writes
+# .orchestrator/notifications/<slug>.json on terminal events. This test
+# covers the `ship` path: a fixture state.json with finalReview.prUrl /
+# finalReview.prNumber should produce a notification file containing all
+# documented schema keys.
+
+REPO_ROOT_REAL="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+HOOK="${REPO_ROOT_REAL}/hooks/orch-lifecycle/02-agent-notify.sh"
+
+setup() {
+  TEST_TMP="$(mktemp -d -t orch-notify-lifecycle-XXXXXX)"
+  export TEST_TMP
+
+  SLUG="example-plan"
+  export SLUG
+
+  PLAN_DIR="${TEST_TMP}/.orchestrator/plans/${SLUG}"
+  NOTIF_DIR="${TEST_TMP}/.orchestrator/notifications"
+  mkdir -p "${PLAN_DIR}"
+  export PLAN_DIR
+  export NOTIF_DIR
+
+  cat >"${PLAN_DIR}/state.json" <<'JSON'
+{
+  "slug": "example-plan",
+  "issueNumber": 123,
+  "status": "completed",
+  "finalReview": {
+    "decision": "SHIP",
+    "prUrl": "https://github.com/example/repo/pull/456",
+    "prNumber": 456
+  }
+}
+JSON
+}
+
+teardown() {
+  if [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]]; then
+    rm -rf "${TEST_TMP}"
+  fi
+}
+
+@test "ship event writes notification with all required schema keys" {
+  cd "${TEST_TMP}"
+  run bash "${HOOK}" ship "${SLUG}" --items 4 --passed 4 --elapsed 12m
+  [ "${status}" -eq 0 ]
+
+  NOTIF_FILE="${NOTIF_DIR}/${SLUG}.json"
+  [ -f "${NOTIF_FILE}" ]
+
+  # Required keys present.
+  for key in slug status prUrl prNumber issueNumber summary createdAt seen; do
+    run jq -e --arg k "${key}" 'has($k)' "${NOTIF_FILE}"
+    [ "${status}" -eq 0 ]
+  done
+
+  # Required values match the fixture.
+  run jq -e '.slug == "example-plan"' "${NOTIF_FILE}"
+  [ "${status}" -eq 0 ]
+  run jq -e '.status == "completed"' "${NOTIF_FILE}"
+  [ "${status}" -eq 0 ]
+  run jq -e '.prUrl == "https://github.com/example/repo/pull/456"' "${NOTIF_FILE}"
+  [ "${status}" -eq 0 ]
+  run jq -e '.prNumber == 456' "${NOTIF_FILE}"
+  [ "${status}" -eq 0 ]
+  run jq -e '.issueNumber == 123' "${NOTIF_FILE}"
+  [ "${status}" -eq 0 ]
+  run jq -e '.seen == false' "${NOTIF_FILE}"
+  [ "${status}" -eq 0 ]
+  run jq -e '.summary | type == "string" and length > 0' "${NOTIF_FILE}"
+  [ "${status}" -eq 0 ]
+  run jq -e '.createdAt | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")' "${NOTIF_FILE}"
+  [ "${status}" -eq 0 ]
+}

--- a/tests/orch/test_notify_stop_hook.bats
+++ b/tests/orch/test_notify_stop_hook.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+#
+# Tests for hooks/stop/01-orch-notify.sh.
+#
+# The Stop hook scans ${CLAUDE_PROJECT_DIR}/.orchestrator/notifications/*.json
+# for entries with `seen: false`, emits a Claude Code Stop-hook block JSON
+# ({"decision": "block", "reason": "..."}) on stdout, and marks each entry
+# `seen: true` via atomic rewrite. A second invocation with no unseen
+# entries must be silent (idempotent).
+
+REPO_ROOT_REAL="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+HOOK="${REPO_ROOT_REAL}/hooks/stop/01-orch-notify.sh"
+
+setup() {
+  TEST_TMP="$(mktemp -d -t orch-stop-hook-XXXXXX)"
+  export TEST_TMP
+  export CLAUDE_PROJECT_DIR="${TEST_TMP}"
+
+  NOTIF_DIR="${TEST_TMP}/.orchestrator/notifications"
+  mkdir -p "${NOTIF_DIR}"
+  export NOTIF_DIR
+
+  cat >"${NOTIF_DIR}/example-plan.json" <<'JSON'
+{
+  "slug": "example-plan",
+  "status": "ship",
+  "issueNumber": 123,
+  "prNumber": 456,
+  "prUrl": "https://github.com/example/repo/pull/456",
+  "summary": "All items shipped.",
+  "seen": false
+}
+JSON
+}
+
+teardown() {
+  if [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]]; then
+    rm -rf "${TEST_TMP}"
+  fi
+}
+
+@test "stop hook emits block JSON with non-empty reason and marks entries seen" {
+  run bash "${HOOK}" </dev/null
+  [ "${status}" -eq 0 ]
+  [ -n "${output}" ]
+
+  # stdout must be a JSON object with decision == "block" and a non-empty reason.
+  printf '%s' "${output}" | jq -e '.decision == "block"' >/dev/null
+  printf '%s' "${output}" | jq -e '.reason | type == "string" and length > 0' >/dev/null
+
+  # The notification file must now have seen: true.
+  run jq -e '.seen == true' "${NOTIF_DIR}/example-plan.json"
+  [ "${status}" -eq 0 ]
+}
+
+@test "stop hook is idempotent — second run produces no stdout" {
+  run bash "${HOOK}" </dev/null
+  [ "${status}" -eq 0 ]
+  [ -n "${output}" ]
+
+  run bash "${HOOK}" </dev/null
+  [ "${status}" -eq 0 ]
+  [ -z "${output}" ]
+}
+
+@test "stop hook is a no-op when notifications dir is absent" {
+  rm -rf "${NOTIF_DIR}"
+  run bash "${HOOK}" </dev/null
+  [ "${status}" -eq 0 ]
+  [ -z "${output}" ]
+}


### PR DESCRIPTION
## Summary

Implements the agent-bump notification mechanism from plan #258:

- `hooks/orch-lifecycle/02-agent-notify.sh` writes `.orchestrator/notifications/<slug>.json` on terminal events (ship / verify-fail / revise-bailout)
- `hooks/stop/01-orch-notify.sh` injects unseen notifications into the next agent turn via `{"decision": "block", "reason": "..."}` Stop-hook contract; idempotently marks each entry `seen: true`
- `settings.json` registers the new Stop hook
- `tests/orch/test_notify_lifecycle.bats` + `tests/orch/test_notify_stop_hook.bats` cover schema, JSON output, idempotency, and dir-absent no-op
- `docs/orch-agent-notifications.md` user-facing explanation

## Run notes

Plan #258 ran via orch but every agent review iteration hit the Claude Code rate limit (`out of extra usage · resets 6pm`), so all 6 items were marked failed/REVISE in state.json despite the actual work being committed cleanly on this branch. I verified the artifacts manually after killing the runaway engine — the output below is from local verification, not agent review.

## Test plan

- [x] `shellcheck hooks/orch-lifecycle/02-agent-notify.sh hooks/stop/01-orch-notify.sh` exits 0
- [x] `shfmt -d hooks/orch-lifecycle/02-agent-notify.sh hooks/stop/01-orch-notify.sh` exits 0
- [x] `bats tests/orch/test_notify_lifecycle.bats tests/orch/test_notify_stop_hook.bats` — 4/4 passing
- [x] `test -x` on both new hooks
- [x] `jq -e '.hooks.Stop | map(.hooks[].command) | any(. | contains("01-orch-notify"))' settings.json` — true
- [ ] Manual: trigger a real plan completion with this branch installed; observe Stop hook bumps the agent on next turn

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)