### PR TITLE
feat(canon): rename POLYMARKET_PRIVATE_KEY → WALLET_PRIVATE_KEY

### DIFF
--- a/canon/cli/__tests__/auth.test.ts
+++ b/canon/cli/__tests__/auth.test.ts
@@ -8,24 +8,24 @@ describe("getPrivateKey", () => {
   let originalKey: string | undefined;
 
   beforeEach(() => {
-    originalKey = process.env["POLYMARKET_PRIVATE_KEY"];
+    originalKey = process.env["WALLET_PRIVATE_KEY"];
   });
 
   afterEach(() => {
     if (originalKey === undefined) {
-      delete process.env["POLYMARKET_PRIVATE_KEY"];
+      delete process.env["WALLET_PRIVATE_KEY"];
     } else {
-      process.env["POLYMARKET_PRIVATE_KEY"] = originalKey;
+      process.env["WALLET_PRIVATE_KEY"] = originalKey;
     }
   });
 
   it("returns the key when set", () => {
-    process.env["POLYMARKET_PRIVATE_KEY"] = "0xabc123";
+    process.env["WALLET_PRIVATE_KEY"] = "0xabc123";
     expect(getPrivateKey()).toBe("0xabc123");
   });
 
   it("returns undefined when not set", () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
     expect(getPrivateKey()).toBeUndefined();
   });
 });
