### PR TITLE
fix(templates): drop "Cycle" wording from runner log strings

### DIFF
--- a/canon/templates/nba-momentum/src/runner.ts
+++ b/canon/templates/nba-momentum/src/runner.ts
@@ -9,8 +9,8 @@
  *
  * Stdout protocol — each line is tagged for dashboard parsing:
  *   START <message>       Runner started
- *   SCAN <message>        Cycle started, fetching data
- *   NO_EDGE <message>     Scan cycle complete, no opportunities
+ *   SCAN <message>        Iteration started, fetching data
+ *   NO_EDGE <message>     Scan iteration complete, no opportunities
  *   SIGNAL <message>      Mispricing detected (dry-run skip)
  *   SCAN_ERROR <message>  Scan cycle failed
  *   STOP <message>        Runner shutting down
@@ -203,7 +203,7 @@ async function runCycle(config: StrategyConfig): Promise<void> {
   cycleCount++;
   const ts = new Date().toISOString();
 
-  out("SCAN", `Cycle ${cycleCount} — fetching NBA futures...`);
+  out("SCAN", `#${cycleCount} — fetching NBA futures...`);
 
   // 1. Fetch championship outright odds from sportsbooks
   const events = await fetchOdds("basketball_nba_championship_winner");
@@ -255,7 +255,7 @@ async function runCycle(config: StrategyConfig): Promise<void> {
   // 4. Heartbeat if no signals
   if (cycleSignals === 0) {
     const reasoning =
-      `Cycle ${cycleCount} — ${teamOdds.length} teams, ` +
+      `#${cycleCount} — ${teamOdds.length} teams, ` +
       `${markets.length} markets, ${matchedCount} matched, no edges`;
 
     const entry: HeartbeatLogEntry = {
@@ -301,7 +301,7 @@ async function main(): Promise<void> {
   process.on("SIGINT", () => {
     out(
       "STOP",
-      `Shutting down — ${cycleCount} cycles, ` +
+      `Shutting down — ${cycleCount} iterations, ` +
         `${signalCount} signals, ${errorCount} errors`,
     );
     running = false;
@@ -322,7 +322,7 @@ async function main(): Promise<void> {
         reasoning: message,
       };
       appendLog(errorEntry);
-      out("SCAN_ERROR", `Cycle ${cycleCount} — ${message}`);
+      out("SCAN_ERROR", `#${cycleCount} — ${message}`);
     }
 
     if (running) {
@@ -332,7 +332,7 @@ async function main(): Promise<void> {
 
   out(
     "STOP",
-    `Runner stopped — ${cycleCount} cycles, ` +
+    `Runner stopped — ${cycleCount} iterations, ` +
       `${signalCount} signals, ${errorCount} errors`,
   );
 }

--- a/canon/templates/runner.ts
+++ b/canon/templates/runner.ts
@@ -240,7 +240,7 @@ export function createRunner(
   async function cycle(): Promise<void> {
     cycleCount++;
     updateFlow("scan", []);
-    out("SCAN", `Cycle ${String(cycleCount)}`);
+    out("SCAN", `#${String(cycleCount)}`);
 
     const portfolio = await deps.positions.reconcile();
 
@@ -257,7 +257,7 @@ export function createRunner(
     if (signals.length === 0) {
       out(
         "NO_EDGE",
-        `Cycle ${String(cycleCount)} — 0 signals, no edges`,
+        `#${String(cycleCount)} — 0 signals, no edges`,
       );
     }
 
@@ -275,7 +275,7 @@ export function createRunner(
     sigintHandler = () => {
       out(
         "STOP",
-        `Shutting down — ${String(cycleCount)} cycles, ` +
+        `Shutting down — ${String(cycleCount)} iterations, ` +
           `${String(signalCount)} signals, ${String(errorCount)} errors`,
       );
       stop();
@@ -290,7 +290,7 @@ export function createRunner(
           errorCount++;
           const message =
             err instanceof Error ? err.message : String(err);
-          out("SCAN_ERROR", `Cycle ${String(cycleCount)} — ${message}`);
+          out("SCAN_ERROR", `#${String(cycleCount)} — ${message}`);
           deps.log(
             logEntry("error", "runner", "", {
               error: message,


### PR DESCRIPTION
## Summary

User-visible runner logs were emitting the word "Cycle" (e.g. `SCAN Cycle 1`, `NO_EDGE Cycle 1 — 0 signals, no edges`). The event tag already conveys semantic; the iteration count is just a number. Drop the "Cycle"/"cycles" word from every user-visible log string in the two runner files.

Internal identifiers (`cycleCount`, `async function cycle()`, `runCycle`, `stage: "cycle"` in error context, `cycle:` typed JSON fields) are untouched — they don't reach the user.

## Files

- `canon/templates/runner.ts` — generic strategy poll loop (4 log strings)
- `canon/templates/nba-momentum/src/runner.ts` — strategy-specific poll loop (5 log strings + 1 doc-comment)

## Renames

| Before | After |
|--------|-------|
| `` `Cycle ${n}` `` | `` `#${n}` `` |
| `` `Cycle ${n} — 0 signals, no edges` `` | `` `#${n} — 0 signals, no edges` `` |
| `` `Cycle ${n} — ${message}` `` | `` `#${n} — ${message}` `` |
| `` `Shutting down — ${n} cycles, ...` `` | `` `Shutting down — ${n} iterations, ...` `` |
| `` `Runner stopped — ${n} cycles, ...` `` | `` `Runner stopped — ${n} iterations, ...` `` |
| `// SCAN <message> Cycle started, fetching data` | `// SCAN <message> Iteration started, fetching data` |

## Why direct to main

Hotfix-grade — purely string-content changes in user-facing logs, zero behavioral or interface changes. Same precedent as PR #284. Will sync back to develop after.

## Test plan

- [x] `pnpm exec vitest run` in `canon/templates` → 601 passed, 11 skipped, 0 failed
- [x] grep audit: zero user-visible "Cycle" or "cycles," strings remain in either runner file
- [x] No test assertions reference the renamed strings (only test-helper identifiers like `runOneCycle` use the word)

🤖 Generated with [Claude Code](https://claude.com/claude-code)