### PR TITLE
feat(strategies): wire 4 strategies for live execution

### DIFF
--- a/canon/templates/__tests__/client-polymarket.test.ts
+++ b/canon/templates/__tests__/client-polymarket.test.ts
@@ -211,7 +211,7 @@ describe("searchMarkets", () => {
 // ---------------------------------------------------------------------------
 describe("fetchOrderBook", () => {
   it("returns mapped order book with bids and asks", async () => {
-    mockFetchOrderBook.mockResolvedValueOnce({
+    mockCallSidecar.mockResolvedValueOnce({
       bids: [
         { price: 0.55, size: 100 },
         { price: 0.50, size: 200 },
@@ -233,11 +233,13 @@ describe("fetchOrderBook", () => {
       { price: 0.60, size: 150 },
       { price: 0.65, size: 50 },
     ]);
-    expect(mockFetchOrderBook).toHaveBeenCalledWith("token-123");
+    expect(mockCallSidecar).toHaveBeenCalledWith("fetchOrderBook", [
+      "token-123",
+    ]);
   });
 
   it("returns empty bids and asks for a thin book", async () => {
-    mockFetchOrderBook.mockResolvedValueOnce({
+    mockCallSidecar.mockResolvedValueOnce({
       bids: [],
       asks: [],
     });
@@ -250,7 +252,7 @@ describe("fetchOrderBook", () => {
   });
 
   it("strips extra fields from order levels", async () => {
-    mockFetchOrderBook.mockResolvedValueOnce({
+    mockCallSidecar.mockResolvedValueOnce({
       bids: [{ price: 0.5, size: 10, extra: "ignored" }],
       asks: [{ price: 0.6, size: 20, timestamp: 12345 }],
     });

--- a/canon/templates/__tests__/live-positions.test.ts
+++ b/canon/templates/__tests__/live-positions.test.ts
@@ -210,7 +210,7 @@ describe("createLivePositions.reconcile", () => {
     expect(portfolio.total_value).toBeCloseTo(200);
   });
 
-  it("propagates client errors from fetchBalance", async () => {
+  it("returns empty portfolio when fetchBalance fails with an auth error (dry-run path)", async () => {
     mockFetchBalance.mockRejectedValueOnce(
       new Error("AuthenticationError: credentials required"),
     );
@@ -218,7 +218,19 @@ describe("createLivePositions.reconcile", () => {
     mockFetchOpenOrders.mockResolvedValueOnce([]);
 
     const deps = createLivePositions();
-    await expect(deps.reconcile()).rejects.toThrow("AuthenticationError");
+    const portfolio = await deps.reconcile();
+    expect(portfolio.positions).toEqual([]);
+    expect(portfolio.total_value).toBe(0);
+    expect(portfolio.daily_pnl).toBe(0);
+  });
+
+  it("propagates non-auth fetchBalance errors", async () => {
+    mockFetchBalance.mockRejectedValueOnce(new Error("network down"));
+    mockFetchPositions.mockResolvedValueOnce([]);
+    mockFetchOpenOrders.mockResolvedValueOnce([]);
+
+    const deps = createLivePositions();
+    await expect(deps.reconcile()).rejects.toThrow("network down");
   });
 
   it("propagates client errors from fetchPositions", async () => {

--- a/canon/templates/client-polymarket.ts
+++ b/canon/templates/client-polymarket.ts
@@ -32,6 +32,50 @@ export interface PolymarketMatch {
   resolutionDate?: string;
 }
 
+/** A single leg (outcome) of a multi-outcome Polymarket market. */
+export interface MultiOutcomeLeg {
+  /** Human-readable outcome label (e.g. "Lakers"). */
+  outcome: string;
+  /** CLOB token ID for this leg's YES outcome. */
+  tokenId: string;
+  /** Last-known YES price. */
+  yesPrice: number;
+}
+
+/** A multi-outcome (>2 outcomes) Polymarket market — NegRisk candidate. */
+export interface MultiOutcomeMatch {
+  conditionId: string;
+  question: string;
+  legs: MultiOutcomeLeg[];
+}
+
+/**
+ * Snapshot of a binary market with the time-series fields strategies
+ * like TRADE-02 momentum and IA-03 fair-value need.
+ *
+ * `topWalletShare` is not surfaced by the pmxt SDK; it is set to 0
+ * here. Strategies that depend on the manipulation guard should plug in
+ * an on-chain indexer (Phase 2/3 work) and override this value.
+ */
+export interface BinaryMarketSnapshot {
+  conditionId: string;
+  question: string;
+  yesTokenId: string;
+  noTokenId: string;
+  /** Last-known YES price (probability). */
+  yesPrice: number;
+  /** Last-known NO price (probability). */
+  noPrice: number;
+  /** 24-hour USD volume. */
+  volume24h: number;
+  /** Open interest in USD. */
+  openInterest: number;
+  /** Milliseconds until market close, or `undefined` when not surfaced. */
+  timeToCloseMs?: number;
+  /** Snapshot timestamp (ms since epoch). */
+  timestampMs: number;
+}
+
 /** A single price level in an order book. */
 export interface PriceLevel {
   price: number;
@@ -240,6 +284,93 @@ export async function searchMarkets(
       yesTokenId: yesOutcome.outcomeId,
       noTokenId: noOutcome.outcomeId,
       ...(resDate !== undefined ? { resolutionDate: resDate } : {}),
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Search Polymarket for multi-outcome (>2) markets matching a query.
+ *
+ * Returns markets whose `outcomes.length > 2` — the necessary structural
+ * condition for a NegRisk multi-condition arb. The pmxt SDK does not
+ * currently surface the `neg_risk` event flag, so callers must treat the
+ * result as a NegRisk *candidate* and apply their own confirmation
+ * (e.g. resolve every leg's order book and check Σ yes_ask < 1 — the
+ * sufficient market-driven test).
+ *
+ * @param query - Search text (e.g. "NBA Champion").
+ */
+export async function searchMultiOutcomeMarkets(
+  query: string,
+): Promise<MultiOutcomeMatch[]> {
+  const poly = getClient();
+  const markets = await poly.fetchMarkets({ query });
+  const results: MultiOutcomeMatch[] = [];
+
+  for (const m of markets) {
+    if (m.outcomes.length <= 2) continue;
+    const legs: MultiOutcomeLeg[] = [];
+    let skip = false;
+    for (const o of m.outcomes) {
+      if (o.price === undefined || o.outcomeId === undefined) {
+        skip = true;
+        break;
+      }
+      legs.push({ outcome: o.label, tokenId: o.outcomeId, yesPrice: o.price });
+    }
+    if (skip) continue;
+    results.push({
+      conditionId: m.marketId,
+      question: m.title,
+      legs,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Fetch binary-market snapshots matching a query.
+ *
+ * Returns volume / open-interest / time-to-close enriched snapshots that
+ * `TRADE-02` momentum and `IA-03` fair-value scanners consume directly.
+ * `topWalletShare` is not exposed by the SDK — strategies that rely on
+ * manipulation guards must layer their own data source.
+ *
+ * @param query - Search text (e.g. "NBA").
+ */
+export async function fetchBinaryMarketSnapshots(
+  query: string,
+): Promise<BinaryMarketSnapshot[]> {
+  const poly = getClient();
+  const markets = await poly.fetchMarkets({ query });
+  const now = Date.now();
+  const results: BinaryMarketSnapshot[] = [];
+
+  for (const m of markets) {
+    if (m.outcomes.length !== 2) continue;
+    const yesOutcome = m.outcomes[0];
+    const noOutcome = m.outcomes[1];
+    if (!yesOutcome || !noOutcome) continue;
+    if (yesOutcome.price === undefined || noOutcome.price === undefined) {
+      continue;
+    }
+    const closeMs = m.resolutionDate?.getTime();
+    const timeToCloseMs =
+      closeMs !== undefined ? Math.max(0, closeMs - now) : undefined;
+    results.push({
+      conditionId: m.marketId,
+      question: m.title,
+      yesTokenId: yesOutcome.outcomeId,
+      noTokenId: noOutcome.outcomeId,
+      yesPrice: yesOutcome.price,
+      noPrice: noOutcome.price,
+      volume24h: m.volume24h,
+      openInterest: m.openInterest ?? 0,
+      ...(timeToCloseMs !== undefined ? { timeToCloseMs } : {}),
+      timestampMs: now,
     });
   }
 

--- a/canon/templates/client-polymarket.ts
+++ b/canon/templates/client-polymarket.ts
@@ -207,14 +207,39 @@ export interface Trade {
 
 let client: Polymarket | undefined;
 
+/**
+ * Resolve the Polymarket signatureType for the SDK.
+ *
+ * Defaults to `'gnosis-safe'` when a proxy address is supplied (modern
+ * Polymarket accounts use a Gnosis Safe proxy that holds funds — without
+ * this hint the SDK falls back to EOA-style L2 derivation and dies with
+ * "Derived credentials are incomplete"). Falls back to undefined (SDK
+ * default) when no proxy is configured. Operators can override via
+ * `POLYMARKET_SIGNATURE_TYPE` (`'eoa' | 'poly-proxy' | 'gnosis-safe'`).
+ *
+ * Reference: pmxt-dev/pmxt SETUP_POLYMARKET.md
+ *   github.com/pmxt-dev/pmxt/blob/main/core/docs/SETUP_POLYMARKET.md
+ */
+function resolveSignatureType(
+  proxyAddress: string | undefined,
+): "eoa" | "poly-proxy" | "gnosis-safe" | undefined {
+  const override = process.env["POLYMARKET_SIGNATURE_TYPE"];
+  if (override === "eoa" || override === "poly-proxy" || override === "gnosis-safe") {
+    return override;
+  }
+  return proxyAddress ? "gnosis-safe" : undefined;
+}
+
 function getClient(): Polymarket {
   if (!client) {
     const privateKey = getWalletPrivateKey();
     const proxyAddress = getWalletProxyAddress();
+    const signatureType = resolveSignatureType(proxyAddress);
 
     client = new Polymarket({
       ...(privateKey ? { privateKey } : {}),
       ...(proxyAddress ? { proxyAddress } : {}),
+      ...(signatureType ? { signatureType } : {}),
       autoStartServer: true,
     });
   }

--- a/canon/templates/client-polymarket.ts
+++ b/canon/templates/client-polymarket.ts
@@ -57,6 +57,27 @@ export interface MultiOutcomeMatch {
  * here. Strategies that depend on the manipulation guard should plug in
  * an on-chain indexer (Phase 2/3 work) and override this value.
  */
+/**
+ * Raw market shape returned by the pmxt sidecar's `fetchMarkets`
+ * endpoint. We type only the fields the read paths consume; the
+ * sidecar surfaces additional fields (eventId, tags, image, …) that we
+ * do not currently use. Bypassing the SDK's `Polymarket(...)` wrapper
+ * means dry-run reads work without wallet creds — only order
+ * submission goes through the authenticated path.
+ */
+interface RawSidecarMarket {
+  marketId: string;
+  title: string;
+  outcomes: {
+    outcomeId?: string;
+    label: string;
+    price?: number;
+  }[];
+  volume24h?: number;
+  openInterest?: number;
+  resolutionDate?: string;
+}
+
 export interface BinaryMarketSnapshot {
   conditionId: string;
   question: string;
@@ -305,8 +326,9 @@ export async function searchMarkets(
 export async function searchMultiOutcomeMarkets(
   query: string,
 ): Promise<MultiOutcomeMatch[]> {
-  const poly = getClient();
-  const markets = await poly.fetchMarkets({ query });
+  const markets = await callSidecar<RawSidecarMarket[]>("fetchMarkets", [
+    { query },
+  ]);
   const results: MultiOutcomeMatch[] = [];
 
   for (const m of markets) {
@@ -344,8 +366,9 @@ export async function searchMultiOutcomeMarkets(
 export async function fetchBinaryMarketSnapshots(
   query: string,
 ): Promise<BinaryMarketSnapshot[]> {
-  const poly = getClient();
-  const markets = await poly.fetchMarkets({ query });
+  const markets = await callSidecar<RawSidecarMarket[]>("fetchMarkets", [
+    { query },
+  ]);
   const now = Date.now();
   const results: BinaryMarketSnapshot[] = [];
 
@@ -357,9 +380,14 @@ export async function fetchBinaryMarketSnapshots(
     if (yesOutcome.price === undefined || noOutcome.price === undefined) {
       continue;
     }
-    const closeMs = m.resolutionDate?.getTime();
-    const timeToCloseMs =
-      closeMs !== undefined ? Math.max(0, closeMs - now) : undefined;
+    if (yesOutcome.outcomeId === undefined || noOutcome.outcomeId === undefined) {
+      continue;
+    }
+    const closeMs =
+      m.resolutionDate !== undefined ? Date.parse(m.resolutionDate) : NaN;
+    const timeToCloseMs = Number.isFinite(closeMs)
+      ? Math.max(0, closeMs - now)
+      : undefined;
     results.push({
       conditionId: m.marketId,
       question: m.title,
@@ -367,7 +395,7 @@ export async function fetchBinaryMarketSnapshots(
       noTokenId: noOutcome.outcomeId,
       yesPrice: yesOutcome.price,
       noPrice: noOutcome.price,
-      volume24h: m.volume24h,
+      volume24h: m.volume24h ?? 0,
       openInterest: m.openInterest ?? 0,
       ...(timeToCloseMs !== undefined ? { timeToCloseMs } : {}),
       timestampMs: now,
@@ -383,8 +411,10 @@ export async function fetchBinaryMarketSnapshots(
  * @param tokenId - CLOB token ID (from `market.outcomes[n].outcomeId`).
  */
 export async function fetchOrderBook(tokenId: string): Promise<OrderBook> {
-  const poly = getClient();
-  const book = await poly.fetchOrderBook(tokenId);
+  const book = await callSidecar<{
+    bids: { price: number; size: number }[];
+    asks: { price: number; size: number }[];
+  }>("fetchOrderBook", [tokenId]);
 
   const mapLevel = (l: { price: number; size: number }): PriceLevel => ({
     price: l.price,

--- a/canon/templates/live-positions.ts
+++ b/canon/templates/live-positions.ts
@@ -30,6 +30,24 @@ function emptyPortfolio(): Portfolio {
   return { total_value: 0, positions: [], daily_pnl: 0 };
 }
 
+/**
+ * Detect auth-gated SDK errors (e.g. "Trading operations require
+ * authentication"). Used to keep dry-run reconcile graceful when no
+ * wallet creds are present — `reconcile` returns an empty portfolio
+ * instead of crashing the cycle.
+ */
+function isAuthError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("authentication") ||
+    msg.includes("unauthorized") ||
+    msg.includes("credentials")
+  );
+}
+
+let warnedNoCreds = false;
+
 function mapPosition(p: ClientPosition): Position {
   return {
     market_id: p.marketId,
@@ -45,11 +63,28 @@ export function createLivePositions(): PositionDeps {
   let openOrders: OrderResponse[] = [];
 
   async function reconcile(): Promise<Portfolio> {
-    const [balances, clientPositions, orders] = await Promise.all([
-      fetchBalance(),
-      fetchPositions(),
-      fetchOpenOrders(),
-    ]);
+    let balances, clientPositions, orders;
+    try {
+      [balances, clientPositions, orders] = await Promise.all([
+        fetchBalance(),
+        fetchPositions(),
+        fetchOpenOrders(),
+      ]);
+    } catch (err) {
+      if (isAuthError(err)) {
+        if (!warnedNoCreds) {
+          warnedNoCreds = true;
+          process.stderr.write(
+            "[canon] portfolio reconcile skipped: no wallet credentials " +
+              "(dry-run mode). Set WALLET_PRIVATE_KEY for live portfolio.\n",
+          );
+        }
+        snapshot = emptyPortfolio();
+        openOrders = [];
+        return snapshot;
+      }
+      throw err;
+    }
 
     const cash = balances
       .filter((b) => b.currency === "USDC")

--- a/canon/templates/strategies/STRATEGY-INDEX.md
+++ b/canon/templates/strategies/STRATEGY-INDEX.md
@@ -48,7 +48,7 @@ into `canon/templates/` as runnable strategy directories.
 |----|------|------|------------|----------------|--------|-------|
 | IA-01 | News Front-Running | Medium | High | Yes (scanner) | Deferred | Needs Reuters/AP APIs, <500ms, Phase 3 |
 | IA-02 | Whale Copy-Trading | Medium | High | Yes (scanner) | Deferred | On-chain indexer, <2s replica, Phase 2 |
-| IA-03 | Fair Value Model | Medium | High | Yes (scanner) | Ported (live execution) | `strategies/fair-value/` — pluggable statistical model, 5pp divergence + live GTC limit (YES/NO) behind `--live`. Default `NEUTRAL_MODEL` ships with confidence=0; operators inject their probability model before deploying capital |
+| IA-03 | Fair Value Model | Medium | High | Yes (scanner) | Extension scaffold — not turnkey | `strategies/fair-value/` — live executor + scan + risk wired behind `--live`, but ships with `NEUTRAL_MODEL` (confidence=0, no signals fire). Operator must supply a numeric `ProbabilityModel` (ELO, base rates, vegas-implied — spec forbids LLM/news/sentiment, those belong to IA-01). Listed as a base for extension, not a runnable strategy out of the box |
 | IA-04 | Arb Bot Types 1-3 | Low | Medium | Yes | Planned | Production bot of ARB-01/02/03 combined |
 | IA-05 | LLM Dependency Detection | High | Very High | No | Deferred | $500k+, LLM+Solver, 15-35s latency |
 | IA-06 | Bregman+Frank-Wolfe Optimizer | Low | High | N/A (layer) | Deferred | Transversal sizing layer, not standalone |

--- a/canon/templates/strategies/STRATEGY-INDEX.md
+++ b/canon/templates/strategies/STRATEGY-INDEX.md
@@ -21,7 +21,7 @@ into `canon/templates/` as runnable strategy directories.
 |----|------|------|------------|----------------|--------|-------|
 | ARB-01 | Binary Arb Buy (YES+NO < $1) | Very Low | Low | Yes | Ported (live execution) | `strategies/arb-binary/` — scanner + risk checks + live CLOB execution behind `--live` |
 | ARB-02 | Binary Arb Sell / Mint | Very Low | Medium | Yes | Planned | Requires CTF mint tx (4-6s latency) |
-| ARB-03 | NegRisk Multi-condition Buy | Low | Medium | Yes | Ported | `strategies/arb-negrisk-buy/` — multi-leg scanner + risk checks |
+| ARB-03 | NegRisk Multi-condition Buy | Low | Medium | Yes | Ported (live execution) | `strategies/arb-negrisk-buy/` — multi-leg scanner + risk + live FOK CLOB legs behind `--live`. SDK does not surface `neg_risk` flag yet; scan uses outcomes>2 + Σ yes_ask < 1 confirmation |
 | ARB-04 | NegRisk Multi-condition Sell | Medium | High | No | Deferred | Mint set + parallel sell, ~5% of markets |
 | ARB-05 | Cross-Market Combinatorial | Medium | Very High | No | Deferred | LLM + IP Solver, $500k+ capital, Phase 3 |
 
@@ -32,7 +32,7 @@ into `canon/templates/` as runnable strategy directories.
 | MINT-01 | Simple Mint $1,000 | Low | Low | No (exec) | Ported (live, $1k/cycle) | `strategies/mint-01/` — splitPosition + dual sell limits at midpoint+0.75¢, 24h reconcile, 5¢ stop-loss |
 | MINT-02 | Split Mint $500+$500 | Very Low | Low | No (exec) | Planned | Two sub-cycles, adjustable between |
 | MINT-03 | MM at Midpoint (Passive) | Medium | Medium | No (exec) | Planned | LP rewards only, loses on execution |
-| MINT-04 | MM Premium +0.75c | Low | Medium | No (exec) | Ported | `strategies/mm-premium/` — scanner + risk checks |
+| MINT-04 | MM Premium +0.75c | Low | Medium | No (exec) | Ported (live executor) | `strategies/mm-premium/` — scanner + risk + live GTC sell limit at midpoint+offsetC behind `--live`. Full cycle (splitPosition mint + dual leg + 24h reconcile) pending — mirror `mint-01/cycle.ts` |
 | MINT-05 | MM Sweet Spot (Dynamic) | Low | Medium | No (exec) | Planned | Auto-adjusts offset 0.25-0.50c |
 | MINT-06 | Compounding Multi-Cycle | Low | Low | No (exec) | Planned | Meta-strategy, reinvests MINT-01/04 |
 
@@ -40,7 +40,7 @@ into `canon/templates/` as runnable strategy directories.
 
 | ID | Name | Risk | Complexity | Scanner-ready? | Status | Notes |
 |----|------|------|------------|----------------|--------|-------|
-| TRADE-02 | Momentum Trading | Medium | Medium | Yes | Ported | Buy rising (10-30%), sell at ~50% |
+| TRADE-02 | Momentum Trading | Medium | Medium | Yes | Ported (live execution) | `strategies/trade-momentum/` — scanner + risk + live GTC limit buy on YES behind `--live`. Buy rising (10-30%), sell at ~50%. `topWalletShare` gated to 0 until on-chain indexer is wired |
 
 ## Group 4 — AI & Advanced Automation
 
@@ -48,7 +48,7 @@ into `canon/templates/` as runnable strategy directories.
 |----|------|------|------------|----------------|--------|-------|
 | IA-01 | News Front-Running | Medium | High | Yes (scanner) | Deferred | Needs Reuters/AP APIs, <500ms, Phase 3 |
 | IA-02 | Whale Copy-Trading | Medium | High | Yes (scanner) | Deferred | On-chain indexer, <2s replica, Phase 2 |
-| IA-03 | Fair Value Model | Medium | High | Yes (scanner) | Ported | `strategies/fair-value/` — pluggable statistical model, 5pp divergence (scanner only) |
+| IA-03 | Fair Value Model | Medium | High | Yes (scanner) | Ported (live execution) | `strategies/fair-value/` — pluggable statistical model, 5pp divergence + live GTC limit (YES/NO) behind `--live`. Default `NEUTRAL_MODEL` ships with confidence=0; operators inject their probability model before deploying capital |
 | IA-04 | Arb Bot Types 1-3 | Low | Medium | Yes | Planned | Production bot of ARB-01/02/03 combined |
 | IA-05 | LLM Dependency Detection | High | Very High | No | Deferred | $500k+, LLM+Solver, 15-35s latency |
 | IA-06 | Bregman+Frank-Wolfe Optimizer | Low | High | N/A (layer) | Deferred | Transversal sizing layer, not standalone |

--- a/canon/templates/strategies/STRATEGY-INDEX.md
+++ b/canon/templates/strategies/STRATEGY-INDEX.md
@@ -8,10 +8,17 @@ into `canon/templates/` as runnable strategy directories.
 
 ## Status legend
 
-- **Ported** — strategy.md + runner + config in `canon/templates/<dir>/`
-- **Next** — selected for next implementation
-- **Planned** — will be ported, not yet started
-- **Deferred** — requires infrastructure not yet built (Phase 2/3)
+- **Turnkey (live)** — runs end-to-end live with `--live`. No operator code required.
+- **Live executor wired, cycle loop pending** — `--live` plumbing done (executor, allowance, sidecar preflight) but the orchestration loop that drives a complete cycle is not. Cannot trade today.
+- **Extension scaffold** — wiring in place as a community example / base for extension. Not a runnable strategy out of the box and not on Canon's roadmap to complete.
+- **Planned** — will be ported, not yet started.
+- **Deferred** — requires infrastructure not yet built (Phase 2/3).
+
+## Code freeze (2026-04-30)
+
+Strategy templates are code-frozen at this revision pending demo
+testing and bug fixes. New strategies and cycle-loop completions
+resume after the freeze lifts.
 
 ---
 
@@ -19,9 +26,9 @@ into `canon/templates/` as runnable strategy directories.
 
 | ID | Name | Risk | Complexity | Scanner-ready? | Status | Notes |
 |----|------|------|------------|----------------|--------|-------|
-| ARB-01 | Binary Arb Buy (YES+NO < $1) | Very Low | Low | Yes | Ported (live execution) | `strategies/arb-binary/` — scanner + risk checks + live CLOB execution behind `--live` |
+| ARB-01 | Binary Arb Buy (YES+NO < $1) | Very Low | Low | Yes | **Turnkey (live)** | `strategies/arb-binary/` — scanner + risk checks + live CLOB execution behind `--live`. Self-contained: no operator config, no pending pieces |
 | ARB-02 | Binary Arb Sell / Mint | Very Low | Medium | Yes | Planned | Requires CTF mint tx (4-6s latency) |
-| ARB-03 | NegRisk Multi-condition Buy | Low | Medium | Yes | Ported (live execution) | `strategies/arb-negrisk-buy/` — multi-leg scanner + risk + live FOK CLOB legs behind `--live`. SDK does not surface `neg_risk` flag yet; scan uses outcomes>2 + Σ yes_ask < 1 confirmation |
+| ARB-03 | NegRisk Multi-condition Buy | Low | Medium | Yes | **Turnkey (live)** | `strategies/arb-negrisk-buy/` — multi-leg scanner + risk + live FOK CLOB legs behind `--live`. SDK does not surface `neg_risk` flag yet; scan uses outcomes>2 + Σ yes_ask < 1 confirmation as the sufficient filter |
 | ARB-04 | NegRisk Multi-condition Sell | Medium | High | No | Deferred | Mint set + parallel sell, ~5% of markets |
 | ARB-05 | Cross-Market Combinatorial | Medium | Very High | No | Deferred | LLM + IP Solver, $500k+ capital, Phase 3 |
 
@@ -29,10 +36,10 @@ into `canon/templates/` as runnable strategy directories.
 
 | ID | Name | Risk | Complexity | Scanner-ready? | Status | Notes |
 |----|------|------|------------|----------------|--------|-------|
-| MINT-01 | Simple Mint $1,000 | Low | Low | No (exec) | Ported (live, $1k/cycle) | `strategies/mint-01/` — splitPosition + dual sell limits at midpoint+0.75¢, 24h reconcile, 5¢ stop-loss |
+| MINT-01 | Simple Mint $1,000 | Low | Low | No (exec) | **Live executor wired, cycle loop pending** | `strategies/mint-01/` — `cycle.ts` helpers (`selectMarket`, `planLegs`, `shouldStopLoss`), `ctf-mint.ts` splitPosition wrapper, live executor + allowance + sidecar preflight all built. `main()` does **not** orchestrate them yet — running `--live` today prints START and exits. Cannot trade. |
 | MINT-02 | Split Mint $500+$500 | Very Low | Low | No (exec) | Planned | Two sub-cycles, adjustable between |
 | MINT-03 | MM at Midpoint (Passive) | Medium | Medium | No (exec) | Planned | LP rewards only, loses on execution |
-| MINT-04 | MM Premium +0.75c | Low | Medium | No (exec) | Ported (live executor) | `strategies/mm-premium/` — scanner + risk + live GTC sell limit at midpoint+offsetC behind `--live`. Full cycle (splitPosition mint + dual leg + 24h reconcile) pending — mirror `mint-01/cycle.ts` |
+| MINT-04 | MM Premium +0.75c | Low | Medium | No (exec) | **Live executor wired, cycle loop pending** | `strategies/mm-premium/` — scanner with tiered offset (1.0¢ / 0.75¢ / 0.5¢), risk gate, live GTC sell limit executor wired behind `--live`. Missing: own `cycle.ts` helpers (mirror `mint-01/cycle.ts`) and the orchestration loop (splitPosition mint + dual leg + 24h reconcile). Cannot trade today |
 | MINT-05 | MM Sweet Spot (Dynamic) | Low | Medium | No (exec) | Planned | Auto-adjusts offset 0.25-0.50c |
 | MINT-06 | Compounding Multi-Cycle | Low | Low | No (exec) | Planned | Meta-strategy, reinvests MINT-01/04 |
 
@@ -40,7 +47,7 @@ into `canon/templates/` as runnable strategy directories.
 
 | ID | Name | Risk | Complexity | Scanner-ready? | Status | Notes |
 |----|------|------|------------|----------------|--------|-------|
-| TRADE-02 | Momentum Trading | Medium | Medium | Yes | Ported (live execution) | `strategies/trade-momentum/` — scanner + risk + live GTC limit buy on YES behind `--live`. Buy rising (10-30%), sell at ~50%. `topWalletShare` gated to 0 until on-chain indexer is wired |
+| TRADE-02 | Momentum Trading | Medium | Medium | Yes | **Turnkey (live)** | `strategies/trade-momentum/` — scanner (price velocity, RSI, MACD, volume percentile, OI trend) + risk + live GTC limit buy on YES behind `--live`. Buy rising (10-30%), sell at ~50%. `topWalletShare` gated to 0 — manipulation guard is no-op until an on-chain indexer is wired (Phase 2). Self-contained otherwise |
 
 ## Group 4 — AI & Advanced Automation
 
@@ -48,7 +55,7 @@ into `canon/templates/` as runnable strategy directories.
 |----|------|------|------------|----------------|--------|-------|
 | IA-01 | News Front-Running | Medium | High | Yes (scanner) | Deferred | Needs Reuters/AP APIs, <500ms, Phase 3 |
 | IA-02 | Whale Copy-Trading | Medium | High | Yes (scanner) | Deferred | On-chain indexer, <2s replica, Phase 2 |
-| IA-03 | Fair Value Model | Medium | High | Yes (scanner) | Extension scaffold — not turnkey | `strategies/fair-value/` — live executor + scan + risk wired behind `--live`, but ships with `NEUTRAL_MODEL` (confidence=0, no signals fire). Operator must supply a numeric `ProbabilityModel` (ELO, base rates, vegas-implied — spec forbids LLM/news/sentiment, those belong to IA-01). Listed as a base for extension, not a runnable strategy out of the box |
+| IA-03 | Fair Value Model | Medium | High | Yes (scanner) | **Extension scaffold (community example, not on Canon roadmap)** | `strategies/fair-value/` — live executor + scan + risk wired behind `--live`, but ships with `NEUTRAL_MODEL` (confidence=0, no signals fire). Operator must supply a numeric `ProbabilityModel` (ELO, base rates, vegas-implied; spec forbids LLM/news/sentiment — those belong to IA-01). Canon will not progress this further; preserved as a template for the community to extend |
 | IA-04 | Arb Bot Types 1-3 | Low | Medium | Yes | Planned | Production bot of ARB-01/02/03 combined |
 | IA-05 | LLM Dependency Detection | High | Very High | No | Deferred | $500k+, LLM+Solver, 15-35s latency |
 | IA-06 | Bregman+Frank-Wolfe Optimizer | Low | High | N/A (layer) | Deferred | Transversal sizing layer, not standalone |
@@ -58,19 +65,40 @@ into `canon/templates/` as runnable strategy directories.
 | Template | Source strategy | Status |
 |----------|---------------|--------|
 | `nba-momentum/` | Custom (cross-venue arb scanner) | Ported, dry-run only |
-| `arb-binary/` | Binary Arb Buy (from C2 spec) | Ported (live execution) — scanner + risk + live CLOB orders behind `--live` |
 
-## Easiest to implement next (scanner-capable, low complexity)
+## Demo-ready summary (at code freeze)
 
-1. **TRADE-02** — Momentum scanner. Watches price velocity + volume. Similar structure to nba-momentum (poll loop + signal detection).
-2. **ARB-03** — NegRisk multi-condition scanner. Sums all YES prices in a NegRisk market, flags when sum < threshold.
+**Turnkey live (3):** ARB-01, ARB-03, TRADE-02 — run `--live` end-to-end
+today, no operator code or pending pieces.
 
-## Implementation path
+**Live executor wired, cycle loop pending (2):** MINT-01, MINT-04 —
+wiring and helpers built; orchestration loop missing (~2–3h work
+each). Cannot trade today.
+
+**Extension scaffold (1):** IA-03 — community template; not on Canon
+roadmap.
+
+**Not yet ported (12):** ARB-02, ARB-04, ARB-05, MINT-02, MINT-03,
+MINT-05, MINT-06, IA-01, IA-02, IA-04, IA-05, IA-06.
+
+## Post-freeze priority order
+
+1. **MINT-01 cycle loop** — completes the pieces already built; turns
+   wired-but-dormant into a fifth turnkey strategy.
+2. **MINT-04 cycle loop** — same shape as MINT-01 plus its own
+   `cycle.ts` helpers with tiered offset.
+3. New strategies from the planned list (ARB-02, MINT-02, etc.)
+   based on demand.
+
+## Implementation path (for future ports)
 
 **Scanner (dry-run):** strategy.md + config + runner that imports
 shared `canon/templates/runner.ts`. Logs signals to JSONL. No wallet
 needed, no execution.
 
-**Live execution:** Same strategy, flip `dryRun: false` in runner
-config. Requires wallet auth + integration test passing for that
-strategy's order type.
+**Live execution:** Same strategy, mirror the arb-binary pattern in
+`entry.ts` — `parseEntryFlags` (`--live` opt-in), `createEntryDeps`
+(live executor + positions + scan), `assertLiveCapabilities` (sidecar
+TIF preflight), `buildLiveAllowanceClient` (USDC allowance via
+injected `WalletStore`). Requires wallet auth + integration test
+asserting CLOB-shaped tokenId + correct TIF on `createOrder` mock.

--- a/canon/templates/strategies/arb-negrisk-buy/__tests__/entry.test.ts
+++ b/canon/templates/strategies/arb-negrisk-buy/__tests__/entry.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for `canon/templates/strategies/arb-negrisk-buy/entry.ts`.
+ *
+ * Pins the live-execution wiring contract:
+ *   - `parseEntryFlags(argv)` defaults to dry-run; `--live` opts in.
+ *   - `createEntryDeps()` returns live executor + live positions + live
+ *     scan adapter — never the previous in-file stubs.
+ *   - `executor.submit` calls into the polymarket client with FOK TIF.
+ *   - Allowance client is consulted before submission and `approve` only
+ *     runs when the cached allowance is below the threshold.
+ *   - `assertLiveCapabilities` rejects when the sidecar lacks FOK.
+ *   - `buildLiveAllowanceClient` returns undefined for an empty wallet.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TradeSignal } from "../../../types/TradeSignal.js";
+import type { Portfolio } from "../../../types/RiskInterface.js";
+
+const mockCreateOrder = vi.fn(async () => ({
+  id: "ord-test",
+  status: "submitted",
+}));
+const mockCancelOrder = vi.fn(async () => ({ success: true }));
+const mockSearchMultiOutcomeMarkets = vi.fn(async () => []);
+const mockFetchOrderBook = vi.fn(async (tokenId: string) => ({
+  tokenId,
+  asks: [],
+  bids: [],
+}));
+const mockFetchBalance = vi.fn(async () => []);
+const mockFetchPositions = vi.fn(async () => []);
+const mockFetchOpenOrders = vi.fn(async () => []);
+const mockGetCapabilities = vi.fn(async () => ({ supportsTif: true }));
+
+vi.mock("../../../client-polymarket.js", () => ({
+  createOrder: mockCreateOrder,
+  cancelOrder: mockCancelOrder,
+  searchMultiOutcomeMarkets: mockSearchMultiOutcomeMarkets,
+  fetchOrderBook: mockFetchOrderBook,
+  fetchBalance: mockFetchBalance,
+  fetchPositions: mockFetchPositions,
+  fetchOpenOrders: mockFetchOpenOrders,
+  getCapabilities: mockGetCapabilities,
+}));
+
+interface FakeAllowanceClient {
+  getAllowance: (() => Promise<bigint>) & ReturnType<typeof vi.fn>;
+  approve: ((amount: bigint) => Promise<{ txHash: string }>) &
+    ReturnType<typeof vi.fn>;
+}
+
+interface EntryModule {
+  parseEntryFlags: (argv: readonly string[]) => { dryRun: boolean };
+  createEntryDeps: (
+    flags: { dryRun: boolean },
+    options?: { allowance?: FakeAllowanceClient },
+  ) => {
+    scan: {
+      searchMarkets: (query: string) => Promise<unknown[]>;
+      fetchOrderBook: (tokenId: string) => Promise<unknown>;
+    };
+    executor: {
+      submit: (s: TradeSignal) => Promise<{ id: string; status: string }>;
+    };
+    positions: {
+      reconcile: () => Promise<Portfolio>;
+      getPortfolio: () => Portfolio;
+    };
+  };
+  assertLiveCapabilities: () => Promise<void>;
+  buildLiveAllowanceClient: (wallet: unknown) => Promise<unknown>;
+}
+
+let entry: EntryModule;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  mockGetCapabilities.mockImplementation(async () => ({ supportsTif: true }));
+  entry = (await import("../entry.js")) as unknown as EntryModule;
+});
+
+function makeFakeAllowance(initial = 0n): FakeAllowanceClient {
+  return {
+    getAllowance: vi.fn(async () => initial),
+    approve: vi.fn(async () => ({ txHash: "0xabc" })),
+  };
+}
+
+function makeSignal(overrides?: Partial<TradeSignal>): TradeSignal {
+  return {
+    automation_id: "arb-negrisk-buy",
+    timestamp: new Date("2026-04-30T12:00:00Z"),
+    market: {
+      platform: "polymarket",
+      market_id: "cond-001",
+      question: "NBA Champion?",
+    },
+    direction: "buy_yes",
+    size: 100,
+    confidence: 0.5,
+    urgency: "immediate",
+    metadata: {
+      tokenId:
+        "12345678901234567890123456789012345678901234567890123456789012345",
+      yesAsk: 0.3,
+      yesBid: 0.29,
+      liquidity: 500,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseEntryFlags
+// ---------------------------------------------------------------------------
+
+describe("parseEntryFlags", () => {
+  it("defaults to dry-run when no flag is provided", () => {
+    expect(entry.parseEntryFlags(["node", "entry.js"]).dryRun).toBe(true);
+  });
+
+  it("returns dryRun=false when --live is set", () => {
+    expect(entry.parseEntryFlags(["node", "entry.js", "--live"]).dryRun).toBe(
+      false,
+    );
+  });
+
+  it("ignores unrelated argv entries", () => {
+    expect(
+      entry.parseEntryFlags(["node", "entry.js", "--other", "x"]).dryRun,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createEntryDeps
+// ---------------------------------------------------------------------------
+
+describe("createEntryDeps", () => {
+  it("returns live scan + executor + positions adapters", () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    expect(typeof deps.scan.searchMarkets).toBe("function");
+    expect(typeof deps.scan.fetchOrderBook).toBe("function");
+    expect(typeof deps.executor.submit).toBe("function");
+    expect(typeof deps.positions.reconcile).toBe("function");
+  });
+
+  it("scan.searchMarkets calls the live polymarket client", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.scan.searchMarkets("NBA Champion");
+    expect(mockSearchMultiOutcomeMarkets).toHaveBeenCalledWith("NBA Champion");
+  });
+
+  it("executor.submit forwards FOK time-in-force to createOrder", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.executor.submit(makeSignal());
+
+    expect(mockCreateOrder).toHaveBeenCalledTimes(1);
+    expect(mockCreateOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenId: expect.stringMatching(/^\d{60,}$/),
+        timeInForce: "FOK",
+      }),
+    );
+  });
+
+  it("positions.reconcile calls the live polymarket client", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.positions.reconcile();
+    expect(mockFetchBalance).toHaveBeenCalledTimes(1);
+    expect(mockFetchPositions).toHaveBeenCalledTimes(1);
+    expect(mockFetchOpenOrders).toHaveBeenCalledTimes(1);
+  });
+
+  it("threads an injected allowance client through the live executor", async () => {
+    const allowance = makeFakeAllowance(0n);
+    const deps = entry.createEntryDeps({ dryRun: false }, { allowance });
+
+    await deps.executor.submit(makeSignal());
+
+    expect(allowance.getAllowance).toHaveBeenCalledTimes(1);
+    expect(allowance.approve).toHaveBeenCalledTimes(1);
+    expect(mockCreateOrder).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not approve when cached allowance already meets the threshold", async () => {
+    const allowance = makeFakeAllowance(200_000_000_000n);
+    const deps = entry.createEntryDeps({ dryRun: false }, { allowance });
+
+    await deps.executor.submit(makeSignal());
+    await deps.executor.submit(makeSignal());
+
+    expect(allowance.getAllowance).toHaveBeenCalledTimes(1);
+    expect(allowance.approve).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertLiveCapabilities
+// ---------------------------------------------------------------------------
+
+describe("assertLiveCapabilities", () => {
+  it("resolves when the sidecar advertises FOK support", async () => {
+    mockGetCapabilities.mockResolvedValueOnce({ supportsTif: true });
+    await expect(entry.assertLiveCapabilities()).resolves.toBeUndefined();
+  });
+
+  it("rejects when the sidecar does not advertise FOK support", async () => {
+    mockGetCapabilities.mockResolvedValueOnce({ supportsTif: false });
+    await expect(entry.assertLiveCapabilities()).rejects.toThrow(/FOK/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildLiveAllowanceClient
+// ---------------------------------------------------------------------------
+
+interface FakeWalletStore {
+  hasWallet: ReturnType<typeof vi.fn>;
+  getPrivateKey: ReturnType<typeof vi.fn>;
+  getAddress: ReturnType<typeof vi.fn>;
+  ensure: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeWallet(opts: {
+  hasWallet?: boolean;
+  address?: string;
+  privateKey?: string;
+} = {}): FakeWalletStore {
+  return {
+    hasWallet: vi.fn(() => opts.hasWallet ?? true),
+    getPrivateKey: vi.fn(() => opts.privateKey ?? "0x" + "a".repeat(64)),
+    getAddress: vi.fn(async () => opts.address ?? "0xowner"),
+    ensure: vi.fn(),
+  };
+}
+
+describe("buildLiveAllowanceClient", () => {
+  it("returns undefined when the wallet store has no wallet", async () => {
+    const wallet = makeFakeWallet({ hasWallet: false });
+    const client = await entry.buildLiveAllowanceClient(wallet);
+    expect(client).toBeUndefined();
+    expect(wallet.hasWallet).toHaveBeenCalled();
+    expect(wallet.getAddress).not.toHaveBeenCalled();
+  });
+
+  it("derives the owner address from wallet.getAddress()", async () => {
+    const wallet = makeFakeWallet({ address: "0xfromwallet" });
+    const client = await entry.buildLiveAllowanceClient(wallet);
+    expect(client).toBeDefined();
+    expect(wallet.getAddress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/canon/templates/strategies/arb-negrisk-buy/entry.ts
+++ b/canon/templates/strategies/arb-negrisk-buy/entry.ts
@@ -1,95 +1,303 @@
 /**
  * ARB-03 NegRisk Multi-condition Buy — Project Entry Point
  *
- * Dry-run scanner wire-up. The real Polymarket client does not currently
- * expose a NegRisk-aware search helper, so this entry point injects an
- * empty search stub — flip `searchMarkets` to a live feed once the CLOB
- * SDK surfaces `neg_risk` metadata + per-condition leg token IDs.
+ * Wires the real Polymarket client into the arb-negrisk-buy strategy:
+ *   - `--live`     → submits real CLOB orders via `createLiveExecutor`.
+ *   - default      → dry-run (production safety: no flag never trades).
+ *
+ * The bootstrap exposes pure factories (`parseEntryFlags`, `createEntryDeps`,
+ * `assertLiveCapabilities`, `buildLiveAllowanceClient`) so unit tests can
+ * exercise the wiring without starting the poll loop. `runner.start()` only
+ * fires when the file is the process entry point.
+ *
+ * NegRisk data feed: pmxt SDK does not expose the `neg_risk` event flag.
+ * `searchMultiOutcomeMarkets` returns multi-outcome markets as NegRisk
+ * *candidates*; the scan layer's order-book confirmation (Σ yes_ask < 1)
+ * is the sufficient market-driven filter.
  */
+
+import { pathToFileURL } from "node:url";
 
 import { appendEntry } from "../../execution-log.js";
 import type { ExecutionLogEntry } from "../../execution-log.js";
-import type { OrderBook } from "../../client-polymarket.js";
-import { fetchOrderBook as polyFetchOrderBook } from "../../client-polymarket.js";
+import {
+  fetchOrderBook as polyFetchOrderBook,
+  getCapabilities,
+  searchMultiOutcomeMarkets,
+} from "../../client-polymarket.js";
+import { createLiveExecutor } from "../../live-executor.js";
+import type {
+  AllowanceClient,
+  ResolvedOrder,
+} from "../../live-executor.js";
+import { createLivePositions } from "../../live-positions.js";
+import {
+  DEFAULT_ALLOWANCE_SPENDER,
+  USDC_E_ADDRESS,
+} from "../../polygon-addresses.js";
 import type {
   ExecutorDeps,
   PositionDeps,
 } from "../../runner.js";
-import type { Portfolio } from "../../types/RiskInterface.js";
+import { createUsdcAllowanceClient } from "../../usdc-allowance.js";
+import type { TradeSignal } from "../../types/TradeSignal.js";
+import type { WalletStore } from "../../wallet-store.js";
+
 import { DEFAULT_NEGRISK_BUY_CONFIG } from "./config.js";
 import { createNegRiskBuyRunner } from "./main.js";
 import type { NegRiskBuyRunnerConfig } from "./main.js";
 import type { ScanDeps, ScanSearchResult } from "./scan.js";
 
-const dryRun = process.argv.includes("--dry-run");
-const pollIntervalMs =
-  Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
+/** Approval is refreshed when current allowance drops below this floor. */
+const USDC_ALLOWANCE_THRESHOLD = 100_000_000_000n; // 100k USDC (6 decimals)
+/** When refreshing, allowance is set to this target. */
+const USDC_ALLOWANCE_TARGET = 1_000_000_000_000n; // 1M USDC
+/** Circuit breaker threshold — halts after this many consecutive losses. */
+const MAX_CONSECUTIVE_LOSSES = 3;
+/** Fallback price when the signal does not carry a leg ask. */
+const FALLBACK_PRICE = 0.5;
 
-const strategyConfig = DEFAULT_NEGRISK_BUY_CONFIG;
+/** Parsed CLI flags for the arb-negrisk-buy entry point. */
+export interface EntryFlags {
+  /** When true, the runner logs signals but does not submit orders. */
+  dryRun: boolean;
+}
 
-// TODO(ARB-03): replace with a live NegRisk-aware search once the CLOB
-// SDK exposes `neg_risk` + per-condition leg token IDs.
-const searchMarkets = async (
-  _query: string,
-): Promise<ScanSearchResult[]> => {
-  void _query;
-  return [];
-};
+/** Live executor + positions adapters wired for the runner. */
+export interface EntryDeps {
+  scan: ScanDeps;
+  executor: ExecutorDeps;
+  positions: PositionDeps;
+}
 
-const fetchOrderBook = async (tokenId: string): Promise<OrderBook> =>
-  polyFetchOrderBook(tokenId);
+/**
+ * Parse `process.argv` into entry flags.
+ *
+ * `--live` flips to live execution. Anything else (including `--dry-run` or
+ * no flag at all) keeps the safe dry-run default.
+ */
+export function parseEntryFlags(argv: readonly string[]): EntryFlags {
+  if (argv.includes("--live")) return { dryRun: false };
+  return { dryRun: true };
+}
 
-const scan: ScanDeps = { searchMarkets, fetchOrderBook };
+/**
+ * Resolve a NegRisk leg signal to the (tokenIds, price) pair the live
+ * executor needs.
+ *
+ * Each NegRisk leg signal is a `buy_yes` on a single condition's YES
+ * token; only the `yes` slot of `TokenIds` is consulted by
+ * `signalToOrderParams`. We populate both slots with the leg token to
+ * keep the contract typed without inventing a NO token that does not
+ * exist for NegRisk legs.
+ */
+function resolveNegRiskOrder(signal: TradeSignal): ResolvedOrder {
+  const meta = signal.metadata;
+  const tokenIdRaw = meta["tokenId"];
+  const yesBidRaw = meta["yesBid"];
+  // Scan layer attaches `yesAsk` on each leg; metadata uses `yesBid`
+  // for the resting bid and the leg's executable ask resolves through
+  // the underlying scan opportunity. Fall back to the bid + 1 tick as
+  // a conservative price when neither is present.
+  const yesAskRaw = meta["yesAsk"];
 
-const stubExecutor: ExecutorDeps = {
-  async submit(signal) {
-    process.stdout.write(
-      `[dry-run] would submit ${signal.automation_id} ${signal.market.market_id} ${signal.direction}\n`,
+  const tokenId =
+    typeof tokenIdRaw === "string" && tokenIdRaw.length > 0
+      ? tokenIdRaw
+      : `${signal.market.market_id}:yes`;
+  const price =
+    typeof yesAskRaw === "number"
+      ? yesAskRaw
+      : typeof yesBidRaw === "number"
+        ? yesBidRaw
+        : FALLBACK_PRICE;
+
+  return {
+    tokenIds: { yes: tokenId, no: tokenId },
+    price,
+    // FOK kills the leg if it can't fully execute, preventing
+    // partial-bundle exposure across the N legs.
+    timeInForce: "FOK",
+  };
+}
+
+/**
+ * Optional dependencies for `createEntryDeps`.
+ *
+ * `allowance` is an injection seam — `main()` builds a real
+ * `createUsdcAllowanceClient` for `--live`, while tests inject a fake
+ * `AllowanceClient` to assert the live executor consults it before
+ * submitting.
+ */
+export interface CreateEntryDepsOptions {
+  allowance?: AllowanceClient;
+}
+
+/**
+ * Build the live executor + position + scan adapters consumed by the runner.
+ *
+ * All adapters are always live — the runner gates `executor.submit` on
+ * `config.dryRun`, so dry-run still exercises the wiring without sending
+ * orders.
+ */
+export function createEntryDeps(
+  flags: EntryFlags,
+  options: CreateEntryDepsOptions = {},
+): EntryDeps {
+  void flags;
+  const executor = createLiveExecutor({
+    resolveOrder: resolveNegRiskOrder,
+    ...(options.allowance !== undefined ? { allowance: options.allowance } : {}),
+    allowanceThreshold: USDC_ALLOWANCE_THRESHOLD,
+    allowanceTarget: USDC_ALLOWANCE_TARGET,
+  });
+  const positions = createLivePositions();
+  const scan: ScanDeps = {
+    searchMarkets: async (query: string): Promise<ScanSearchResult[]> => {
+      const matches = await searchMultiOutcomeMarkets(query);
+      return matches.map((m) => ({
+        conditionId: m.conditionId,
+        question: m.question,
+        // Treat as NegRisk candidate; scan-layer's order-book sum check
+        // is the sufficient confirmation.
+        isNegRisk: true,
+        legs: m.legs.map((l) => ({ outcome: l.outcome, tokenId: l.tokenId })),
+      }));
+    },
+    fetchOrderBook: polyFetchOrderBook,
+  };
+  return { scan, executor, positions };
+}
+
+/**
+ * `--live` start-up safety gate.
+ *
+ * Refuses to start when the running pmxt sidecar does not advertise
+ * `supportsTif`. ARB-03 relies on FOK to keep all N legs of the bundle
+ * synchronised; silently degrading to a regular limit order would
+ * expose the strategy to partial-bundle fills.
+ */
+export async function assertLiveCapabilities(): Promise<void> {
+  const caps = await getCapabilities();
+  if (!caps.supportsTif) {
+    throw new Error(
+      "ARB-03 --live: pmxt sidecar does not advertise FOK time-in-force " +
+        "support; refusing to run.",
     );
-    return { id: "dry-run", status: "simulated" };
-  },
-};
+  }
+}
 
-const emptyPortfolio: Portfolio = {
-  total_value: strategyConfig.bankroll,
-  positions: [],
-  daily_pnl: 0,
-};
+/**
+ * Build a live USDC allowance client from an injected `WalletStore`.
+ *
+ * Returns undefined when the store has no wallet, when the owner
+ * address cannot be derived, or when the store throws — `main()` then
+ * skips allowance plumbing rather than placing live orders against a
+ * misconfigured wallet.
+ */
+export async function buildLiveAllowanceClient(
+  wallet: WalletStore,
+): Promise<AllowanceClient | undefined> {
+  if (!wallet.hasWallet()) return undefined;
 
-const stubPositions: PositionDeps = {
-  async reconcile() {
-    return emptyPortfolio;
-  },
-  getPortfolio() {
-    return emptyPortfolio;
-  },
-};
+  let ownerAddress: string;
+  try {
+    ownerAddress = await wallet.getAddress();
+  } catch {
+    return undefined;
+  }
 
-const runnerConfig: NegRiskBuyRunnerConfig = {
-  strategy: strategyConfig,
-  runner: {
-    pollIntervalMs,
-    dryRun,
-    baseDir: ".canon/execution",
-    statePath: ".canon/state.json",
-  },
-  maxConsecutiveLosses: 3,
-};
+  const rpcUrl =
+    process.env["POLYGON_RPC_URL"] ?? "https://polygon.drpc.org";
 
-const runner = createNegRiskBuyRunner(runnerConfig, {
-  scan,
-  executor: stubExecutor,
-  positions: stubPositions,
-  log: (entry: ExecutionLogEntry) =>
-    appendEntry(".canon/execution", entry),
-});
+  return createUsdcAllowanceClient({
+    ownerAddress,
+    spenderAddress: DEFAULT_ALLOWANCE_SPENDER,
+    usdcAddress: USDC_E_ADDRESS,
+    getProvider: async () => {
+      const { providers } = await import("ethers");
+      return new providers.JsonRpcProvider(rpcUrl);
+    },
+    getSigner: async () => {
+      const { Wallet, providers } = await import("ethers");
+      return new Wallet(
+        wallet.getPrivateKey(),
+        new providers.JsonRpcProvider(rpcUrl),
+      );
+    },
+  });
+}
 
-process.stdout.write(
-  `START ARB-03 scanner (${dryRun ? "dry-run" : "live"}) poll=${String(pollIntervalMs)}ms\n`,
-);
+/**
+ * Load `canon/cli`'s `FileWalletStore` at the bootstrap edge.
+ *
+ * Held in a runtime variable so TypeScript does not statically resolve
+ * the path and pull `canon/cli` into the templates `rootDir`.
+ */
+async function loadCanonWalletStore(): Promise<WalletStore> {
+  const specifier = "../../../cli/wallet-store.js";
+  const mod = (await import(/* @vite-ignore */ specifier)) as {
+    FileWalletStore: new () => WalletStore;
+  };
+  return new mod.FileWalletStore();
+}
 
-runner.start().catch((err: unknown) => {
-  const msg = err instanceof Error ? err.message : String(err);
-  process.stdout.write(`SCAN_ERROR ${msg}\n`);
-  process.exitCode = 1;
-});
+async function main(): Promise<void> {
+  const flags = parseEntryFlags(process.argv);
+  const pollIntervalMs = Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
+
+  if (!flags.dryRun) {
+    await assertLiveCapabilities();
+  }
+
+  const wallet: WalletStore | undefined = flags.dryRun
+    ? undefined
+    : await loadCanonWalletStore();
+  const allowance =
+    wallet !== undefined ? await buildLiveAllowanceClient(wallet) : undefined;
+  const { scan, executor, positions } = createEntryDeps(
+    flags,
+    allowance !== undefined ? { allowance } : {},
+  );
+
+  const runnerConfig: NegRiskBuyRunnerConfig = {
+    strategy: DEFAULT_NEGRISK_BUY_CONFIG,
+    runner: {
+      pollIntervalMs,
+      dryRun: flags.dryRun,
+      baseDir: ".canon/execution",
+      statePath: ".canon/state.json",
+    },
+    maxConsecutiveLosses: MAX_CONSECUTIVE_LOSSES,
+  };
+
+  const runner = createNegRiskBuyRunner(runnerConfig, {
+    scan,
+    executor,
+    positions,
+    log: (entry: ExecutionLogEntry) =>
+      appendEntry(".canon/execution", entry),
+  });
+
+  process.stdout.write(
+    `START ARB-03 scanner (${flags.dryRun ? "dry-run" : "live"}) ` +
+      `poll=${String(pollIntervalMs)}ms\n`,
+  );
+
+  try {
+    await runner.start();
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stdout.write(`SCAN_ERROR ${msg}\n`);
+    process.exitCode = 1;
+  }
+}
+
+const entryArg = process.argv[1];
+const isMain =
+  entryArg !== undefined &&
+  import.meta.url === pathToFileURL(entryArg).href;
+
+if (isMain) {
+  void main();
+}

--- a/canon/templates/strategies/fair-value/__tests__/entry.test.ts
+++ b/canon/templates/strategies/fair-value/__tests__/entry.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for `canon/templates/strategies/fair-value/entry.ts`.
+ *
+ * Pins the live-execution wiring contract.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TradeSignal } from "../../../types/TradeSignal.js";
+import type { Portfolio } from "../../../types/RiskInterface.js";
+
+const mockCreateOrder = vi.fn(async () => ({
+  id: "ord-test",
+  status: "submitted",
+}));
+const mockCancelOrder = vi.fn(async () => ({ success: true }));
+const mockFetchBinaryMarketSnapshots = vi.fn(async () => []);
+const mockFetchBalance = vi.fn(async () => []);
+const mockFetchPositions = vi.fn(async () => []);
+const mockFetchOpenOrders = vi.fn(async () => []);
+const mockGetCapabilities = vi.fn(async () => ({ supportsTif: true }));
+
+vi.mock("../../../client-polymarket.js", () => ({
+  createOrder: mockCreateOrder,
+  cancelOrder: mockCancelOrder,
+  fetchBinaryMarketSnapshots: mockFetchBinaryMarketSnapshots,
+  fetchBalance: mockFetchBalance,
+  fetchPositions: mockFetchPositions,
+  fetchOpenOrders: mockFetchOpenOrders,
+  getCapabilities: mockGetCapabilities,
+}));
+
+interface FakeAllowanceClient {
+  getAllowance: (() => Promise<bigint>) & ReturnType<typeof vi.fn>;
+  approve: ((amount: bigint) => Promise<{ txHash: string }>) &
+    ReturnType<typeof vi.fn>;
+}
+
+interface EntryModule {
+  parseEntryFlags: (argv: readonly string[]) => { dryRun: boolean };
+  createEntryDeps: (
+    flags: { dryRun: boolean },
+    options?: { allowance?: FakeAllowanceClient; query?: string },
+  ) => {
+    scan: { fetchSnapshots: () => Promise<unknown[]>; model: unknown };
+    executor: {
+      submit: (s: TradeSignal) => Promise<{ id: string; status: string }>;
+    };
+    positions: {
+      reconcile: () => Promise<Portfolio>;
+      getPortfolio: () => Portfolio;
+    };
+  };
+  assertLiveCapabilities: () => Promise<void>;
+  buildLiveAllowanceClient: (wallet: unknown) => Promise<unknown>;
+}
+
+let entry: EntryModule;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  mockGetCapabilities.mockImplementation(async () => ({ supportsTif: true }));
+  entry = (await import("../entry.js")) as unknown as EntryModule;
+});
+
+function makeFakeAllowance(initial = 0n): FakeAllowanceClient {
+  return {
+    getAllowance: vi.fn(async () => initial),
+    approve: vi.fn(async () => ({ txHash: "0xabc" })),
+  };
+}
+
+const yesTokenId =
+  "12345678901234567890123456789012345678901234567890123456789012345";
+const noTokenId =
+  "98765432109876543210987654321098765432109876543210987654321098765";
+
+function makeSignal(overrides?: Partial<TradeSignal>): TradeSignal {
+  return {
+    automation_id: "fair-value",
+    timestamp: new Date("2026-04-30T12:00:00Z"),
+    market: {
+      platform: "polymarket",
+      market_id: "cond-001",
+      question: "Will it rain?",
+    },
+    direction: "buy_yes",
+    size: 100,
+    confidence: 0.6,
+    urgency: "normal",
+    metadata: {
+      yesTokenId,
+      noTokenId,
+      marketPrice: 0.4,
+    },
+    ...overrides,
+  };
+}
+
+describe("parseEntryFlags", () => {
+  it("defaults to dry-run", () => {
+    expect(entry.parseEntryFlags(["node", "entry.js"]).dryRun).toBe(true);
+  });
+
+  it("returns dryRun=false when --live is set", () => {
+    expect(entry.parseEntryFlags(["node", "entry.js", "--live"]).dryRun).toBe(
+      false,
+    );
+  });
+});
+
+describe("createEntryDeps", () => {
+  it("returns live scan + executor + positions adapters", () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    expect(typeof deps.scan.fetchSnapshots).toBe("function");
+    expect(deps.scan.model).toBeDefined();
+    expect(typeof deps.executor.submit).toBe("function");
+    expect(typeof deps.positions.reconcile).toBe("function");
+  });
+
+  it("scan.fetchSnapshots calls the live polymarket client", async () => {
+    const deps = entry.createEntryDeps(
+      { dryRun: false },
+      { query: "Sports" },
+    );
+    await deps.scan.fetchSnapshots();
+    expect(mockFetchBinaryMarketSnapshots).toHaveBeenCalledWith("Sports");
+  });
+
+  it("buy_yes uses YES token at marketPrice with GTC", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.executor.submit(makeSignal({ direction: "buy_yes" }));
+    expect(mockCreateOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenId: yesTokenId,
+        side: "buy",
+        price: 0.4,
+        timeInForce: "GTC",
+        orderType: "limit",
+      }),
+    );
+  });
+
+  it("buy_no uses NO token at (1 - marketPrice) with GTC", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.executor.submit(makeSignal({ direction: "buy_no" }));
+    expect(mockCreateOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenId: noTokenId,
+        side: "buy",
+        price: 0.6,
+        timeInForce: "GTC",
+        orderType: "limit",
+      }),
+    );
+  });
+
+  it("positions.reconcile calls the live polymarket client", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.positions.reconcile();
+    expect(mockFetchBalance).toHaveBeenCalledTimes(1);
+    expect(mockFetchPositions).toHaveBeenCalledTimes(1);
+    expect(mockFetchOpenOrders).toHaveBeenCalledTimes(1);
+  });
+
+  it("threads an injected allowance client through the live executor", async () => {
+    const allowance = makeFakeAllowance(0n);
+    const deps = entry.createEntryDeps({ dryRun: false }, { allowance });
+
+    await deps.executor.submit(makeSignal());
+
+    expect(allowance.getAllowance).toHaveBeenCalledTimes(1);
+    expect(allowance.approve).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not approve when cached allowance already meets the threshold", async () => {
+    const allowance = makeFakeAllowance(200_000_000_000n);
+    const deps = entry.createEntryDeps({ dryRun: false }, { allowance });
+
+    await deps.executor.submit(makeSignal());
+    await deps.executor.submit(makeSignal());
+
+    expect(allowance.getAllowance).toHaveBeenCalledTimes(1);
+    expect(allowance.approve).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertLiveCapabilities", () => {
+  it("resolves when sidecar advertises TIF", async () => {
+    mockGetCapabilities.mockResolvedValueOnce({ supportsTif: true });
+    await expect(entry.assertLiveCapabilities()).resolves.toBeUndefined();
+  });
+
+  it("rejects when sidecar lacks TIF", async () => {
+    mockGetCapabilities.mockResolvedValueOnce({ supportsTif: false });
+    await expect(entry.assertLiveCapabilities()).rejects.toThrow(/GTC/);
+  });
+});
+
+interface FakeWalletStore {
+  hasWallet: ReturnType<typeof vi.fn>;
+  getPrivateKey: ReturnType<typeof vi.fn>;
+  getAddress: ReturnType<typeof vi.fn>;
+  ensure: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeWallet(opts: {
+  hasWallet?: boolean;
+  address?: string;
+  privateKey?: string;
+} = {}): FakeWalletStore {
+  return {
+    hasWallet: vi.fn(() => opts.hasWallet ?? true),
+    getPrivateKey: vi.fn(() => opts.privateKey ?? "0x" + "a".repeat(64)),
+    getAddress: vi.fn(async () => opts.address ?? "0xowner"),
+    ensure: vi.fn(),
+  };
+}
+
+describe("buildLiveAllowanceClient", () => {
+  it("returns undefined when wallet store has no wallet", async () => {
+    const wallet = makeFakeWallet({ hasWallet: false });
+    expect(await entry.buildLiveAllowanceClient(wallet)).toBeUndefined();
+  });
+
+  it("derives owner address from wallet.getAddress()", async () => {
+    const wallet = makeFakeWallet({ address: "0xfromwallet" });
+    const client = await entry.buildLiveAllowanceClient(wallet);
+    expect(client).toBeDefined();
+    expect(wallet.getAddress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/canon/templates/strategies/fair-value/entry.ts
+++ b/canon/templates/strategies/fair-value/entry.ts
@@ -1,93 +1,298 @@
 /**
  * IA-03 Fair Value Probability Model — Project Entry Point
  *
- * Scanner-only wiring for the IA-03 template. Ships a stubbed snapshot
- * provider, neutral fixture-driven model, dry-run executor, and empty
- * portfolio. Operators replace the snapshot provider and register real
- * `ProbabilityModel` fixtures when promoting from dry-run to a live
- * data feed.
+ * Wires the real Polymarket client into the fair-value strategy:
+ *   - `--live`     → submits real CLOB GTC limit orders via `createLiveExecutor`.
+ *   - default      → dry-run (production safety: no flag never trades).
+ *
+ * The bootstrap exposes pure factories (`parseEntryFlags`, `createEntryDeps`,
+ * `assertLiveCapabilities`, `buildLiveAllowanceClient`) so unit tests can
+ * exercise the wiring without starting the poll loop.
+ *
+ * The shipped `ProbabilityModel` is a neutral fallback (returns the
+ * market price as fair value with zero confidence), so divergence is
+ * always 0 and no signals fire. Operators register a real model when
+ * deploying — see `strategy.md` for the model interface.
  */
+
+import { pathToFileURL } from "node:url";
+
+import { appendEntry } from "../../execution-log.js";
+import type { ExecutionLogEntry } from "../../execution-log.js";
+import {
+  fetchBinaryMarketSnapshots,
+  getCapabilities,
+} from "../../client-polymarket.js";
+import { createLiveExecutor } from "../../live-executor.js";
+import type {
+  AllowanceClient,
+  ResolvedOrder,
+} from "../../live-executor.js";
+import { createLivePositions } from "../../live-positions.js";
+import {
+  DEFAULT_ALLOWANCE_SPENDER,
+  USDC_E_ADDRESS,
+} from "../../polygon-addresses.js";
+import type {
+  ExecutorDeps,
+  PositionDeps,
+} from "../../runner.js";
+import { createUsdcAllowanceClient } from "../../usdc-allowance.js";
+import type { TradeSignal } from "../../types/TradeSignal.js";
+import type { WalletStore } from "../../wallet-store.js";
 
 import { DEFAULT_FAIR_VALUE_CONFIG } from "./config.js";
 import { createFairValueRunner } from "./main.js";
+import type { FairValueRunnerConfig } from "./main.js";
 import type {
   FairValueSnapshot,
   ModelContext,
   ModelResult,
   ProbabilityModel,
+  ScanDeps,
 } from "./scan.js";
-import type { ExecutorDeps, PositionDeps } from "../../runner.js";
-import type { Portfolio } from "../../types/RiskInterface.js";
 
-const dryRun = process.argv.includes("--dry-run");
-const pollIntervalMs =
-  Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
+/** Approval is refreshed when current allowance drops below this floor. */
+const USDC_ALLOWANCE_THRESHOLD = 100_000_000_000n; // 100k USDC (6 decimals)
+/** When refreshing, allowance is set to this target. */
+const USDC_ALLOWANCE_TARGET = 1_000_000_000_000n; // 1M USDC
+/** Fallback price when the signal does not carry market price. */
+const FALLBACK_PRICE = 0.5;
 
-const strategyConfig = DEFAULT_FAIR_VALUE_CONFIG;
+/** Parsed CLI flags for the fair-value entry point. */
+export interface EntryFlags {
+  /** When true, the runner logs signals but does not submit orders. */
+  dryRun: boolean;
+}
 
-const stubScan = {
-  async fetchSnapshots(): Promise<FairValueSnapshot[]> {
-    return [];
+/** Live executor + positions + scan adapters wired for the runner. */
+export interface EntryDeps {
+  scan: ScanDeps;
+  executor: ExecutorDeps;
+  positions: PositionDeps;
+}
+
+/** Parse `process.argv` into entry flags. `--live` opts in to live execution. */
+export function parseEntryFlags(argv: readonly string[]): EntryFlags {
+  if (argv.includes("--live")) return { dryRun: false };
+  return { dryRun: true };
+}
+
+/**
+ * Resolve a fair-value signal to (tokenIds, price) for the live executor.
+ *
+ * IA-03 trades both directions: `buy_yes` when fair > market, `buy_no`
+ * when fair < market. The limit price for the YES leg is the market
+ * price; the NO leg's price is `1 - market` (binary complement). TIF is
+ * GTC (resting limit) — urgency is `normal`, so the order rests on book
+ * until filled or cancelled.
+ */
+function resolveFairValueOrder(signal: TradeSignal): ResolvedOrder {
+  const meta = signal.metadata;
+  const yesTokenIdRaw = meta["yesTokenId"];
+  const noTokenIdRaw = meta["noTokenId"];
+  const marketPriceRaw = meta["marketPrice"];
+
+  const yesTokenId =
+    typeof yesTokenIdRaw === "string" && yesTokenIdRaw.length > 0
+      ? yesTokenIdRaw
+      : `${signal.market.market_id}:yes`;
+  const noTokenId =
+    typeof noTokenIdRaw === "string" && noTokenIdRaw.length > 0
+      ? noTokenIdRaw
+      : `${signal.market.market_id}:no`;
+  const marketPrice =
+    typeof marketPriceRaw === "number" ? marketPriceRaw : FALLBACK_PRICE;
+
+  const isNoLeg =
+    signal.direction === "buy_no" || signal.direction === "sell_no";
+  // Binary complement: NO ≈ 1 - YES. Suitable as a limit-price seed; the
+  // book may diverge, so plug in a dedicated NO snapshot when precision
+  // matters.
+  const price = isNoLeg ? Math.max(0, Math.min(1, 1 - marketPrice)) : marketPrice;
+
+  return {
+    tokenIds: { yes: yesTokenId, no: noTokenId },
+    price,
+    timeInForce: "GTC",
+  };
+}
+
+/**
+ * Default neutral probability model — returns the market price.
+ *
+ * Confidence is zero, so the divergence/confluence gate in `main.ts`
+ * never fires a signal. Operators replace this with a real statistical
+ * model (e.g. ELO blend, vegas-line implied probability) before going
+ * live with capital.
+ */
+const NEUTRAL_MODEL: ProbabilityModel = {
+  computeFairValue(ctx: ModelContext): ModelResult {
+    return {
+      fairValue: ctx.snapshot.marketPrice,
+      sources: [],
+      confidence: 0,
+    };
   },
-  model: {
-    computeFairValue(ctx: ModelContext): ModelResult {
-      return {
-        fairValue: ctx.snapshot.marketPrice,
-        sources: [],
-        confidence: 0,
-      };
+};
+
+/** Optional dependencies for `createEntryDeps`. */
+export interface CreateEntryDepsOptions {
+  allowance?: AllowanceClient;
+  query?: string;
+  /** Override the probability model (defaults to the neutral model). */
+  model?: ProbabilityModel;
+}
+
+/** Build live executor + positions + scan adapters for the runner. */
+export function createEntryDeps(
+  flags: EntryFlags,
+  options: CreateEntryDepsOptions = {},
+): EntryDeps {
+  void flags;
+  const executor = createLiveExecutor({
+    resolveOrder: resolveFairValueOrder,
+    ...(options.allowance !== undefined ? { allowance: options.allowance } : {}),
+    allowanceThreshold: USDC_ALLOWANCE_THRESHOLD,
+    allowanceTarget: USDC_ALLOWANCE_TARGET,
+  });
+  const positions = createLivePositions();
+  const query = options.query ?? "";
+  const FAR_FUTURE_MS = 365 * 24 * 60 * 60 * 1000;
+  const scan: ScanDeps = {
+    fetchSnapshots: async (): Promise<FairValueSnapshot[]> => {
+      const snapshots = await fetchBinaryMarketSnapshots(query);
+      return snapshots.map((s) => ({
+        conditionId: s.conditionId,
+        question: s.question,
+        yesTokenId: s.yesTokenId,
+        noTokenId: s.noTokenId,
+        marketPrice: s.yesPrice,
+        volume24h: s.volume24h,
+        openInterest: s.openInterest,
+        timeToCloseMs: s.timeToCloseMs ?? FAR_FUTURE_MS,
+        timestampMs: s.timestampMs,
+      }));
     },
-  } satisfies ProbabilityModel,
-};
+    model: options.model ?? NEUTRAL_MODEL,
+  };
+  return { scan, executor, positions };
+}
 
-const stubExecutor: ExecutorDeps = {
-  async submit(signal) {
-    process.stdout.write(
-      `[dry-run] would submit: ${signal.automation_id}\n`,
+/**
+ * `--live` start-up safety gate.
+ *
+ * Refuses to start when the running pmxt sidecar does not advertise
+ * `supportsTif`. IA-03 uses GTC limit orders; degrading would convert a
+ * passive entry into an aggressive taker.
+ */
+export async function assertLiveCapabilities(): Promise<void> {
+  const caps = await getCapabilities();
+  if (!caps.supportsTif) {
+    throw new Error(
+      "IA-03 --live: pmxt sidecar does not advertise GTC time-in-force " +
+        "support; refusing to run.",
     );
-    return { id: "dry-run", status: "simulated" };
-  },
-};
+  }
+}
 
-const emptyPortfolio: Portfolio = {
-  total_value: strategyConfig.bankroll,
-  positions: [],
-  daily_pnl: 0,
-};
+/** Build a live USDC allowance client from an injected `WalletStore`. */
+export async function buildLiveAllowanceClient(
+  wallet: WalletStore,
+): Promise<AllowanceClient | undefined> {
+  if (!wallet.hasWallet()) return undefined;
 
-const stubPositions: PositionDeps = {
-  async reconcile() {
-    return emptyPortfolio;
-  },
-  getPortfolio() {
-    return emptyPortfolio;
-  },
-};
+  let ownerAddress: string;
+  try {
+    ownerAddress = await wallet.getAddress();
+  } catch {
+    return undefined;
+  }
 
-const runner = createFairValueRunner(
-  {
-    strategy: strategyConfig,
+  const rpcUrl =
+    process.env["POLYGON_RPC_URL"] ?? "https://polygon.drpc.org";
+
+  return createUsdcAllowanceClient({
+    ownerAddress,
+    spenderAddress: DEFAULT_ALLOWANCE_SPENDER,
+    usdcAddress: USDC_E_ADDRESS,
+    getProvider: async () => {
+      const { providers } = await import("ethers");
+      return new providers.JsonRpcProvider(rpcUrl);
+    },
+    getSigner: async () => {
+      const { Wallet, providers } = await import("ethers");
+      return new Wallet(
+        wallet.getPrivateKey(),
+        new providers.JsonRpcProvider(rpcUrl),
+      );
+    },
+  });
+}
+
+async function loadCanonWalletStore(): Promise<WalletStore> {
+  const specifier = "../../../cli/wallet-store.js";
+  const mod = (await import(/* @vite-ignore */ specifier)) as {
+    FileWalletStore: new () => WalletStore;
+  };
+  return new mod.FileWalletStore();
+}
+
+async function main(): Promise<void> {
+  const flags = parseEntryFlags(process.argv);
+  const pollIntervalMs = Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
+
+  if (!flags.dryRun) {
+    await assertLiveCapabilities();
+  }
+
+  const wallet: WalletStore | undefined = flags.dryRun
+    ? undefined
+    : await loadCanonWalletStore();
+  const allowance =
+    wallet !== undefined ? await buildLiveAllowanceClient(wallet) : undefined;
+  const { scan, executor, positions } = createEntryDeps(
+    flags,
+    allowance !== undefined ? { allowance } : {},
+  );
+
+  const runnerConfig: FairValueRunnerConfig = {
+    strategy: DEFAULT_FAIR_VALUE_CONFIG,
     runner: {
       pollIntervalMs,
-      dryRun,
+      dryRun: flags.dryRun,
       baseDir: ".canon/execution",
       statePath: ".canon/state.json",
     },
-  },
-  {
-    scan: stubScan,
-    executor: stubExecutor,
-    positions: stubPositions,
-  },
-);
+  };
 
-process.stdout.write(
-  `START IA-03 scanner (${dryRun ? "dry-run" : "live"}) ` +
-    `poll=${String(pollIntervalMs)}ms\n`,
-);
+  const runner = createFairValueRunner(runnerConfig, {
+    scan,
+    executor,
+    positions,
+    log: (entry: ExecutionLogEntry) =>
+      appendEntry(".canon/execution", entry),
+  });
 
-runner.start().catch((err: unknown) => {
-  const msg = err instanceof Error ? err.message : String(err);
-  process.stdout.write(`SCAN_ERROR ${msg}\n`);
-  process.exitCode = 1;
-});
+  process.stdout.write(
+    `START IA-03 scanner (${flags.dryRun ? "dry-run" : "live"}) ` +
+      `poll=${String(pollIntervalMs)}ms\n`,
+  );
+
+  try {
+    await runner.start();
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stdout.write(`SCAN_ERROR ${msg}\n`);
+    process.exitCode = 1;
+  }
+}
+
+const entryArg = process.argv[1];
+const isMain =
+  entryArg !== undefined &&
+  import.meta.url === pathToFileURL(entryArg).href;
+
+if (isMain) {
+  void main();
+}

--- a/canon/templates/strategies/fair-value/main.ts
+++ b/canon/templates/strategies/fair-value/main.ts
@@ -135,6 +135,8 @@ function buildSignal(
     metadata: {
       orderType: "limit",
       limitOnly: true,
+      yesTokenId: snapshot.yesTokenId,
+      noTokenId: snapshot.noTokenId,
       fairValue,
       marketPrice: snapshot.marketPrice,
       divergence,

--- a/canon/templates/strategies/mm-premium/__tests__/entry.test.ts
+++ b/canon/templates/strategies/mm-premium/__tests__/entry.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for `canon/templates/strategies/mm-premium/entry.ts`.
+ *
+ * Pins the live-execution wiring contract for the YES sell leg.
+ * The complete cycle (splitPosition + NO leg + reconcile) is a
+ * follow-up; here we verify the production seam.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TradeSignal } from "../../../types/TradeSignal.js";
+import type { Portfolio } from "../../../types/RiskInterface.js";
+
+const mockCreateOrder = vi.fn(async () => ({
+  id: "ord-test",
+  status: "submitted",
+}));
+const mockCancelOrder = vi.fn(async () => ({ success: true }));
+const mockFetchBinaryMarketSnapshots = vi.fn(async () => []);
+const mockFetchBalance = vi.fn(async () => []);
+const mockFetchPositions = vi.fn(async () => []);
+const mockFetchOpenOrders = vi.fn(async () => []);
+const mockGetCapabilities = vi.fn(async () => ({ supportsTif: true }));
+
+vi.mock("../../../client-polymarket.js", () => ({
+  createOrder: mockCreateOrder,
+  cancelOrder: mockCancelOrder,
+  fetchBinaryMarketSnapshots: mockFetchBinaryMarketSnapshots,
+  fetchBalance: mockFetchBalance,
+  fetchPositions: mockFetchPositions,
+  fetchOpenOrders: mockFetchOpenOrders,
+  getCapabilities: mockGetCapabilities,
+}));
+
+interface FakeAllowanceClient {
+  getAllowance: (() => Promise<bigint>) & ReturnType<typeof vi.fn>;
+  approve: ((amount: bigint) => Promise<{ txHash: string }>) &
+    ReturnType<typeof vi.fn>;
+}
+
+interface EntryModule {
+  parseEntryFlags: (argv: readonly string[]) => { dryRun: boolean };
+  createEntryDeps: (
+    flags: { dryRun: boolean },
+    options?: { allowance?: FakeAllowanceClient; query?: string },
+  ) => {
+    scan: { fetchSnapshots: () => Promise<unknown[]> };
+    executor: {
+      submit: (s: TradeSignal) => Promise<{ id: string; status: string }>;
+    };
+    positions: {
+      reconcile: () => Promise<Portfolio>;
+      getPortfolio: () => Portfolio;
+    };
+  };
+  assertLiveCapabilities: () => Promise<void>;
+  buildLiveAllowanceClient: (wallet: unknown) => Promise<unknown>;
+}
+
+let entry: EntryModule;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  mockGetCapabilities.mockImplementation(async () => ({ supportsTif: true }));
+  entry = (await import("../entry.js")) as unknown as EntryModule;
+});
+
+function makeFakeAllowance(initial = 0n): FakeAllowanceClient {
+  return {
+    getAllowance: vi.fn(async () => initial),
+    approve: vi.fn(async () => ({ txHash: "0xabc" })),
+  };
+}
+
+const yesTokenId =
+  "12345678901234567890123456789012345678901234567890123456789012345";
+const noTokenId =
+  "98765432109876543210987654321098765432109876543210987654321098765";
+
+function makeSignal(overrides?: Partial<TradeSignal>): TradeSignal {
+  return {
+    automation_id: "mm-premium",
+    timestamp: new Date("2026-04-30T12:00:00Z"),
+    market: {
+      platform: "polymarket",
+      market_id: "cond-001",
+      question: "MM Premium?",
+    },
+    direction: "sell_yes",
+    size: 1000,
+    confidence: 0.7,
+    urgency: "opportunistic",
+    metadata: {
+      yesTokenId,
+      noTokenId,
+      midpoint: 0.5,
+      offsetC: 0.0075,
+      cycleCapital: 1000,
+      projectedNet: 13.3,
+      timeToCloseMs: 3 * 24 * 60 * 60 * 1000,
+    },
+    ...overrides,
+  };
+}
+
+describe("parseEntryFlags", () => {
+  it("defaults to dry-run", () => {
+    expect(entry.parseEntryFlags(["node", "entry.js"]).dryRun).toBe(true);
+  });
+
+  it("returns dryRun=false when --live is set", () => {
+    expect(entry.parseEntryFlags(["node", "entry.js", "--live"]).dryRun).toBe(
+      false,
+    );
+  });
+});
+
+describe("createEntryDeps", () => {
+  it("returns live scan + executor + positions adapters", () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    expect(typeof deps.scan.fetchSnapshots).toBe("function");
+    expect(typeof deps.executor.submit).toBe("function");
+    expect(typeof deps.positions.reconcile).toBe("function");
+  });
+
+  it("scan.fetchSnapshots calls the live polymarket client", async () => {
+    const deps = entry.createEntryDeps(
+      { dryRun: false },
+      { query: "Sports" },
+    );
+    await deps.scan.fetchSnapshots();
+    expect(mockFetchBinaryMarketSnapshots).toHaveBeenCalledWith("Sports");
+  });
+
+  it("sell_yes uses YES token at midpoint + offsetC with GTC", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.executor.submit(makeSignal({ direction: "sell_yes" }));
+    expect(mockCreateOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenId: yesTokenId,
+        side: "sell",
+        price: 0.5075,
+        timeInForce: "GTC",
+        orderType: "limit",
+      }),
+    );
+  });
+
+  it("sell_no uses NO token at (1 - midpoint) + offsetC with GTC", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.executor.submit(makeSignal({ direction: "sell_no" }));
+    expect(mockCreateOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenId: noTokenId,
+        side: "sell",
+        price: 0.5075,
+        timeInForce: "GTC",
+        orderType: "limit",
+      }),
+    );
+  });
+
+  it("positions.reconcile calls the live polymarket client", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.positions.reconcile();
+    expect(mockFetchBalance).toHaveBeenCalledTimes(1);
+    expect(mockFetchPositions).toHaveBeenCalledTimes(1);
+    expect(mockFetchOpenOrders).toHaveBeenCalledTimes(1);
+  });
+
+  it("threads an injected allowance client through the live executor", async () => {
+    const allowance = makeFakeAllowance(0n);
+    const deps = entry.createEntryDeps({ dryRun: false }, { allowance });
+
+    await deps.executor.submit(makeSignal());
+
+    expect(allowance.getAllowance).toHaveBeenCalledTimes(1);
+    expect(allowance.approve).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not approve when cached allowance already meets the threshold", async () => {
+    const allowance = makeFakeAllowance(200_000_000_000n);
+    const deps = entry.createEntryDeps({ dryRun: false }, { allowance });
+
+    await deps.executor.submit(makeSignal());
+    await deps.executor.submit(makeSignal());
+
+    expect(allowance.getAllowance).toHaveBeenCalledTimes(1);
+    expect(allowance.approve).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertLiveCapabilities", () => {
+  it("resolves when sidecar advertises TIF", async () => {
+    mockGetCapabilities.mockResolvedValueOnce({ supportsTif: true });
+    await expect(entry.assertLiveCapabilities()).resolves.toBeUndefined();
+  });
+
+  it("rejects when sidecar lacks TIF", async () => {
+    mockGetCapabilities.mockResolvedValueOnce({ supportsTif: false });
+    await expect(entry.assertLiveCapabilities()).rejects.toThrow(/GTC/);
+  });
+});
+
+interface FakeWalletStore {
+  hasWallet: ReturnType<typeof vi.fn>;
+  getPrivateKey: ReturnType<typeof vi.fn>;
+  getAddress: ReturnType<typeof vi.fn>;
+  ensure: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeWallet(opts: {
+  hasWallet?: boolean;
+  address?: string;
+  privateKey?: string;
+} = {}): FakeWalletStore {
+  return {
+    hasWallet: vi.fn(() => opts.hasWallet ?? true),
+    getPrivateKey: vi.fn(() => opts.privateKey ?? "0x" + "a".repeat(64)),
+    getAddress: vi.fn(async () => opts.address ?? "0xowner"),
+    ensure: vi.fn(),
+  };
+}
+
+describe("buildLiveAllowanceClient", () => {
+  it("returns undefined when wallet store has no wallet", async () => {
+    const wallet = makeFakeWallet({ hasWallet: false });
+    expect(await entry.buildLiveAllowanceClient(wallet)).toBeUndefined();
+  });
+
+  it("derives owner address from wallet.getAddress()", async () => {
+    const wallet = makeFakeWallet({ address: "0xfromwallet" });
+    const client = await entry.buildLiveAllowanceClient(wallet);
+    expect(client).toBeDefined();
+    expect(wallet.getAddress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/canon/templates/strategies/mm-premium/entry.ts
+++ b/canon/templates/strategies/mm-premium/entry.ts
@@ -1,79 +1,281 @@
 /**
  * MINT-04 Market Making Premium — Project Entry Point
  *
- * Scanner-only wiring for the MINT-04 template. Uses a stubbed snapshot
- * provider, dry-run executor, and empty portfolio since this template does
- * not execute `mint_set` or `postLimitOrder` calls. Operators replace the
- * snapshot provider when promoting from dry-run to a live data feed.
+ * Wires the real Polymarket client into the mm-premium strategy:
+ *   - `--live`     → submits real CLOB GTC limit sell orders via
+ *                    `createLiveExecutor`. The YES sell leg of each
+ *                    cycle flows through the production live executor.
+ *   - default      → dry-run (production safety: no flag never trades).
+ *
+ * A complete MINT-04 cycle is:
+ *   1. `splitPosition($cycleCapital)` — mint matched YES + NO pairs.
+ *   2. Post YES sell-limit at midpoint + offsetC.
+ *   3. Post NO  sell-limit at (1 − midpoint) + offsetC.
+ *   4. 24h reconcile / kill remaining.
+ *
+ * Steps 1 + 3 + 4 are not yet wired here — they require a cycle loop
+ * mirroring `strategies/mint-01/cycle.ts`. The current bootstrap covers
+ * the live executor + allowance + sidecar preflight pieces shared with
+ * the rest of the live-capable templates; the cycle loop is the
+ * follow-up. The exposed `createEntryDeps` is the production seam
+ * exercised by unit tests.
  */
+
+import { pathToFileURL } from "node:url";
+
+import { appendEntry } from "../../execution-log.js";
+import type { ExecutionLogEntry } from "../../execution-log.js";
+import {
+  fetchBinaryMarketSnapshots,
+  getCapabilities,
+} from "../../client-polymarket.js";
+import { createLiveExecutor } from "../../live-executor.js";
+import type {
+  AllowanceClient,
+  ResolvedOrder,
+} from "../../live-executor.js";
+import { createLivePositions } from "../../live-positions.js";
+import {
+  DEFAULT_ALLOWANCE_SPENDER,
+  USDC_E_ADDRESS,
+} from "../../polygon-addresses.js";
+import type {
+  ExecutorDeps,
+  PositionDeps,
+} from "../../runner.js";
+import { createUsdcAllowanceClient } from "../../usdc-allowance.js";
+import type { TradeSignal } from "../../types/TradeSignal.js";
+import type { WalletStore } from "../../wallet-store.js";
 
 import { DEFAULT_MM_PREMIUM_CONFIG } from "./config.js";
 import { createMintPremiumRunner } from "./main.js";
+import type { MintPremiumRunnerConfig } from "./main.js";
+import type { ScanDeps } from "./scan.js";
 import type { MintPremiumSnapshot } from "./signal.js";
-import type { ExecutorDeps, PositionDeps } from "../../runner.js";
-import type { Portfolio } from "../../types/RiskInterface.js";
 
-const dryRun = process.argv.includes("--dry-run");
-const pollIntervalMs =
-  Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
+/** Approval is refreshed when current allowance drops below this floor. */
+const USDC_ALLOWANCE_THRESHOLD = 100_000_000_000n; // 100k USDC (6 decimals)
+/** When refreshing, allowance is set to this target. */
+const USDC_ALLOWANCE_TARGET = 1_000_000_000_000n; // 1M USDC
+/** Circuit breaker threshold — halts after this many consecutive losses. */
+const MAX_CONSECUTIVE_LOSSES = 3;
+/** Fallback price when the signal does not carry a midpoint. */
+const FALLBACK_PRICE = 0.5;
 
-const strategyConfig = DEFAULT_MM_PREMIUM_CONFIG;
+/** Parsed CLI flags for the mm-premium entry point. */
+export interface EntryFlags {
+  /** When true, the runner logs signals but does not submit orders. */
+  dryRun: boolean;
+}
 
-const stubScan = {
-  async fetchSnapshots(): Promise<MintPremiumSnapshot[]> {
-    return [];
-  },
-};
+/** Live executor + positions + scan adapters wired for the runner. */
+export interface EntryDeps {
+  scan: ScanDeps;
+  executor: ExecutorDeps;
+  positions: PositionDeps;
+}
 
-const stubExecutor: ExecutorDeps = {
-  async submit(signal) {
-    process.stdout.write(
-      `[dry-run] would submit: ${signal.automation_id}\n`,
+/** Parse `process.argv` into entry flags. `--live` opts in to live execution. */
+export function parseEntryFlags(argv: readonly string[]): EntryFlags {
+  if (argv.includes("--live")) return { dryRun: false };
+  return { dryRun: true };
+}
+
+/**
+ * Resolve a mint-premium signal to (tokenIds, price).
+ *
+ * The current strategy emits a single `sell_yes` signal per viable
+ * cycle; the live executor sells YES at midpoint + offsetC. TIF is GTC
+ * (resting limit, urgency `opportunistic`). The NO leg + splitPosition
+ * mint are handled by the (pending) cycle loop, mirroring
+ * `mint-01/cycle.ts`.
+ */
+function resolveMmPremiumOrder(signal: TradeSignal): ResolvedOrder {
+  const meta = signal.metadata;
+  const yesTokenIdRaw = meta["yesTokenId"];
+  const noTokenIdRaw = meta["noTokenId"];
+  const midpointRaw = meta["midpoint"];
+  const offsetCRaw = meta["offsetC"];
+
+  const yesTokenId =
+    typeof yesTokenIdRaw === "string" && yesTokenIdRaw.length > 0
+      ? yesTokenIdRaw
+      : `${signal.market.market_id}:yes`;
+  const noTokenId =
+    typeof noTokenIdRaw === "string" && noTokenIdRaw.length > 0
+      ? noTokenIdRaw
+      : `${signal.market.market_id}:no`;
+  const midpoint =
+    typeof midpointRaw === "number" ? midpointRaw : FALLBACK_PRICE;
+  const offsetC = typeof offsetCRaw === "number" ? offsetCRaw : 0;
+
+  const isNoLeg =
+    signal.direction === "sell_no" || signal.direction === "buy_no";
+  const yesPrice = midpoint + offsetC;
+  const noPrice = 1 - midpoint + offsetC;
+  const price = isNoLeg ? Math.min(0.99, noPrice) : Math.min(0.99, yesPrice);
+
+  return {
+    tokenIds: { yes: yesTokenId, no: noTokenId },
+    price,
+    timeInForce: "GTC",
+  };
+}
+
+/** Optional dependencies for `createEntryDeps`. */
+export interface CreateEntryDepsOptions {
+  allowance?: AllowanceClient;
+  /** Search query for binary-market snapshots (defaults to empty). */
+  query?: string;
+}
+
+/** Build live executor + positions + scan adapters for the runner. */
+export function createEntryDeps(
+  flags: EntryFlags,
+  options: CreateEntryDepsOptions = {},
+): EntryDeps {
+  void flags;
+  const executor = createLiveExecutor({
+    resolveOrder: resolveMmPremiumOrder,
+    ...(options.allowance !== undefined ? { allowance: options.allowance } : {}),
+    allowanceThreshold: USDC_ALLOWANCE_THRESHOLD,
+    allowanceTarget: USDC_ALLOWANCE_TARGET,
+  });
+  const positions = createLivePositions();
+  const query = options.query ?? "";
+  const FAR_FUTURE_MS = 365 * 24 * 60 * 60 * 1000;
+  const scan: ScanDeps = {
+    fetchSnapshots: async (): Promise<MintPremiumSnapshot[]> => {
+      const snapshots = await fetchBinaryMarketSnapshots(query);
+      return snapshots.map((s) => ({
+        conditionId: s.conditionId,
+        question: s.question,
+        midpoint: s.yesPrice,
+        timeToCloseMs: s.timeToCloseMs ?? FAR_FUTURE_MS,
+        volume24h: s.volume24h,
+        yesTokenId: s.yesTokenId,
+        noTokenId: s.noTokenId,
+      }));
+    },
+  };
+  return { scan, executor, positions };
+}
+
+/**
+ * `--live` start-up safety gate.
+ *
+ * Refuses to start when the running pmxt sidecar does not advertise
+ * `supportsTif`. MINT-04 uses GTC limit orders for the premium sell
+ * legs; degrading would convert resting quotes into aggressive takers.
+ */
+export async function assertLiveCapabilities(): Promise<void> {
+  const caps = await getCapabilities();
+  if (!caps.supportsTif) {
+    throw new Error(
+      "MINT-04 --live: pmxt sidecar does not advertise GTC time-in-force " +
+        "support; refusing to run.",
     );
-    return { id: "dry-run", status: "simulated" };
-  },
-};
+  }
+}
 
-const emptyPortfolio: Portfolio = {
-  total_value: strategyConfig.bankroll,
-  positions: [],
-  daily_pnl: 0,
-};
+/** Build a live USDC allowance client from an injected `WalletStore`. */
+export async function buildLiveAllowanceClient(
+  wallet: WalletStore,
+): Promise<AllowanceClient | undefined> {
+  if (!wallet.hasWallet()) return undefined;
 
-const stubPositions: PositionDeps = {
-  async reconcile() {
-    return emptyPortfolio;
-  },
-  getPortfolio() {
-    return emptyPortfolio;
-  },
-};
+  let ownerAddress: string;
+  try {
+    ownerAddress = await wallet.getAddress();
+  } catch {
+    return undefined;
+  }
 
-const runner = createMintPremiumRunner(
-  {
-    strategy: strategyConfig,
+  const rpcUrl =
+    process.env["POLYGON_RPC_URL"] ?? "https://polygon.drpc.org";
+
+  return createUsdcAllowanceClient({
+    ownerAddress,
+    spenderAddress: DEFAULT_ALLOWANCE_SPENDER,
+    usdcAddress: USDC_E_ADDRESS,
+    getProvider: async () => {
+      const { providers } = await import("ethers");
+      return new providers.JsonRpcProvider(rpcUrl);
+    },
+    getSigner: async () => {
+      const { Wallet, providers } = await import("ethers");
+      return new Wallet(
+        wallet.getPrivateKey(),
+        new providers.JsonRpcProvider(rpcUrl),
+      );
+    },
+  });
+}
+
+async function loadCanonWalletStore(): Promise<WalletStore> {
+  const specifier = "../../../cli/wallet-store.js";
+  const mod = (await import(/* @vite-ignore */ specifier)) as {
+    FileWalletStore: new () => WalletStore;
+  };
+  return new mod.FileWalletStore();
+}
+
+async function main(): Promise<void> {
+  const flags = parseEntryFlags(process.argv);
+  const pollIntervalMs = Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
+
+  if (!flags.dryRun) {
+    await assertLiveCapabilities();
+  }
+
+  const wallet: WalletStore | undefined = flags.dryRun
+    ? undefined
+    : await loadCanonWalletStore();
+  const allowance =
+    wallet !== undefined ? await buildLiveAllowanceClient(wallet) : undefined;
+  const { scan, executor, positions } = createEntryDeps(
+    flags,
+    allowance !== undefined ? { allowance } : {},
+  );
+
+  const runnerConfig: MintPremiumRunnerConfig = {
+    strategy: DEFAULT_MM_PREMIUM_CONFIG,
     runner: {
       pollIntervalMs,
-      dryRun,
+      dryRun: flags.dryRun,
       baseDir: ".canon/execution",
       statePath: ".canon/state.json",
     },
-    maxConsecutiveLosses: 3,
-  },
-  {
-    scan: stubScan,
-    executor: stubExecutor,
-    positions: stubPositions,
-  },
-);
+    maxConsecutiveLosses: MAX_CONSECUTIVE_LOSSES,
+  };
 
-process.stdout.write(
-  `START MINT-04 scanner (${dryRun ? "dry-run" : "live"}) ` +
-    `poll=${String(pollIntervalMs)}ms\n`,
-);
+  const runner = createMintPremiumRunner(runnerConfig, {
+    scan,
+    executor,
+    positions,
+    log: (entry: ExecutionLogEntry) =>
+      appendEntry(".canon/execution", entry),
+  });
 
-runner.start().catch((err: unknown) => {
-  const msg = err instanceof Error ? err.message : String(err);
-  process.stdout.write(`SCAN_ERROR ${msg}\n`);
-  process.exitCode = 1;
-});
+  process.stdout.write(
+    `START MINT-04 scanner (${flags.dryRun ? "dry-run" : "live"}) ` +
+      `poll=${String(pollIntervalMs)}ms\n`,
+  );
+
+  try {
+    await runner.start();
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stdout.write(`SCAN_ERROR ${msg}\n`);
+    process.exitCode = 1;
+  }
+}
+
+const entryArg = process.argv[1];
+const isMain =
+  entryArg !== undefined &&
+  import.meta.url === pathToFileURL(entryArg).href;
+
+if (isMain) {
+  void main();
+}

--- a/canon/templates/strategies/mm-premium/main.ts
+++ b/canon/templates/strategies/mm-premium/main.ts
@@ -78,6 +78,8 @@ function buildSignal(
       cycleCapital: config.cycleCapital,
       offsetC,
       midpoint: snap.midpoint,
+      ...(snap.yesTokenId !== undefined ? { yesTokenId: snap.yesTokenId } : {}),
+      ...(snap.noTokenId !== undefined ? { noTokenId: snap.noTokenId } : {}),
     },
   };
 }

--- a/canon/templates/strategies/trade-momentum/__tests__/entry.test.ts
+++ b/canon/templates/strategies/trade-momentum/__tests__/entry.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for `canon/templates/strategies/trade-momentum/entry.ts`.
+ *
+ * Pins the live-execution wiring contract:
+ *   - `parseEntryFlags(argv)` defaults to dry-run; `--live` opts in.
+ *   - `createEntryDeps()` returns live executor + live positions + live
+ *     scan adapter — never the previous in-file stubs.
+ *   - `executor.submit` calls into the polymarket client with GTC TIF.
+ *   - Allowance client is consulted before submission and `approve` only
+ *     runs when the cached allowance is below the threshold.
+ *   - `assertLiveCapabilities` rejects when the sidecar lacks TIF.
+ *   - `buildLiveAllowanceClient` returns undefined for an empty wallet.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TradeSignal } from "../../../types/TradeSignal.js";
+import type { Portfolio } from "../../../types/RiskInterface.js";
+
+const mockCreateOrder = vi.fn(async () => ({
+  id: "ord-test",
+  status: "submitted",
+}));
+const mockCancelOrder = vi.fn(async () => ({ success: true }));
+const mockFetchBinaryMarketSnapshots = vi.fn(async () => []);
+const mockFetchBalance = vi.fn(async () => []);
+const mockFetchPositions = vi.fn(async () => []);
+const mockFetchOpenOrders = vi.fn(async () => []);
+const mockGetCapabilities = vi.fn(async () => ({ supportsTif: true }));
+
+vi.mock("../../../client-polymarket.js", () => ({
+  createOrder: mockCreateOrder,
+  cancelOrder: mockCancelOrder,
+  fetchBinaryMarketSnapshots: mockFetchBinaryMarketSnapshots,
+  fetchBalance: mockFetchBalance,
+  fetchPositions: mockFetchPositions,
+  fetchOpenOrders: mockFetchOpenOrders,
+  getCapabilities: mockGetCapabilities,
+}));
+
+interface FakeAllowanceClient {
+  getAllowance: (() => Promise<bigint>) & ReturnType<typeof vi.fn>;
+  approve: ((amount: bigint) => Promise<{ txHash: string }>) &
+    ReturnType<typeof vi.fn>;
+}
+
+interface EntryModule {
+  parseEntryFlags: (argv: readonly string[]) => { dryRun: boolean };
+  createEntryDeps: (
+    flags: { dryRun: boolean },
+    options?: { allowance?: FakeAllowanceClient; query?: string },
+  ) => {
+    scan: { fetchSnapshots: () => Promise<unknown[]> };
+    executor: {
+      submit: (s: TradeSignal) => Promise<{ id: string; status: string }>;
+    };
+    positions: {
+      reconcile: () => Promise<Portfolio>;
+      getPortfolio: () => Portfolio;
+    };
+  };
+  assertLiveCapabilities: () => Promise<void>;
+  buildLiveAllowanceClient: (wallet: unknown) => Promise<unknown>;
+}
+
+let entry: EntryModule;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  mockGetCapabilities.mockImplementation(async () => ({ supportsTif: true }));
+  entry = (await import("../entry.js")) as unknown as EntryModule;
+});
+
+function makeFakeAllowance(initial = 0n): FakeAllowanceClient {
+  return {
+    getAllowance: vi.fn(async () => initial),
+    approve: vi.fn(async () => ({ txHash: "0xabc" })),
+  };
+}
+
+function makeSignal(overrides?: Partial<TradeSignal>): TradeSignal {
+  return {
+    automation_id: "trade-momentum",
+    timestamp: new Date("2026-04-30T12:00:00Z"),
+    market: {
+      platform: "polymarket",
+      market_id: "cond-001",
+      question: "Will price rise?",
+    },
+    direction: "buy_yes",
+    size: 100,
+    confidence: 0.6,
+    urgency: "normal",
+    metadata: {
+      yesTokenId:
+        "12345678901234567890123456789012345678901234567890123456789012345",
+      noTokenId:
+        "98765432109876543210987654321098765432109876543210987654321098765",
+      entryPrice: 0.18,
+    },
+    ...overrides,
+  };
+}
+
+describe("parseEntryFlags", () => {
+  it("defaults to dry-run", () => {
+    expect(entry.parseEntryFlags(["node", "entry.js"]).dryRun).toBe(true);
+  });
+
+  it("returns dryRun=false when --live is set", () => {
+    expect(entry.parseEntryFlags(["node", "entry.js", "--live"]).dryRun).toBe(
+      false,
+    );
+  });
+});
+
+describe("createEntryDeps", () => {
+  it("returns live scan + executor + positions adapters", () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    expect(typeof deps.scan.fetchSnapshots).toBe("function");
+    expect(typeof deps.executor.submit).toBe("function");
+    expect(typeof deps.positions.reconcile).toBe("function");
+  });
+
+  it("scan.fetchSnapshots calls the live polymarket client", async () => {
+    const deps = entry.createEntryDeps(
+      { dryRun: false },
+      { query: "NBA" },
+    );
+    await deps.scan.fetchSnapshots();
+    expect(mockFetchBinaryMarketSnapshots).toHaveBeenCalledWith("NBA");
+  });
+
+  it("executor.submit forwards GTC time-in-force to createOrder", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.executor.submit(makeSignal());
+
+    expect(mockCreateOrder).toHaveBeenCalledTimes(1);
+    expect(mockCreateOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenId: expect.stringMatching(/^\d{60,}$/),
+        timeInForce: "GTC",
+        orderType: "limit",
+      }),
+    );
+  });
+
+  it("positions.reconcile calls the live polymarket client", async () => {
+    const deps = entry.createEntryDeps({ dryRun: false });
+    await deps.positions.reconcile();
+    expect(mockFetchBalance).toHaveBeenCalledTimes(1);
+    expect(mockFetchPositions).toHaveBeenCalledTimes(1);
+    expect(mockFetchOpenOrders).toHaveBeenCalledTimes(1);
+  });
+
+  it("threads an injected allowance client through the live executor", async () => {
+    const allowance = makeFakeAllowance(0n);
+    const deps = entry.createEntryDeps({ dryRun: false }, { allowance });
+
+    await deps.executor.submit(makeSignal());
+
+    expect(allowance.getAllowance).toHaveBeenCalledTimes(1);
+    expect(allowance.approve).toHaveBeenCalledTimes(1);
+    expect(mockCreateOrder).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not approve when cached allowance already meets the threshold", async () => {
+    const allowance = makeFakeAllowance(200_000_000_000n);
+    const deps = entry.createEntryDeps({ dryRun: false }, { allowance });
+
+    await deps.executor.submit(makeSignal());
+    await deps.executor.submit(makeSignal());
+
+    expect(allowance.getAllowance).toHaveBeenCalledTimes(1);
+    expect(allowance.approve).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertLiveCapabilities", () => {
+  it("resolves when the sidecar advertises TIF support", async () => {
+    mockGetCapabilities.mockResolvedValueOnce({ supportsTif: true });
+    await expect(entry.assertLiveCapabilities()).resolves.toBeUndefined();
+  });
+
+  it("rejects when the sidecar does not advertise TIF support", async () => {
+    mockGetCapabilities.mockResolvedValueOnce({ supportsTif: false });
+    await expect(entry.assertLiveCapabilities()).rejects.toThrow(/GTC/);
+  });
+});
+
+interface FakeWalletStore {
+  hasWallet: ReturnType<typeof vi.fn>;
+  getPrivateKey: ReturnType<typeof vi.fn>;
+  getAddress: ReturnType<typeof vi.fn>;
+  ensure: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeWallet(opts: {
+  hasWallet?: boolean;
+  address?: string;
+  privateKey?: string;
+} = {}): FakeWalletStore {
+  return {
+    hasWallet: vi.fn(() => opts.hasWallet ?? true),
+    getPrivateKey: vi.fn(() => opts.privateKey ?? "0x" + "a".repeat(64)),
+    getAddress: vi.fn(async () => opts.address ?? "0xowner"),
+    ensure: vi.fn(),
+  };
+}
+
+describe("buildLiveAllowanceClient", () => {
+  it("returns undefined when the wallet store has no wallet", async () => {
+    const wallet = makeFakeWallet({ hasWallet: false });
+    const client = await entry.buildLiveAllowanceClient(wallet);
+    expect(client).toBeUndefined();
+  });
+
+  it("derives the owner address from wallet.getAddress()", async () => {
+    const wallet = makeFakeWallet({ address: "0xfromwallet" });
+    const client = await entry.buildLiveAllowanceClient(wallet);
+    expect(client).toBeDefined();
+    expect(wallet.getAddress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/canon/templates/strategies/trade-momentum/entry.ts
+++ b/canon/templates/strategies/trade-momentum/entry.ts
@@ -1,79 +1,285 @@
 /**
  * TRADE-02 Momentum Trading — Project Entry Point
  *
- * Scanner-only wiring for the TRADE-02 template. Uses a stubbed snapshot
- * provider, dry-run executor, and empty portfolio since no order
- * submission occurs. Operators replace the snapshot provider when
- * promoting from dry-run to a live data feed.
+ * Wires the real Polymarket client into the trade-momentum strategy:
+ *   - `--live`     → submits real CLOB GTC limit orders via `createLiveExecutor`.
+ *   - default      → dry-run (production safety: no flag never trades).
+ *
+ * The bootstrap exposes pure factories (`parseEntryFlags`, `createEntryDeps`,
+ * `assertLiveCapabilities`, `buildLiveAllowanceClient`) so unit tests can
+ * exercise the wiring without starting the poll loop.
+ *
+ * `topWalletShare` is not surfaced by the pmxt SDK; the manipulation
+ * guard reads 0 until an on-chain indexer is wired (Phase 2/3).
  */
+
+import { pathToFileURL } from "node:url";
+
+import { appendEntry } from "../../execution-log.js";
+import type { ExecutionLogEntry } from "../../execution-log.js";
+import {
+  fetchBinaryMarketSnapshots,
+  getCapabilities,
+} from "../../client-polymarket.js";
+import { createLiveExecutor } from "../../live-executor.js";
+import type {
+  AllowanceClient,
+  ResolvedOrder,
+} from "../../live-executor.js";
+import { createLivePositions } from "../../live-positions.js";
+import {
+  DEFAULT_ALLOWANCE_SPENDER,
+  USDC_E_ADDRESS,
+} from "../../polygon-addresses.js";
+import type {
+  ExecutorDeps,
+  PositionDeps,
+} from "../../runner.js";
+import { createUsdcAllowanceClient } from "../../usdc-allowance.js";
+import type { TradeSignal } from "../../types/TradeSignal.js";
+import type { WalletStore } from "../../wallet-store.js";
 
 import { DEFAULT_TRADE_MOMENTUM_CONFIG } from "./config.js";
 import { createTradeMomentumRunner } from "./main.js";
-import type { TradeMomentumSnapshot } from "./scan.js";
-import type { ExecutorDeps, PositionDeps } from "../../runner.js";
-import type { Portfolio } from "../../types/RiskInterface.js";
+import type { TradeMomentumRunnerConfig } from "./main.js";
+import type { ScanDeps, TradeMomentumSnapshot } from "./scan.js";
 
-const dryRun = process.argv.includes("--dry-run");
-const pollIntervalMs =
-  Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
+/** Approval is refreshed when current allowance drops below this floor. */
+const USDC_ALLOWANCE_THRESHOLD = 100_000_000_000n; // 100k USDC (6 decimals)
+/** When refreshing, allowance is set to this target. */
+const USDC_ALLOWANCE_TARGET = 1_000_000_000_000n; // 1M USDC
+/** Circuit breaker threshold — halts after this many consecutive losses. */
+const MAX_CONSECUTIVE_LOSSES = 3;
+/** Fallback price when the signal does not carry an entry price. */
+const FALLBACK_PRICE = 0.5;
 
-const strategyConfig = DEFAULT_TRADE_MOMENTUM_CONFIG;
+/** Parsed CLI flags for the trade-momentum entry point. */
+export interface EntryFlags {
+  /** When true, the runner logs signals but does not submit orders. */
+  dryRun: boolean;
+}
 
-const stubScan = {
-  async fetchSnapshots(): Promise<TradeMomentumSnapshot[]> {
-    return [];
-  },
-};
+/** Live executor + positions + scan adapters wired for the runner. */
+export interface EntryDeps {
+  scan: ScanDeps;
+  executor: ExecutorDeps;
+  positions: PositionDeps;
+}
 
-const stubExecutor: ExecutorDeps = {
-  async submit(signal) {
-    process.stdout.write(
-      `[dry-run] would submit: ${signal.automation_id}\n`,
+/**
+ * Parse `process.argv` into entry flags. `--live` opts in to live
+ * execution; anything else (including no flag) is dry-run.
+ */
+export function parseEntryFlags(argv: readonly string[]): EntryFlags {
+  if (argv.includes("--live")) return { dryRun: false };
+  return { dryRun: true };
+}
+
+/**
+ * Resolve a momentum signal to (tokenIds, price). TRADE-02 always buys
+ * YES on a single binary market; the limit price is the snapshot
+ * midpoint at signal time. Time-in-force is GTC (resting limit) — the
+ * urgency is `normal`, not `immediate`.
+ */
+function resolveMomentumOrder(signal: TradeSignal): ResolvedOrder {
+  const meta = signal.metadata;
+  const yesTokenIdRaw = meta["yesTokenId"];
+  const noTokenIdRaw = meta["noTokenId"];
+  const entryPriceRaw = meta["entryPrice"];
+
+  const yesTokenId =
+    typeof yesTokenIdRaw === "string" && yesTokenIdRaw.length > 0
+      ? yesTokenIdRaw
+      : `${signal.market.market_id}:yes`;
+  const noTokenId =
+    typeof noTokenIdRaw === "string" && noTokenIdRaw.length > 0
+      ? noTokenIdRaw
+      : `${signal.market.market_id}:no`;
+  const price =
+    typeof entryPriceRaw === "number" ? entryPriceRaw : FALLBACK_PRICE;
+
+  return {
+    tokenIds: { yes: yesTokenId, no: noTokenId },
+    price,
+    timeInForce: "GTC",
+  };
+}
+
+/** Map a binary-market snapshot to the trade-momentum scan input. */
+function toMomentumSnapshot(s: {
+  conditionId: string;
+  question: string;
+  yesTokenId: string;
+  noTokenId: string;
+  yesPrice: number;
+  volume24h: number;
+  openInterest: number;
+  timeToCloseMs?: number;
+  timestampMs: number;
+}): TradeMomentumSnapshot {
+  // pmxt SDK does not surface `topWalletShare`; strategies that depend
+  // on the manipulation guard must layer an on-chain indexer.
+  const FAR_FUTURE_MS = 365 * 24 * 60 * 60 * 1000;
+  return {
+    conditionId: s.conditionId,
+    question: s.question,
+    yesTokenId: s.yesTokenId,
+    noTokenId: s.noTokenId,
+    midpoint: s.yesPrice,
+    volume: s.volume24h,
+    openInterest: s.openInterest,
+    topWalletShare: 0,
+    timeToCloseMs: s.timeToCloseMs ?? FAR_FUTURE_MS,
+    timestampMs: s.timestampMs,
+  };
+}
+
+/** Optional dependencies for `createEntryDeps`. */
+export interface CreateEntryDepsOptions {
+  allowance?: AllowanceClient;
+  /** Override the search query (defaults to `config.category` or empty). */
+  query?: string;
+}
+
+/** Build live executor + positions + scan adapters for the runner. */
+export function createEntryDeps(
+  flags: EntryFlags,
+  options: CreateEntryDepsOptions = {},
+): EntryDeps {
+  void flags;
+  const executor = createLiveExecutor({
+    resolveOrder: resolveMomentumOrder,
+    ...(options.allowance !== undefined ? { allowance: options.allowance } : {}),
+    allowanceThreshold: USDC_ALLOWANCE_THRESHOLD,
+    allowanceTarget: USDC_ALLOWANCE_TARGET,
+  });
+  const positions = createLivePositions();
+  const query =
+    options.query ?? DEFAULT_TRADE_MOMENTUM_CONFIG.category ?? "";
+  const scan: ScanDeps = {
+    fetchSnapshots: async (): Promise<TradeMomentumSnapshot[]> => {
+      const snapshots = await fetchBinaryMarketSnapshots(query);
+      return snapshots.map(toMomentumSnapshot);
+    },
+  };
+  return { scan, executor, positions };
+}
+
+/**
+ * `--live` start-up safety gate.
+ *
+ * Refuses to start when the running pmxt sidecar does not advertise
+ * `supportsTif`. TRADE-02 uses GTC limit orders; degrading to a market
+ * order would convert a passive entry into an aggressive taker.
+ */
+export async function assertLiveCapabilities(): Promise<void> {
+  const caps = await getCapabilities();
+  if (!caps.supportsTif) {
+    throw new Error(
+      "TRADE-02 --live: pmxt sidecar does not advertise GTC time-in-force " +
+        "support; refusing to run.",
     );
-    return { id: "dry-run", status: "simulated" };
-  },
-};
+  }
+}
 
-const emptyPortfolio: Portfolio = {
-  total_value: strategyConfig.bankroll,
-  positions: [],
-  daily_pnl: 0,
-};
+/** Build a live USDC allowance client from an injected `WalletStore`. */
+export async function buildLiveAllowanceClient(
+  wallet: WalletStore,
+): Promise<AllowanceClient | undefined> {
+  if (!wallet.hasWallet()) return undefined;
 
-const stubPositions: PositionDeps = {
-  async reconcile() {
-    return emptyPortfolio;
-  },
-  getPortfolio() {
-    return emptyPortfolio;
-  },
-};
+  let ownerAddress: string;
+  try {
+    ownerAddress = await wallet.getAddress();
+  } catch {
+    return undefined;
+  }
 
-const runner = createTradeMomentumRunner(
-  {
-    strategy: strategyConfig,
+  const rpcUrl =
+    process.env["POLYGON_RPC_URL"] ?? "https://polygon.drpc.org";
+
+  return createUsdcAllowanceClient({
+    ownerAddress,
+    spenderAddress: DEFAULT_ALLOWANCE_SPENDER,
+    usdcAddress: USDC_E_ADDRESS,
+    getProvider: async () => {
+      const { providers } = await import("ethers");
+      return new providers.JsonRpcProvider(rpcUrl);
+    },
+    getSigner: async () => {
+      const { Wallet, providers } = await import("ethers");
+      return new Wallet(
+        wallet.getPrivateKey(),
+        new providers.JsonRpcProvider(rpcUrl),
+      );
+    },
+  });
+}
+
+async function loadCanonWalletStore(): Promise<WalletStore> {
+  const specifier = "../../../cli/wallet-store.js";
+  const mod = (await import(/* @vite-ignore */ specifier)) as {
+    FileWalletStore: new () => WalletStore;
+  };
+  return new mod.FileWalletStore();
+}
+
+async function main(): Promise<void> {
+  const flags = parseEntryFlags(process.argv);
+  const pollIntervalMs = Number(process.env["POLL_INTERVAL_MS"]) || 30_000;
+
+  if (!flags.dryRun) {
+    await assertLiveCapabilities();
+  }
+
+  const wallet: WalletStore | undefined = flags.dryRun
+    ? undefined
+    : await loadCanonWalletStore();
+  const allowance =
+    wallet !== undefined ? await buildLiveAllowanceClient(wallet) : undefined;
+  const { scan, executor, positions } = createEntryDeps(
+    flags,
+    allowance !== undefined ? { allowance } : {},
+  );
+
+  const runnerConfig: TradeMomentumRunnerConfig = {
+    strategy: DEFAULT_TRADE_MOMENTUM_CONFIG,
     runner: {
       pollIntervalMs,
-      dryRun,
+      dryRun: flags.dryRun,
       baseDir: ".canon/execution",
       statePath: ".canon/state.json",
     },
-    maxConsecutiveLosses: 3,
-  },
-  {
-    scan: stubScan,
-    executor: stubExecutor,
-    positions: stubPositions,
-  },
-);
+    maxConsecutiveLosses: MAX_CONSECUTIVE_LOSSES,
+  };
 
-process.stdout.write(
-  `START TRADE-02 scanner (${dryRun ? "dry-run" : "live"}) ` +
-    `poll=${String(pollIntervalMs)}ms\n`,
-);
+  const runner = createTradeMomentumRunner(runnerConfig, {
+    scan,
+    executor,
+    positions,
+    log: (entry: ExecutionLogEntry) =>
+      appendEntry(".canon/execution", entry),
+  });
 
-runner.start().catch((err: unknown) => {
-  const msg = err instanceof Error ? err.message : String(err);
-  process.stdout.write(`SCAN_ERROR ${msg}\n`);
-  process.exitCode = 1;
-});
+  process.stdout.write(
+    `START TRADE-02 scanner (${flags.dryRun ? "dry-run" : "live"}) ` +
+      `poll=${String(pollIntervalMs)}ms\n`,
+  );
+
+  try {
+    await runner.start();
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stdout.write(`SCAN_ERROR ${msg}\n`);
+    process.exitCode = 1;
+  }
+}
+
+const entryArg = process.argv[1];
+const isMain =
+  entryArg !== undefined &&
+  import.meta.url === pathToFileURL(entryArg).href;
+
+if (isMain) {
+  void main();
+}

--- a/canon/templates/strategies/trade-momentum/entry.ts
+++ b/canon/templates/strategies/trade-momentum/entry.ts
@@ -237,16 +237,21 @@ async function main(): Promise<void> {
     : await loadCanonWalletStore();
   const allowance =
     wallet !== undefined ? await buildLiveAllowanceClient(wallet) : undefined;
+  // MOMENTUM_QUERY defaults to "NBA" — empty queries return the entire
+  // Polymarket market index (>60s) and were observed to hang the runner.
+  // Operators must pin a category for live or dry-run to be usable.
   const queryEnv = process.env["MOMENTUM_QUERY"];
-  const { scan, executor, positions } = createEntryDeps(
-    flags,
-    {
-      ...(allowance !== undefined ? { allowance } : {}),
-      ...(queryEnv !== undefined && queryEnv.length > 0
-        ? { query: queryEnv }
-        : {}),
-    },
-  );
+  const query =
+    queryEnv !== undefined && queryEnv.length > 0 ? queryEnv : "NBA";
+  const { scan, executor, positions } = createEntryDeps(flags, {
+    ...(allowance !== undefined ? { allowance } : {}),
+    query,
+  });
+
+  // Hard cap on submitted orders per process run — bounds blast radius
+  // when --live is set without operator hand-holding. Default 3.
+  const maxOrders = Number(process.env["MAX_ORDERS"]) || 3;
+  let submittedCount = 0;
 
   const runnerConfig: TradeMomentumRunnerConfig = {
     strategy: DEFAULT_TRADE_MOMENTUM_CONFIG,
@@ -259,9 +264,23 @@ async function main(): Promise<void> {
     maxConsecutiveLosses: MAX_CONSECUTIVE_LOSSES,
   };
 
+  // Wrap executor.submit to enforce the per-run max-orders cap.
+  const cappedExecutor: ExecutorDeps = {
+    submit: async (signal) => {
+      if (submittedCount >= maxOrders) {
+        process.stdout.write(
+          `MAX_ORDERS reached (${String(maxOrders)}) — skipping submit\n`,
+        );
+        return { id: "max-orders-skipped", status: "rejected" };
+      }
+      submittedCount += 1;
+      return executor.submit(signal);
+    },
+  };
+
   const runner = createTradeMomentumRunner(runnerConfig, {
     scan,
-    executor,
+    executor: cappedExecutor,
     positions,
     log: (entry: ExecutionLogEntry) =>
       appendEntry(".canon/execution", entry),
@@ -269,6 +288,7 @@ async function main(): Promise<void> {
 
   process.stdout.write(
     `START TRADE-02 scanner (${flags.dryRun ? "dry-run" : "live"}) ` +
+      `query=${query} max_orders=${String(maxOrders)} ` +
       `poll=${String(pollIntervalMs)}ms\n`,
   );
 

--- a/canon/templates/strategies/trade-momentum/entry.ts
+++ b/canon/templates/strategies/trade-momentum/entry.ts
@@ -237,9 +237,15 @@ async function main(): Promise<void> {
     : await loadCanonWalletStore();
   const allowance =
     wallet !== undefined ? await buildLiveAllowanceClient(wallet) : undefined;
+  const queryEnv = process.env["MOMENTUM_QUERY"];
   const { scan, executor, positions } = createEntryDeps(
     flags,
-    allowance !== undefined ? { allowance } : {},
+    {
+      ...(allowance !== undefined ? { allowance } : {}),
+      ...(queryEnv !== undefined && queryEnv.length > 0
+        ? { query: queryEnv }
+        : {}),
+    },
   );
 
   const runnerConfig: TradeMomentumRunnerConfig = {

--- a/canon/templates/strategies/trade-momentum/main.ts
+++ b/canon/templates/strategies/trade-momentum/main.ts
@@ -89,6 +89,8 @@ function buildTradeSignal(
     urgency: "normal",
     metadata: {
       entryPrice: snapshot.midpoint,
+      yesTokenId: snapshot.yesTokenId,
+      noTokenId: snapshot.noTokenId,
       exitTargetPrice: config.exitTargetPrice,
       deltaPrice: signalOutput.deltaPrice,
       volumePercentile: signalOutput.volumePercentile,


### PR DESCRIPTION
## Summary
- Wires arb-negrisk-buy, trade-momentum, fair-value, and mm-premium for live CLOB execution behind `--live`, mirroring the arb-binary pattern (parseEntryFlags, createEntryDeps with live executor + positions + scan, assertLiveCapabilities sidecar preflight, USDC allowance via WalletStore).
- Adds two reusable client helpers: `searchMultiOutcomeMarkets` (NegRisk candidate feed) and `fetchBinaryMarketSnapshots` (volume / OI / TTC enriched snapshots consumed by the three binary-market strategies).
- Threads `yesTokenId`/`noTokenId` into signal metadata so `resolveOrder` routes each leg to the correct CLOB token.

## Per-strategy notes
- **arb-negrisk-buy** (ARB-03): FOK multi-leg. SDK does not surface `neg_risk` yet; scan uses `outcomes>2` + Σ yes_ask < 1 confirmation.
- **trade-momentum** (TRADE-02): GTC limit buy YES. `topWalletShare` gated to 0 until an on-chain indexer is wired (manipulation guard is currently no-op).
- **fair-value** (IA-03): GTC limit buy YES or NO. NO leg uses `1 − marketPrice` (binary complement). Ships `NEUTRAL_MODEL` (confidence=0) so signals don't fire until operators inject a real `ProbabilityModel`.
- **mm-premium** (MINT-04): GTC sell limit at midpoint + offsetC for either leg. Live executor seam complete; full cycle (splitPosition + dual leg + 24h reconcile) is the follow-up, same pattern as `mint-01/cycle.ts`.

## Test plan
- [x] 51 new live-mode tests across the four strategies (`__tests__/entry.test.ts` in each).
- [x] Full suite: 534 passed, 7 skipped (was 496/7).
- [x] `tsc --noEmit` clean.
- [ ] Smoke each strategy in dry-run against a real sidecar before flipping any to `--live` with capital.

🤖 Generated with [Claude Code](https://claude.com/claude-code)