@@ -36,7 +36,7 @@ describe("requireAuth", () => {
   let tmpRoot: string;
 
   beforeEach(() => {
-    originalKey = process.env["POLYMARKET_PRIVATE_KEY"];
+    originalKey = process.env["WALLET_PRIVATE_KEY"];
     originalCwd = process.cwd();
     tmpRoot = mkdtempSync(join(tmpdir(), "canon-auth-test-"));
     process.chdir(tmpRoot);
@@ -44,59 +44,59 @@ describe("requireAuth", () => {
 
   afterEach(() => {
     if (originalKey === undefined) {
-      delete process.env["POLYMARKET_PRIVATE_KEY"];
+      delete process.env["WALLET_PRIVATE_KEY"];
     } else {
-      process.env["POLYMARKET_PRIVATE_KEY"] = originalKey;
+      process.env["WALLET_PRIVATE_KEY"] = originalKey;
     }
     process.chdir(originalCwd);
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
   it("returns the key when set", () => {
-    process.env["POLYMARKET_PRIVATE_KEY"] = "0xdef456";
+    process.env["WALLET_PRIVATE_KEY"] = "0xdef456";
     expect(requireAuth("position list")).toBe("0xdef456");
   });
 
   it("throws AuthError when key is missing", () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
     expect(() => requireAuth("position list")).toThrow(AuthError);
   });
 
   it("includes command name in error message", () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
     expect(() => requireAuth("position list")).toThrow(
       /position list/,
     );
   });
 
   it("includes instructions to set the env var", () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
     expect(() => requireAuth("order create")).toThrow(
-      /POLYMARKET_PRIVATE_KEY/,
+      /WALLET_PRIVATE_KEY/,
     );
   });
 
   it("mentions read-only commands work without auth", () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
     expect(() => requireAuth("balance")).toThrow(
       /Read-only commands/,
     );
   });
 
   it("falls back to the project-local wallet store when env is unset", () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
     mkdirSync(join(tmpRoot, ".canon"), { recursive: true });
     const storedKey = "0x" + "c".repeat(64);
     writeFileSync(
       join(tmpRoot, ".canon", "wallet.env"),
-      `POLYMARKET_PRIVATE_KEY=${storedKey}\n`,
+      `WALLET_PRIVATE_KEY=${storedKey}\n`,
       { mode: 0o600 },
     );
     expect(requireAuth("order create")).toBe(storedKey);
   });
 
   it("suggests running 'canon-cli wallet ensure' when no wallet exists", () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
     expect(() => requireAuth("order create")).toThrow(
       /canon-cli wallet ensure/,
     );

--- a/canon/cli/__tests__/balance.test.ts
+++ b/canon/cli/__tests__/balance.test.ts
@@ -35,13 +35,13 @@ beforeEach(() => {
   }) as typeof process.stderr.write;
 
   process.exitCode = undefined;
-  process.env["POLYMARKET_PRIVATE_KEY"] = "0xtest";
+  process.env["WALLET_PRIVATE_KEY"] = "0xtest";
 });
 
 afterEach(() => {
   process.stdout.write = originalStdoutWrite;
   process.stderr.write = originalStderrWrite;
-  delete process.env["POLYMARKET_PRIVATE_KEY"];
+  delete process.env["WALLET_PRIVATE_KEY"];
   vi.clearAllMocks();
 });
 
@@ -123,7 +123,7 @@ describe("balance", () => {
   });
 
   it("requires auth", async () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
 
     await run([]);
 

--- a/canon/cli/__tests__/kill.test.ts
+++ b/canon/cli/__tests__/kill.test.ts
@@ -40,8 +40,8 @@ describe("kill subcommand", () => {
   let originalKey: string | undefined;
 
   beforeEach(() => {
-    originalKey = process.env["POLYMARKET_PRIVATE_KEY"];
-    process.env["POLYMARKET_PRIVATE_KEY"] = "0xtest-key";
+    originalKey = process.env["WALLET_PRIVATE_KEY"];
+    process.env["WALLET_PRIVATE_KEY"] = "0xtest-key";
     mockFetchOpenOrders.mockReset();
     mockCancelAllOrders.mockReset();
     stdoutWrite.mockReset();
@@ -53,9 +53,9 @@ describe("kill subcommand", () => {
 
   afterEach(() => {
     if (originalKey === undefined) {
-      delete process.env["POLYMARKET_PRIVATE_KEY"];
+      delete process.env["WALLET_PRIVATE_KEY"];
     } else {
-      process.env["POLYMARKET_PRIVATE_KEY"] = originalKey;
+      process.env["WALLET_PRIVATE_KEY"] = originalKey;
     }
     vi.restoreAllMocks();
   });
@@ -78,13 +78,13 @@ describe("kill subcommand", () => {
   }
 
   it("requires authentication", async () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
     await runKill([]);
 
     const output = parseStderr() as { ok: boolean; error: string };
     expect(output.ok).toBe(false);
     expect(output.error).toMatch(/requires authentication/);
-    expect(output.error).toMatch(/POLYMARKET_PRIVATE_KEY/);
+    expect(output.error).toMatch(/WALLET_PRIVATE_KEY/);
     expect(mockFetchOpenOrders).not.toHaveBeenCalled();
   });
 
@@ -242,7 +242,7 @@ describe("kill subcommand", () => {
   });
 
   it("includes command name in auth error", async () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
     await runKill([]);
 
     const output = parseStderr() as { ok: boolean; error: string };

--- a/canon/cli/__tests__/onboard.test.ts
+++ b/canon/cli/__tests__/onboard.test.ts
@@ -34,14 +34,14 @@ beforeEach(() => {
     return true;
   }) as typeof process.stderr.write;
   process.exitCode = undefined;
-  process.env["POLYMARKET_PRIVATE_KEY"] = "0xtest";
+  process.env["WALLET_PRIVATE_KEY"] = "0xtest";
   delete process.env["ONBOARD_POL_GAS_RESERVE"];
 });
 
 afterEach(() => {
   process.stdout.write = originalStdoutWrite;
   process.stderr.write = originalStderrWrite;
-  delete process.env["POLYMARKET_PRIVATE_KEY"];
+  delete process.env["WALLET_PRIVATE_KEY"];
   vi.clearAllMocks();
 });
 
@@ -239,7 +239,7 @@ describe("onboard", () => {
   });
 
   it("requires auth", async () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
     await run([]);
     const parsed = JSON.parse(stderrData) as { ok: boolean; error: string };
     expect(parsed.ok).toBe(false);

--- a/canon/cli/__tests__/order.test.ts
+++ b/canon/cli/__tests__/order.test.ts
@@ -40,13 +40,13 @@ beforeEach(() => {
   }) as typeof process.stderr.write;
 
   process.exitCode = undefined;
-  process.env["POLYMARKET_PRIVATE_KEY"] = "0xtest";
+  process.env["WALLET_PRIVATE_KEY"] = "0xtest";
 });
 
 afterEach(() => {
   process.stdout.write = originalStdoutWrite;
   process.stderr.write = originalStderrWrite;
-  delete process.env["POLYMARKET_PRIVATE_KEY"];
+  delete process.env["WALLET_PRIVATE_KEY"];
   vi.clearAllMocks();
 });
 
@@ -229,7 +229,7 @@ describe("order create", () => {
   });
 
   it("requires auth", async () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
 
     await run([
       "create",
@@ -318,7 +318,7 @@ describe("order cancel", () => {
   });
 
   it("requires auth", async () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
 
     await run(["cancel", "ord-1"]);
 
@@ -407,7 +407,7 @@ describe("order trades", () => {
   });
 
   it("requires auth", async () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
 
     await run(["trades"]);
 

--- a/canon/cli/__tests__/position.test.ts
+++ b/canon/cli/__tests__/position.test.ts
@@ -43,13 +43,13 @@ beforeEach(() => {
   }) as typeof process.stderr.write;
 
   process.exitCode = undefined;
-  process.env["POLYMARKET_PRIVATE_KEY"] = "0xtest";
+  process.env["WALLET_PRIVATE_KEY"] = "0xtest";
 });
 
 afterEach(() => {
   process.stdout.write = originalStdoutWrite;
   process.stderr.write = originalStderrWrite;
-  delete process.env["POLYMARKET_PRIVATE_KEY"];
+  delete process.env["WALLET_PRIVATE_KEY"];
   vi.clearAllMocks();
 });
 
@@ -161,7 +161,7 @@ describe("position list", () => {
   });
 
   it("requires auth", async () => {
-    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    delete process.env["WALLET_PRIVATE_KEY"];
 
     await run(["list"]);
 

--- a/canon/cli/__tests__/wallet-store.test.ts
+++ b/canon/cli/__tests__/wallet-store.test.ts
@@ -2,13 +2,17 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtempSync, rmSync, statSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { FileWalletStore } from "../wallet-store.js";
+import {
+  FileWalletStore,
+  _resetLegacyKeyWarningForTests,
+} from "../wallet-store.js";
 
 describe("FileWalletStore", () => {
   let root: string;
 
   beforeEach(() => {
     root = mkdtempSync(join(tmpdir(), "canon-wallet-test-"));
+    _resetLegacyKeyWarningForTests();
   });
 
   afterEach(() => {
@@ -38,12 +42,13 @@ describe("FileWalletStore", () => {
     expect(store.hasWallet()).toBe(true);
   });
 
-  it("persists the key in .canon/wallet.env", async () => {
+  it("persists the key in .canon/wallet.env using the modern key name", async () => {
     const store = new FileWalletStore(root);
     const { address } = await store.ensure();
     const path = join(root, ".canon", "wallet.env");
     const contents = readFileSync(path, "utf8");
-    expect(contents).toMatch(/^POLYMARKET_PRIVATE_KEY=0x[0-9a-fA-F]{64}\n?$/m);
+    expect(contents).toMatch(/^WALLET_PRIVATE_KEY=0x[0-9a-fA-F]{64}\n?$/m);
+    expect(contents).not.toMatch(/^POLYMARKET_PRIVATE_KEY=/m);
     expect(await store.getAddress()).toBe(address);
   });
 
@@ -69,12 +74,12 @@ describe("FileWalletStore", () => {
     expect(store.getPrivateKey()).toMatch(/^0x[0-9a-fA-F]{64}$/);
   });
 
-  it("reads a pre-existing wallet file", async () => {
+  it("reads a modern wallet file (WALLET_PRIVATE_KEY)", async () => {
     mkdirSync(join(root, ".canon"), { recursive: true });
     const key = "0x" + "a".repeat(64);
     writeFileSync(
       join(root, ".canon", "wallet.env"),
-      `POLYMARKET_PRIVATE_KEY=${key}\n`,
+      `WALLET_PRIVATE_KEY=${key}\n`,
       { mode: 0o600 },
     );
     const store = new FileWalletStore(root);
@@ -88,10 +93,58 @@ describe("FileWalletStore", () => {
     const key = "0x" + "b".repeat(64);
     writeFileSync(
       join(root, ".canon", "wallet.env"),
-      `# canon wallet v1\n\nPOLYMARKET_PRIVATE_KEY=${key}\n`,
+      `# canon wallet v1\n\nWALLET_PRIVATE_KEY=${key}\n`,
       { mode: 0o600 },
     );
     const store = new FileWalletStore(root);
     expect(store.getPrivateKey()).toBe(key);
+  });
+
+  // Back-compat: wallets created before #268 used POLYMARKET_PRIVATE_KEY.
+  // The store must still read them, with a one-shot deprecation warning.
+  it("reads a legacy wallet file (POLYMARKET_PRIVATE_KEY) and warns once", async () => {
+    mkdirSync(join(root, ".canon"), { recursive: true });
+    const key = "0x" + "c".repeat(64);
+    writeFileSync(
+      join(root, ".canon", "wallet.env"),
+      `POLYMARKET_PRIVATE_KEY=${key}\n`,
+      { mode: 0o600 },
+    );
+
+    const writes: string[] = [];
+    const realWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      const store = new FileWalletStore(root);
+      expect(store.getPrivateKey()).toBe(key);
+      // Second call must not emit a second warning.
+      expect(store.getPrivateKey()).toBe(key);
+    } finally {
+      process.stderr.write = realWrite;
+    }
+
+    const merged = writes.join("");
+    expect(merged).toMatch(/POLYMARKET_PRIVATE_KEY is deprecated/);
+    const warnings = writes.filter((w) =>
+      w.includes("POLYMARKET_PRIVATE_KEY is deprecated"),
+    );
+    expect(warnings.length).toBeLessThanOrEqual(1);
+  });
+
+  it("prefers the modern key when both are present in wallet.env", () => {
+    mkdirSync(join(root, ".canon"), { recursive: true });
+    const modern = "0x" + "d".repeat(64);
+    const legacy = "0x" + "e".repeat(64);
+    writeFileSync(
+      join(root, ".canon", "wallet.env"),
+      `POLYMARKET_PRIVATE_KEY=${legacy}\nWALLET_PRIVATE_KEY=${modern}\n`,
+      { mode: 0o600 },
+    );
+    const store = new FileWalletStore(root);
+    expect(store.getPrivateKey()).toBe(modern);
   });
 });

--- a/canon/cli/auth.ts
+++ b/canon/cli/auth.ts
@@ -1,14 +1,16 @@
 /**
- * Auth module — resolves the Polymarket private key.
+ * Auth module — resolves the wallet private key.
  *
  * Resolution order:
- *   1. `POLYMARKET_PRIVATE_KEY` env var (preserved for CI / back-compat)
- *   2. Project-local wallet store (`.canon/wallet.env`)
+ *   1. `WALLET_PRIVATE_KEY` env var (legacy `POLYMARKET_PRIVATE_KEY`
+ *      still honoured with a deprecation warning).
+ *   2. Project-local wallet store (`.canon/wallet.env`).
  *
  * Write commands call `requireAuth()` before executing. Read-only
  * commands skip auth entirely.
  */
 
+import { getWalletPrivateKey } from "./env.js";
 import { FileWalletStore, WalletNotFoundError } from "./wallet-store.js";
 
 export class AuthError extends Error {
@@ -20,7 +22,7 @@ export class AuthError extends Error {
 
 /** Synchronous env lookup; returns the raw env var or undefined. */
 export function getPrivateKey(): string | undefined {
-  return process.env["POLYMARKET_PRIVATE_KEY"];
+  return getWalletPrivateKey();
 }
 
 /**
@@ -50,7 +52,7 @@ export function requireAuth(command: string): string {
           "       canon-cli wallet ensure\n" +
           "\n" +
           "  2. Or set the env var (CI / existing wallet):\n" +
-          "       export POLYMARKET_PRIVATE_KEY=<your-private-key>\n" +
+          "       export WALLET_PRIVATE_KEY=<your-private-key>\n" +
           "\n" +
           "Read-only commands (market search, help) work without auth.",
       );

--- a/canon/cli/commands/balance.ts
+++ b/canon/cli/commands/balance.ts
@@ -1,7 +1,7 @@
 /**
  * Balance subcommand — fetch on-chain balances for the EOA on Polygon.
  *
- * Requires POLYMARKET_PRIVATE_KEY.
+ * Requires WALLET_PRIVATE_KEY.
  *
  * Usage:
  *   canon-cli balance [--pretty]

--- a/canon/cli/commands/kill.ts
+++ b/canon/cli/commands/kill.ts
@@ -1,7 +1,7 @@
 /**
  * Kill subcommand — cancel all open orders (kill switch).
  *
- * Requires POLYMARKET_PRIVATE_KEY. Without --yes, performs a dry run
+ * Requires WALLET_PRIVATE_KEY. Without --yes, performs a dry run
  * showing open orders. With --yes, cancels them all.
  *
  * Usage:

--- a/canon/cli/commands/onboard.ts
+++ b/canon/cli/commands/onboard.ts
@@ -2,7 +2,7 @@
  * Onboard subcommand — scan on-chain balances, swap non-USDC.e
  * assets to USDC.e so the user can start trading.
  *
- * Requires POLYMARKET_PRIVATE_KEY.
+ * Requires WALLET_PRIVATE_KEY.
  *
  * Usage:
  *   canon-cli onboard              Show plan (no swaps executed)

--- a/canon/cli/commands/order.ts
+++ b/canon/cli/commands/order.ts
@@ -1,7 +1,7 @@
 /**
  * Order subcommand — create, cancel, and list trades.
  *
- * All operations require POLYMARKET_PRIVATE_KEY.
+ * All operations require WALLET_PRIVATE_KEY.
  *
  * Usage:
  *   canon-cli order create --token-id <id> --side <buy|sell> --size <n> --price <n> [--type <market|limit>] [--market-id <id>]

--- a/canon/cli/commands/position.ts
+++ b/canon/cli/commands/position.ts
@@ -1,7 +1,7 @@
 /**
  * Position subcommand — list positions and calculate PnL.
  *
- * All operations require POLYMARKET_PRIVATE_KEY.
+ * All operations require WALLET_PRIVATE_KEY.
  *
  * Usage:
  *   canon-cli position list [--pretty]

--- a/canon/cli/env.ts
+++ b/canon/cli/env.ts
@@ -1,0 +1,56 @@
+/**
+ * Process-env accessors for canon's wallet variables.
+ *
+ * Canonical names (as of #268) are market-agnostic:
+ *
+ *   WALLET_PRIVATE_KEY    — hex private key for the canon Polygon EOA
+ *   WALLET_PROXY_ADDRESS  — proxy / EOA address (allowance owner)
+ *
+ * Legacy names from earlier releases (`POLYMARKET_PRIVATE_KEY`,
+ * `POLYMARKET_PROXY_ADDRESS`) are still honoured. Reading a legacy
+ * value emits a one-shot stderr warning so callers know to migrate.
+ */
+
+const WALLET_KEY_VARS = {
+  modern: "WALLET_PRIVATE_KEY",
+  legacy: "POLYMARKET_PRIVATE_KEY",
+} as const;
+
+const WALLET_PROXY_VARS = {
+  modern: "WALLET_PROXY_ADDRESS",
+  legacy: "POLYMARKET_PROXY_ADDRESS",
+} as const;
+
+const warned = new Set<string>();
+
+function read(modern: string, legacy: string): string | undefined {
+  const m = process.env[modern];
+  if (m !== undefined && m.length > 0) return m;
+  const l = process.env[legacy];
+  if (l !== undefined && l.length > 0) {
+    if (!warned.has(legacy)) {
+      warned.add(legacy);
+      process.stderr.write(
+        `[canon] env ${legacy} is deprecated; export ${modern} instead ` +
+          `(legacy fallback will be removed in a future release).\n`,
+      );
+    }
+    return l;
+  }
+  return undefined;
+}
+
+/** Return the configured wallet private key, or undefined. */
+export function getWalletPrivateKey(): string | undefined {
+  return read(WALLET_KEY_VARS.modern, WALLET_KEY_VARS.legacy);
+}
+
+/** Return the configured wallet proxy / owner address, or undefined. */
+export function getWalletProxyAddress(): string | undefined {
+  return read(WALLET_PROXY_VARS.modern, WALLET_PROXY_VARS.legacy);
+}
+
+/** Reset the deprecation warning cache (test helper only). */
+export function _resetEnvWarningsForTests(): void {
+  warned.clear();
+}

--- a/canon/cli/wallet-store.ts
+++ b/canon/cli/wallet-store.ts
@@ -38,7 +38,10 @@ export class WalletNotFoundError extends Error {
   }
 }
 
-const KEY_NAME = "POLYMARKET_PRIVATE_KEY";
+/** Canonical line key written to `.canon/wallet.env` for new wallets. */
+const KEY_NAME = "WALLET_PRIVATE_KEY";
+/** Legacy line key kept readable for back-compat with older wallets. */
+const LEGACY_KEY_NAME = "POLYMARKET_PRIVATE_KEY";
 
 /**
  * Project-local wallet store backed by `.canon/wallet.env`.
@@ -84,10 +87,18 @@ export class FileWalletStore implements WalletStore {
     return { address: wallet.address, created: true };
   }
 
-  /** Return the private key from disk, or undefined if not present/parseable. */
+  /**
+   * Return the private key from disk, or undefined if not present/parseable.
+   *
+   * Prefers the canonical `WALLET_PRIVATE_KEY` line. Falls back to the
+   * legacy `POLYMARKET_PRIVATE_KEY` for wallets created before #268,
+   * with a one-shot stderr warning so users know to migrate.
+   */
   private readKey(): string | undefined {
     if (!existsSync(this.path)) return undefined;
     const text = readFileSync(this.path, "utf8");
+    let modern: string | undefined;
+    let legacy: string | undefined;
     for (const raw of text.split("\n")) {
       const line = raw.trim();
       if (!line || line.startsWith("#")) continue;
@@ -95,8 +106,30 @@ export class FileWalletStore implements WalletStore {
       if (eq === -1) continue;
       const name = line.slice(0, eq).trim();
       const value = line.slice(eq + 1).trim();
-      if (name === KEY_NAME && value.length > 0) return value;
+      if (value.length === 0) continue;
+      if (name === KEY_NAME) modern = value;
+      else if (name === LEGACY_KEY_NAME) legacy = value;
+    }
+    if (modern !== undefined) return modern;
+    if (legacy !== undefined) {
+      warnLegacyKeyOnce(this.path);
+      return legacy;
     }
     return undefined;
   }
+}
+
+let legacyKeyWarned = false;
+function warnLegacyKeyOnce(path: string): void {
+  if (legacyKeyWarned) return;
+  legacyKeyWarned = true;
+  process.stderr.write(
+    `[canon] ${path}: ${LEGACY_KEY_NAME} is deprecated; ` +
+      `rename the line to ${KEY_NAME} (back-compat will be dropped in a future release).\n`,
+  );
+}
+
+/** Reset the legacy-key warning latch (test helper only). */
+export function _resetLegacyKeyWarningForTests(): void {
+  legacyKeyWarned = false;
 }

--- a/canon/templates/__tests__/approve-allowances.ts
+++ b/canon/templates/__tests__/approve-allowances.ts
@@ -13,7 +13,7 @@ const NEG_RISK_EXCHANGE = "0xC5d563A36AE78145C45a50134d48A1215220f80a";
 const NEG_RISK_ADAPTER = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296";
 
 const provider = new ethers.providers.StaticJsonRpcProvider("https://polygon.drpc.org", { name: "polygon", chainId: 137 });
-const signer = new ethers.Wallet(process.env["POLYMARKET_PRIVATE_KEY"]!, provider);
+const signer = new ethers.Wallet(process.env["WALLET_PRIVATE_KEY"]!, provider);
 const usdc = new ethers.Contract(
   USDC,
   [

--- a/canon/templates/__tests__/check-balances.ts
+++ b/canon/templates/__tests__/check-balances.ts
@@ -6,7 +6,7 @@ for (const line of env.split("\n")) {
   const m = line.match(/^([A-Z_]+)=(.*)$/);
   if (m && m[1] && !process.env[m[1]]) process.env[m[1]] = m[2];
 }
-const signer = new ethers.Wallet(process.env["POLYMARKET_PRIVATE_KEY"]!);
+const signer = new ethers.Wallet(process.env["WALLET_PRIVATE_KEY"]!);
 const provider = new ethers.providers.StaticJsonRpcProvider("https://polygon.drpc.org", { name: "polygon", chainId: 137 });
 const tokens = {
   "Native USDC (0x3c49)": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",

--- a/canon/templates/__tests__/client-polymarket.test.ts
+++ b/canon/templates/__tests__/client-polymarket.test.ts
@@ -35,7 +35,7 @@ beforeEach(async () => {
   vi.clearAllMocks();
   // Reset the module so the cached singleton is cleared each test
   vi.resetModules();
-  process.env["POLYMARKET_PRIVATE_KEY"] = "0xtest";
+  process.env["WALLET_PRIVATE_KEY"] = "0xtest";
   const mod = await import("../client-polymarket.js");
   fetchMarketPrice = mod.fetchMarketPrice;
   searchMarkets = mod.searchMarkets;
@@ -45,7 +45,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-  delete process.env["POLYMARKET_PRIVATE_KEY"];
+  delete process.env["WALLET_PRIVATE_KEY"];
 });
 
 // ---------------------------------------------------------------------------

--- a/canon/templates/__tests__/integration-auth.test.ts
+++ b/canon/templates/__tests__/integration-auth.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for auth-required Polymarket client methods.
  *
  * These tests hit the real Polymarket mainnet API. They are skipped
- * when POLYMARKET_PRIVATE_KEY is not set (CI-safe).
+ * when WALLET_PRIVATE_KEY is not set (CI-safe).
  *
  * The createOrder+cancelOrder roundtrip uses a $0.01 limit buy at
  * price 0.01 — an extreme price that will never fill. The order is
@@ -21,7 +21,7 @@ import {
 } from "../client-polymarket.js";
 import type { OrderParams } from "../client-polymarket.js";
 
-const HAS_AUTH = Boolean(process.env["POLYMARKET_PRIVATE_KEY"]);
+const HAS_AUTH = Boolean(process.env["WALLET_PRIVATE_KEY"]);
 
 describe.runIf(HAS_AUTH)(
   "integration: auth-required methods",

--- a/canon/templates/__tests__/orders.test.ts
+++ b/canon/templates/__tests__/orders.test.ts
@@ -22,7 +22,7 @@ let buildOrder: typeof BuildOrderFn;
 beforeEach(async () => {
   vi.clearAllMocks();
   vi.resetModules();
-  process.env["POLYMARKET_PRIVATE_KEY"] = "0xtest";
+  process.env["WALLET_PRIVATE_KEY"] = "0xtest";
   const mod = await import("../client-polymarket.js");
   createOrder = mod.createOrder;
   cancelOrder = mod.cancelOrder;
@@ -30,7 +30,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-  delete process.env["POLYMARKET_PRIVATE_KEY"];
+  delete process.env["WALLET_PRIVATE_KEY"];
 });
 
 function validParams(

--- a/canon/templates/__tests__/smoke-auth-init.ts
+++ b/canon/templates/__tests__/smoke-auth-init.ts
@@ -5,7 +5,7 @@ for (const line of env.split("\n")) {
   const m = line.match(/^([A-Z_]+)=(.*)$/);
   if (m && m[1] && !process.env[m[1]]) process.env[m[1]] = m[2];
 }
-console.log("key loaded, length:", process.env["POLYMARKET_PRIVATE_KEY"]?.length);
+console.log("key loaded, length:", process.env["WALLET_PRIVATE_KEY"]?.length);
 
 const { fetchBalance, fetchPositions } = await import("../client-polymarket.js");
 

--- a/canon/templates/__tests__/swap-to-usdce.ts
+++ b/canon/templates/__tests__/swap-to-usdce.ts
@@ -12,7 +12,7 @@ const USDC_E = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
 const ROUTER = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"; // Uniswap SwapRouter02
 
 const provider = new ethers.providers.StaticJsonRpcProvider("https://polygon.drpc.org", { name: "polygon", chainId: 137 });
-const signer = new ethers.Wallet(process.env["POLYMARKET_PRIVATE_KEY"]!, provider);
+const signer = new ethers.Wallet(process.env["WALLET_PRIVATE_KEY"]!, provider);
 
 const erc20 = (addr: string) =>
   new ethers.Contract(

--- a/canon/templates/client-polymarket.ts
+++ b/canon/templates/client-polymarket.ts
@@ -6,6 +6,7 @@
  */
 
 import { Polymarket } from "pmxtjs";
+import { getWalletPrivateKey, getWalletProxyAddress } from "./env.js";
 import {
   callSidecar,
   getSidecarCapabilities,
@@ -143,8 +144,8 @@ let client: Polymarket | undefined;
 
 function getClient(): Polymarket {
   if (!client) {
-    const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
-    const proxyAddress = process.env["POLYMARKET_PROXY_ADDRESS"];
+    const privateKey = getWalletPrivateKey();
+    const proxyAddress = getWalletProxyAddress();
 
     client = new Polymarket({
       ...(privateKey ? { privateKey } : {}),
@@ -269,7 +270,7 @@ export async function fetchOrderBook(tokenId: string): Promise<OrderBook> {
 /**
  * Fetch current positions for the authenticated Polymarket account.
  *
- * Requires `POLYMARKET_PRIVATE_KEY` to be set. Auth errors from
+ * Requires `WALLET_PRIVATE_KEY` to be set. Auth errors from
  * pmxtjs propagate to the caller.
  */
 export async function fetchPositions(): Promise<Position[]> {
@@ -290,7 +291,7 @@ export async function fetchPositions(): Promise<Position[]> {
 /**
  * Fetch account balances for the authenticated Polymarket account.
  *
- * Requires `POLYMARKET_PRIVATE_KEY` to be set. Auth errors from
+ * Requires `WALLET_PRIVATE_KEY` to be set. Auth errors from
  * pmxtjs propagate to the caller.
  */
 export async function fetchBalance(): Promise<AccountBalance[]> {
@@ -311,11 +312,11 @@ export async function fetchBalance(): Promise<AccountBalance[]> {
  * Returns USDC.e (tradeable), native USDC (swap needed), and POL (gas).
  * This is the user-facing balance — what `canon-cli balance` should show.
  *
- * Requires `POLYMARKET_PRIVATE_KEY`. Uses a public Polygon RPC.
+ * Requires `WALLET_PRIVATE_KEY`. Uses a public Polygon RPC.
  */
 export async function fetchOnChainBalances(): Promise<OnChainBalance[]> {
-  const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
-  if (!privateKey) throw new Error("POLYMARKET_PRIVATE_KEY required");
+  const privateKey = getWalletPrivateKey();
+  if (!privateKey) throw new Error("WALLET_PRIVATE_KEY required");
 
   const { ethers } = await import("ethers");
   const rpc = process.env["POLYGON_RPC_URL"] ?? "https://polygon.drpc.org";
@@ -437,8 +438,8 @@ export async function swapToUsdce(
   amountIn: number,
 ): Promise<SwapResult> {
   if (amountIn <= 0) throw new Error(`amountIn must be > 0, got ${amountIn}`);
-  const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
-  if (!privateKey) throw new Error("POLYMARKET_PRIVATE_KEY required");
+  const privateKey = getWalletPrivateKey();
+  if (!privateKey) throw new Error("WALLET_PRIVATE_KEY required");
 
   const route = SWAP_ROUTES[from];
   const slippageBps = Number(process.env["SWAP_SLIPPAGE_BPS"] ?? "50");
@@ -579,7 +580,7 @@ export async function swapToUsdce(
 /**
  * Fetch trade history for the authenticated Polymarket account.
  *
- * Requires `POLYMARKET_PRIVATE_KEY` to be set. Auth errors from
+ * Requires `WALLET_PRIVATE_KEY` to be set. Auth errors from
  * pmxtjs propagate to the caller.
  *
  * @param params - Optional filtering/pagination parameters.
@@ -616,7 +617,7 @@ export async function fetchMyTrades(
 /**
  * Fetch all open orders for the authenticated Polymarket account.
  *
- * Requires `POLYMARKET_PRIVATE_KEY` to be set. Auth errors from
+ * Requires `WALLET_PRIVATE_KEY` to be set. Auth errors from
  * pmxtjs propagate to the caller.
  *
  * @param marketId - Optional market ID to filter orders.
@@ -755,8 +756,8 @@ export async function createOrder(
   params: OrderParams,
 ): Promise<OrderResponse> {
   validateOrderParams(params);
-  const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
-  if (!privateKey) throw new Error("POLYMARKET_PRIVATE_KEY required");
+  const privateKey = getWalletPrivateKey();
+  if (!privateKey) throw new Error("WALLET_PRIVATE_KEY required");
   const order = await callSidecar<{
     id: string;
     marketId: string;
@@ -805,8 +806,8 @@ export async function createOrder(
 export async function cancelOrder(
   orderId: string,
 ): Promise<CancelResult> {
-  const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
-  if (!privateKey) throw new Error("POLYMARKET_PRIVATE_KEY required");
+  const privateKey = getWalletPrivateKey();
+  if (!privateKey) throw new Error("WALLET_PRIVATE_KEY required");
   const order = await callSidecar<{ id?: string; status?: string }>(
     "cancelOrder",
     [orderId],
@@ -829,8 +830,8 @@ export async function buildOrder(
   params: OrderParams,
 ): Promise<BuildOrderResult> {
   validateOrderParams(params);
-  const privateKey = process.env["POLYMARKET_PRIVATE_KEY"];
-  if (!privateKey) throw new Error("POLYMARKET_PRIVATE_KEY required");
+  const privateKey = getWalletPrivateKey();
+  if (!privateKey) throw new Error("WALLET_PRIVATE_KEY required");
   const built = await callSidecar<{
     exchange: string;
     params: {

--- a/canon/templates/env.ts
+++ b/canon/templates/env.ts
@@ -1,0 +1,52 @@
+/**
+ * Process-env accessors for the templates layer.
+ *
+ * Mirrors `canon/cli/env.ts`. The two packages keep separate copies
+ * because canon/templates' tsconfig forbids importing from canon/cli
+ * at compile time. Both helpers must agree on the canonical / legacy
+ * pair — the integration tests in either package will catch drift.
+ */
+
+const WALLET_KEY = {
+  modern: "WALLET_PRIVATE_KEY",
+  legacy: "POLYMARKET_PRIVATE_KEY",
+} as const;
+
+const WALLET_PROXY = {
+  modern: "WALLET_PROXY_ADDRESS",
+  legacy: "POLYMARKET_PROXY_ADDRESS",
+} as const;
+
+const warned = new Set<string>();
+
+function read(modern: string, legacy: string): string | undefined {
+  const m = process.env[modern];
+  if (m !== undefined && m.length > 0) return m;
+  const l = process.env[legacy];
+  if (l !== undefined && l.length > 0) {
+    if (!warned.has(legacy)) {
+      warned.add(legacy);
+      process.stderr.write(
+        `[canon] env ${legacy} is deprecated; export ${modern} instead ` +
+          `(legacy fallback will be removed in a future release).\n`,
+      );
+    }
+    return l;
+  }
+  return undefined;
+}
+
+/** Return the configured wallet private key, or undefined. */
+export function getWalletPrivateKey(): string | undefined {
+  return read(WALLET_KEY.modern, WALLET_KEY.legacy);
+}
+
+/** Return the configured wallet proxy / owner address, or undefined. */
+export function getWalletProxyAddress(): string | undefined {
+  return read(WALLET_PROXY.modern, WALLET_PROXY.legacy);
+}
+
+/** Reset the deprecation warning cache (test helper only). */
+export function _resetEnvWarningsForTests(): void {
+  warned.clear();
+}

--- a/canon/templates/strategies/arb-binary/__tests__/entry.test.ts
+++ b/canon/templates/strategies/arb-binary/__tests__/entry.test.ts
@@ -554,15 +554,15 @@ describe("buildLiveAllowanceClient (WalletStore injection)", () => {
   });
 
   it("derives owner address from wallet.getAddress() (no env vars consulted)", async () => {
-    const prevOwner = process.env["POLYMARKET_PROXY_ADDRESS"];
-    delete process.env["POLYMARKET_PROXY_ADDRESS"];
+    const prevOwner = process.env["WALLET_PROXY_ADDRESS"];
+    delete process.env["WALLET_PROXY_ADDRESS"];
     const wallet = makeFakeWallet({ address: "0xfromwallet" });
     const build = (entry as unknown as { buildLiveAllowanceClient: BuildLiveAllowanceClientFn }).buildLiveAllowanceClient;
     const client = await build(wallet);
     expect(client).toBeDefined();
     expect(wallet.getAddress).toHaveBeenCalledTimes(1);
     if (prevOwner !== undefined) {
-      process.env["POLYMARKET_PROXY_ADDRESS"] = prevOwner;
+      process.env["WALLET_PROXY_ADDRESS"] = prevOwner;
     }
   });
 });


### PR DESCRIPTION
## Summary

Closes #268. Renames the wallet env vars to a market-agnostic shape with a back-compat fallback so existing wallets and CI sessions keep working.

- \`POLYMARKET_PRIVATE_KEY\` → \`WALLET_PRIVATE_KEY\`
- \`POLYMARKET_PROXY_ADDRESS\` → \`WALLET_PROXY_ADDRESS\`

## Behaviour

- New \`canon/cli/env.ts\` and \`canon/templates/env.ts\` prefer the modern name; fall back to the legacy name with a one-shot stderr deprecation warning.
- \`FileWalletStore\` writes \`WALLET_PRIVATE_KEY\` for new wallets and reads either key from existing files. Wallets created on older versions keep working.
- \`canon/cli/__tests__/wallet-store.test.ts\` pins both: a legacy file is still readable (and warns once), and modern wins when both are present.

## Out of scope

- \`poc/pmxt-poc/\` — POC code, untouched.
- Removing the legacy fallback — tracked as a future cleanup once external callers have migrated.

## Test plan

- [x] \`pnpm --dir canon/cli check\` — 136 tests pass
- [x] \`pnpm --dir canon/templates check\` — 438 tests + 7 skipped pass
- [x] \`rg POLYMARKET_PRIVATE_KEY canon/ -g '!node_modules'\` only matches legacy fallback definitions and the back-compat test

🤖 Generated with [Claude Code](https://claude.com/claude-code)