### PR TITLE
fix(templates): add @polymarket/builder-signing-sdk as direct dep

### DIFF
--- a/canon/templates/package.json
+++ b/canon/templates/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@polymarket/builder-relayer-client": "0.0.9",
+    "@polymarket/builder-signing-sdk": "0.0.8",
     "@polymarket/clob-client-v2": "^1.0.0",
     "axios": "^1.16.0",
     "ethers": "5.8.0",

--- a/canon/templates/pnpm-lock.yaml
+++ b/canon/templates/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@polymarket/builder-relayer-client':
         specifier: 0.0.9
         version: 0.0.9(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      '@polymarket/builder-signing-sdk':
+        specifier: 0.0.8
+        version: 0.0.8
       '@polymarket/clob-client-v2':
         specifier: ^1.0.0
         version: 1.0.2(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@6.0.6)


### PR DESCRIPTION
## Summary

`canon/templates/polymarket-onboard.ts:31` imports `BuilderConfig` from `@polymarket/builder-signing-sdk`, but the package was only present transitively via `@polymarket/builder-relayer-client`'s dependency tree. Under pnpm strict mode, transitive packages are not hoisted into a project's top-level `node_modules/`, so every fresh `/canon-start --live` scaffold dies with:

```
Error: Cannot find package '@polymarket/builder-signing-sdk' imported from /<project>/polymarket-onboard.ts
```

This is what just blew up `/canon-start --live` in a fresh test-live3 dir tonight.

## Fix

Declare `@polymarket/builder-signing-sdk` as a direct dependency pinned at `0.0.8` (the version that was already resolving transitively, so no semantic change) and refresh `pnpm-lock.yaml`. pnpm now hoists it into top-level `node_modules/` where the runtime import resolves.

## Test plan

- [x] `pnpm exec vitest run` in `canon/templates` → 601 passed, 11 skipped
- [x] `node_modules/@polymarket/builder-signing-sdk/` exists at the project root after `pnpm install` (verified locally in test-live3)
- [ ] Fresh-dir `/canon-start --live` end-to-end (running tonight)

## Why direct to main

Hotfix unblocking every fresh-scaffold demo. Same precedent as PR #284 (install procedure) and PR #285 (runner log rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)