### PR TITLE
fix(install): canon-cli launcher + post-install canon-templates link

### DIFF
--- a/commands/apply-core.md
+++ b/commands/apply-core.md
@@ -604,14 +604,49 @@ Write the agent discovery skills:
 Safe to overwrite — these are CLI source files and skills with no user
 customization.
 
-Then install dependencies and create the bin link:
+Then install dependencies. After `pnpm install`, two post-install steps
+are required because `canon-cli/package.json` declares
+`"canon-templates": "file:../templates"` — that path is relative to the
+**source repo** layout (`canon/cli` and `canon/templates` are siblings
+there), not the install layout where `canon-cli` lives at
+`~/.degacore/canon-cli/` and templates live at
+`~/.degacore/canon/templates/`. After install, `pnpm` resolves
+`file:../templates` to `~/.degacore/templates/` (a stale or absent dir),
+not the current templates we just laid down. Retarget the symlink so
+`import "canon-templates/<file>.js"` from `canon-cli` resolves to the
+real templates directory.
+
+Also, `canon-cli.ts`'s shebang is `#!/usr/bin/env tsx`, which requires
+`tsx` on global `PATH`. After `pnpm install`, `tsx` is only at
+`~/.degacore/canon-cli/node_modules/.bin/tsx`. So instead of symlinking
+the `.ts` directly, write a shell wrapper at `~/.degacore/bin/canon-cli`
+that explicitly invokes the local `tsx`.
+
 ```bash
 cd ~/.degacore/canon-cli && pnpm install
-chmod +x ~/.degacore/canon-cli/canon-cli.ts
-ln -sf ~/.degacore/canon-cli/canon-cli.ts ~/.degacore/bin/canon-cli
+
+# Retarget the canon-templates link to the actual templates dir installed
+# by Canon Bootstrap above. Idempotent — overwrites any prior link.
+trash ~/.degacore/canon-cli/node_modules/canon-templates 2>/dev/null || true
+ln -sf ~/.degacore/canon/templates ~/.degacore/canon-cli/node_modules/canon-templates
+
+# Also pnpm install the templates package so its own deps (e.g.
+# @polymarket/builder-signing-sdk) get hoisted into
+# ~/.degacore/canon/templates/node_modules/ where canon-cli's runtime
+# imports of canon-templates/polymarket-onboard.js can resolve them.
+cd ~/.degacore/canon/templates && pnpm install
+
+# Write a shell wrapper that uses the local tsx (canon-cli node_modules).
+cat > ~/.degacore/bin/canon-cli <<'WRAPPER'
+#!/bin/sh
+# Canon CLI launcher — runs canon-cli.ts via local tsx (installed by canon-cli package).
+exec "$HOME/.degacore/canon-cli/node_modules/.bin/tsx" "$HOME/.degacore/canon-cli/canon-cli.ts" "$@"
+WRAPPER
+chmod +x ~/.degacore/bin/canon-cli
 ```
 
-If `pnpm` is not available, fall back to `npm install`.
+If `pnpm` is not available, fall back to `npm install` (the wrapper and
+symlink steps are unchanged).
 
 Verify the install works:
 ```bash


### PR DESCRIPTION
## Summary

Fixes two install-procedure bugs that surfaced when running `/apply-core` fresh tonight after the procedure was restored in #284. Both issues silently broke every fresh install.

## Bug 1 — canon-cli launcher uses a `.ts` symlink

The procedure said `ln -sf canon-cli.ts ~/.degacore/bin/canon-cli`. But `canon-cli.ts`'s shebang is `#!/usr/bin/env tsx`, which requires `tsx` on global `PATH`. After `pnpm install`, `tsx` is only at `~/.degacore/canon-cli/node_modules/.bin/tsx` — not global. Result: `canon-cli --help` fails with `env: tsx: No such file or directory`.

**Fix:** write a shell wrapper that explicitly invokes the local `tsx`. Idempotent. Matches the launcher style the May 1 install was actually using.

```sh
#!/bin/sh
exec "$HOME/.degacore/canon-cli/node_modules/.bin/tsx" "$HOME/.degacore/canon-cli/canon-cli.ts" "$@"
```

## Bug 2 — `canon-templates` link resolves to wrong dir

`canon-cli/package.json` declares `"canon-templates": "file:../templates"`. That path works in the **source repo** where `canon/cli` and `canon/templates` are siblings. But in the install layout (`~/.degacore/canon-cli/` and `~/.degacore/canon/templates/`) they are NOT siblings — `pnpm` resolves `file:../templates` to `~/.degacore/templates/` (a stale April-18 dir from older installs, or absent).

Result: `canon-cli onboard` fails at runtime with `Cannot find package 'canon-templates/polymarket-onboard.js'` — exactly what blew up `/canon-start --live` tonight.

**Fix:** post-install, retarget the link to the actual installed templates directory:

```bash
trash ~/.degacore/canon-cli/node_modules/canon-templates 2>/dev/null || true
ln -sf ~/.degacore/canon/templates ~/.degacore/canon-cli/node_modules/canon-templates
```

Also run `pnpm install` inside `~/.degacore/canon/templates/` so its own dependencies (e.g. `@polymarket/builder-signing-sdk` from #286) get hoisted into a `node_modules/` where canon-cli's runtime imports of `canon-templates/polymarket-onboard.js` can resolve them.

## Note on the proper long-term fix for Bug 2

The cleanest source fix would be to install canon-cli at `~/.degacore/canon/cli/` instead of `~/.degacore/canon-cli/` so `file:../templates` resolves naturally to `~/.degacore/canon/templates/`. That requires changing bin paths and docs in many places — bigger restructuring, separate PR. The post-install retarget here is the minimal, mechanical fix that unblocks every fresh `/apply-core` run today.

## Test plan

- [x] Manually verified tonight against a freshly-trashed `~/.degacore/`:
  - [x] `canon-cli --help` runs (shell wrapper resolves tsx correctly)
  - [x] `canon-cli onboard --status` reaches `canon-templates/polymarket-onboard.js` via the retargeted symlink
  - [x] `~/.degacore/canon/templates/node_modules/@polymarket/builder-signing-sdk/` exists after templates pnpm install

## Why direct to main

Hotfix-grade. Same precedent as #284, #285, #286. Will sync develop ← main after all four land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)