### PR TITLE
release: sync develop → main (3 demo fixes)

### DIFF
--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -235,14 +235,27 @@ mkdir -p docs
 cp strategies/<name>/strategy.md docs/strategy-<name>.md
 ```
 
-2. Copy the strategy's pre-built entry point to `src/main.ts`. Each strategy
-   directory includes an `entry.ts` that wires the real API clients, config
-   defaults, and runner deps — no generation needed:
+2. Copy the strategy's pre-built entry point to `src/main.ts` and rewrite
+   its relative imports for the new location. The template at
+   `strategies/<name>/entry.ts` uses `"../../*.js"` (two levels up to project
+   root) and `"./*.js"` (sibling files); from `src/main.ts` those need to
+   become `"../*.js"` and `"../strategies/<name>/*.js"` respectively.
+
+   Use this deterministic two-step transform — do **not** rely on the agent
+   to figure out path rewrites on the fly:
 
 ```bash
 mkdir -p src
-cp strategies/<name>/entry.ts src/main.ts
+NAME="<name>"  # the strategy you selected, e.g. "trade-momentum"
+sed -e 's|"\.\./\.\./|"\.\./|g' \
+    -e "s|\"\\./|\"\\.\\./strategies/${NAME}/|g" \
+    "strategies/${NAME}/entry.ts" > src/main.ts
 ```
+
+   The first expression rewrites `"../../"` → `"../"` (project-root paths
+   shift by one level when moving from `strategies/<name>/` to `src/`).
+   The second rewrites `"./"` → `"../strategies/<name>/"` (sibling
+   imports become explicit cross-directory imports).
 
 3. Copy the strategy's flow definition for the TUI pipeline diagram:
 

--- a/canon/templates/__tests__/integration.test.ts
+++ b/canon/templates/__tests__/integration.test.ts
@@ -80,7 +80,11 @@ describe("integration: read-only", () => {
   // fetchOrderBook
   // -------------------------------------------------------------------------
   describe("fetchOrderBook", () => {
-    it("returns bids and asks for a real token", async () => {
+    // Skipped: hardcoded `tokenId` references a market that has resolved on
+    // Polymarket; the sidecar now returns 404 ORDER_NOT_FOUND. Refresh the
+    // fixture (or query the sidecar for an active token at test start) before
+    // un-skipping.
+    it.skip("returns bids and asks for a real token", async () => {
       const book = await fetchOrderBook(tokenId);
 
       expect(book.tokenId).toBe(tokenId);

--- a/canon/templates/__tests__/live-positions.test.ts
+++ b/canon/templates/__tests__/live-positions.test.ts
@@ -36,9 +36,14 @@ vi.mock("../client-polymarket.js", () => ({
 
 let createLivePositions: () => PositionDeps;
 
+// All existing tests exercise the live SDK path (via mocks) and
+// therefore need WALLET_PRIVATE_KEY set so reconcile() does not
+// short-circuit to an empty portfolio. The no-wallet path has its own
+// dedicated describe block below where this env is explicitly unset.
 beforeEach(async () => {
   vi.clearAllMocks();
   vi.resetModules();
+  process.env["WALLET_PRIVATE_KEY"] = "0x" + "a".repeat(64);
   const mod = await import("../live-positions.js");
   createLivePositions = mod.createLivePositions;
 });
@@ -319,5 +324,40 @@ describe("createLivePositions.getOpenOrders", () => {
   it("returns empty array before first reconcile", () => {
     const deps = createLivePositions();
     expect(deps.getOpenOrders()).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-wallet short-circuit (dry-run path)
+// ---------------------------------------------------------------------------
+
+describe("createLivePositions.reconcile (no wallet)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    delete process.env["WALLET_PRIVATE_KEY"];
+    delete process.env["POLYMARKET_PRIVATE_KEY"];
+    const mod = await import("../live-positions.js");
+    createLivePositions = mod.createLivePositions;
+  });
+
+  it("returns empty portfolio without calling the SDK", async () => {
+    const deps = createLivePositions();
+    const portfolio = await deps.reconcile();
+    expect(portfolio.positions).toEqual([]);
+    expect(portfolio.total_value).toBe(0);
+    expect(portfolio.daily_pnl).toBe(0);
+    expect(mockFetchBalance).not.toHaveBeenCalled();
+    expect(mockFetchPositions).not.toHaveBeenCalled();
+    expect(mockFetchOpenOrders).not.toHaveBeenCalled();
+  });
+
+  it("does not throw even when SDK would reject with non-auth phrasing", async () => {
+    mockFetchOpenOrders.mockRejectedValue(
+      new Error("response.data is not iterable"),
+    );
+    const deps = createLivePositions();
+    await expect(deps.reconcile()).resolves.toBeDefined();
+    expect(mockFetchOpenOrders).not.toHaveBeenCalled();
   });
 });

--- a/canon/templates/live-positions.ts
+++ b/canon/templates/live-positions.ts
@@ -13,6 +13,7 @@ import {
   type OrderResponse,
   type Position as ClientPosition,
 } from "./client-polymarket.js";
+import { getWalletPrivateKey } from "./env.js";
 import type { Portfolio, Position } from "./types/RiskInterface.js";
 
 export interface PositionDeps {
@@ -63,6 +64,25 @@ export function createLivePositions(): PositionDeps {
   let openOrders: OrderResponse[] = [];
 
   async function reconcile(): Promise<Portfolio> {
+    // Short-circuit when no wallet private key is configured. Without
+    // creds, the SDK auth path can throw under several different error
+    // phrasings (e.g. "Authentication failed", "response.data is not
+    // iterable" from a malformed unauthed response) — string matching
+    // against any of them is fragile. Detecting the missing wallet
+    // upfront removes the entire class of error-phrasing surprises.
+    if (!getWalletPrivateKey()) {
+      if (!warnedNoCreds) {
+        warnedNoCreds = true;
+        process.stderr.write(
+          "[canon] portfolio reconcile skipped: no wallet credentials " +
+            "(dry-run mode). Set WALLET_PRIVATE_KEY for live portfolio.\n",
+        );
+      }
+      snapshot = emptyPortfolio();
+      openOrders = [];
+      return snapshot;
+    }
+
     let balances, clientPositions, orders;
     try {
       [balances, clientPositions, orders] = await Promise.all([

--- a/canon/templates/strategies/arb-binary/__tests__/entry.test.ts
+++ b/canon/templates/strategies/arb-binary/__tests__/entry.test.ts
@@ -104,6 +104,7 @@ let entry: EntryModule;
 beforeEach(async () => {
   vi.clearAllMocks();
   vi.resetModules();
+  process.env["WALLET_PRIVATE_KEY"] = "0x" + "a".repeat(64);
   mockGetCapabilities.mockImplementation(async () => ({ supportsTif: true }));
   entry = (await import("../entry.js")) as unknown as EntryModule;
 });

--- a/canon/templates/strategies/arb-negrisk-buy/__tests__/entry.test.ts
+++ b/canon/templates/strategies/arb-negrisk-buy/__tests__/entry.test.ts
@@ -76,6 +76,7 @@ let entry: EntryModule;
 beforeEach(async () => {
   vi.clearAllMocks();
   vi.resetModules();
+  process.env["WALLET_PRIVATE_KEY"] = "0x" + "a".repeat(64);
   mockGetCapabilities.mockImplementation(async () => ({ supportsTif: true }));
   entry = (await import("../entry.js")) as unknown as EntryModule;
 });

--- a/canon/templates/strategies/fair-value/__tests__/entry.test.ts
+++ b/canon/templates/strategies/fair-value/__tests__/entry.test.ts
@@ -59,6 +59,7 @@ let entry: EntryModule;
 beforeEach(async () => {
   vi.clearAllMocks();
   vi.resetModules();
+  process.env["WALLET_PRIVATE_KEY"] = "0x" + "a".repeat(64);
   mockGetCapabilities.mockImplementation(async () => ({ supportsTif: true }));
   entry = (await import("../entry.js")) as unknown as EntryModule;
 });

--- a/canon/templates/strategies/mm-premium/__tests__/entry.test.ts
+++ b/canon/templates/strategies/mm-premium/__tests__/entry.test.ts
@@ -61,6 +61,7 @@ let entry: EntryModule;
 beforeEach(async () => {
   vi.clearAllMocks();
   vi.resetModules();
+  process.env["WALLET_PRIVATE_KEY"] = "0x" + "a".repeat(64);
   mockGetCapabilities.mockImplementation(async () => ({ supportsTif: true }));
   entry = (await import("../entry.js")) as unknown as EntryModule;
 });

--- a/canon/templates/strategies/trade-momentum/__tests__/entry.test.ts
+++ b/canon/templates/strategies/trade-momentum/__tests__/entry.test.ts
@@ -67,6 +67,7 @@ let entry: EntryModule;
 beforeEach(async () => {
   vi.clearAllMocks();
   vi.resetModules();
+  process.env["WALLET_PRIVATE_KEY"] = "0x" + "a".repeat(64);
   mockGetCapabilities.mockImplementation(async () => ({ supportsTif: true }));
   entry = (await import("../entry.js")) as unknown as EntryModule;
 });


### PR DESCRIPTION
## Summary

3 fixes from tonight's demo prep, ready for stage:

- **\`f24d3140\`** — \`fix(canon-start)\`: rewrite \`entry.ts\` imports deterministically when copying to \`src/main.ts\`. Phase 5's bare \`cp\` left broken relative paths; agents had to notice the tsc failure and silently rewrite. Replaced with a two-line sed that produces the same result on the first try, no agent guesswork.
- **\`41ecc409\`** — \`fix(live-positions)\`: short-circuit \`reconcile()\` when no wallet env is present. The previous catch-and-string-match approach missed pmxtjs's \"response.data is not iterable\" rejection (a BadRequest wrapping a malformed unauthed response from \`fetchOpenOrders\`), causing SCAN_ERROR on every dry-run cycle. Detect missing wallet upfront and skip the SDK auth path entirely. Removes the entire class of error-phrasing surprises.
- **\`3670e16b\`** — \`test(integration)\`: skip the \`fetchOrderBook\` integration test that was hardcoded to a now-resolved Polymarket token (404 ORDER_NOT_FOUND). Refresh the fixture before un-skipping.

## Verified

- Full suite: 536 passed, 8 skipped (was 535 + 7 before fix #1's skip).
- Runtime smoke (\`tsx strategies/trade-momentum/entry.ts\` with no wallet env): clean \`SCAN Cycle N\` loop, no \`SCAN_ERROR\`, reconcile gracefully skipped, \`START\` line shows \`query=NBA max_orders=3\`.
- canon-start sed rewrite: produces a \`src/main.ts\` that compiles under \`tsc --noEmit\` in a real scaffolded project (verified against \`~/dega/test-trade\`).

## Test plan

- [x] CI checks (Lint hooks + Test hooks)
- [ ] Post-merge: \`/apply-core\` (or fresh agentic install from main) picks up the 3 fixes
- [ ] In a fresh \`mkdir foo && cd foo && claude && /canon-start\` session: scaffold runs, strategy phase offers trade-momentum, dry-run cycles complete with no SCAN_ERROR

🤖 Generated with [Claude Code](https://claude.com/claude-code)