### PR TITLE
feat(core): VERSION + CORE_VERSION.md + core-version.sh helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Canon scaffold (.canon/ directory): see `Canon_MVP_Technical_Roadmap.md` lines 5
 | `README.md` | Full reference guide — source of truth for all config explanations |
 | `DECISIONS.md` | Settled architecture decisions for Core + Canon |
 | `AGENTS.md` | Project-level agent configuration — single source of truth (this file) |
+| `VERSION` / `CORE_VERSION.md` | Core release version (single-line semver) and natural-language reference for how to read/compare it — see [`CORE_VERSION.md`](CORE_VERSION.md) |
 | `CLAUDE.md` | Shim — points agents to `AGENTS.md` (Claude Code auto-discovery) |
 | `GEMINI.md` | Shim — points agents to `AGENTS.md` (Gemini auto-discovery) |
 | `.cursorrules` | Shim — points agents to `AGENTS.md` (Cursor auto-discovery) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- `CORE_VERSION.md` — natural-language reference for where the version lives, how to read the installed/remote pair, and how the AI should answer "what core version am I on?" — 2026-05-05
+- `scripts/core-version.sh` — helper that prints `installed=<x>  latest=<y>  status=<up-to-date|behind|ahead|unknown>` by comparing `~/.degacore/VERSION` against the remote `main` `VERSION` (override with `DEGACORE_VERSION_FILE` / `DEGACORE_REMOTE_REPO`) — 2026-05-05
+
+### Changed
+- Install copies `VERSION` and `CORE_VERSION.md` to `~/.degacore/` and installs `scripts/core-version.sh` to `~/.degacore/scripts/`, so the running install records its release and the AI has the natural-language reference on hand — 2026-05-05
+
 ## [0.1.1] — 2026-05-04
 
 Live-mode template fixes uncovered during test-live-4. Strategies now

--- a/CORE_VERSION.md
+++ b/CORE_VERSION.md
@@ -1,0 +1,71 @@
+# Core Version
+
+DEGA Core ships with a single source-of-truth version file. This document
+explains where that version lives, how to read it, and how to tell whether
+the locally installed copy is up to date with the remote.
+
+## Where the version lives
+
+| Location | Role |
+|----------|------|
+| `VERSION` (repo root) | Source of truth on `DEGAorg/claude-code-config`. One line, semver (e.g. `0.1.1`). |
+| `~/.degacore/VERSION` | The version of Core that the running install is on. Written by `INSTALL.md` Phase 1 (`cp VERSION ~/.degacore/`). |
+
+The `VERSION` file at the repo root is the canonical source. The copy in
+`~/.degacore/` is a sentinel — it records which release the user installed.
+
+`0.1.0` is the baseline (first formal versioned release, 2026-05-04 — see
+`CHANGELOG.md`). Earlier installs predate the `VERSION` file and have no
+recorded version; treat those as "unknown" until the next install.
+
+## How to read it
+
+Local install:
+
+```bash
+cat ~/.degacore/VERSION
+```
+
+Remote (latest on `main`):
+
+```bash
+gh api -H 'Accept: application/vnd.github.raw' \
+  repos/DEGAorg/claude-code-config/contents/VERSION
+```
+
+Both together (with a status verdict):
+
+```bash
+bash scripts/core-version.sh
+# installed=0.1.1  latest=0.1.1  status=up-to-date
+```
+
+The helper reads `~/.degacore/VERSION` for installed and `gh api …` for
+latest, then compares the two as semver. Override the install path with
+`DEGACORE_VERSION_FILE`; override the remote with `DEGACORE_REMOTE_REPO`.
+Missing files, missing `gh`, or network failures degrade to `status=unknown`
+rather than aborting.
+
+## When the AI is asked about the version
+
+Questions like *"what core version am I on?"*, *"is there an update?"*,
+*"am I behind?"* map to:
+
+1. Run `bash ~/.degacore/scripts/core-version.sh` (or `scripts/core-version.sh` from the repo).
+2. Read the `installed`, `latest`, and `status` tokens it prints.
+3. Report the verdict in plain language.
+
+If `status=behind`, suggest `/core-update` (or re-running `INSTALL.md`,
+which is idempotent). If `status=ahead`, the user is on a development
+branch that has not yet shipped to `main`. If `status=unknown`, fall back
+to `cat ~/.degacore/VERSION` and explain why the remote read failed (no
+`gh`, no network, etc.).
+
+## How to update
+
+Re-run `INSTALL.md` from `DEGAorg/claude-code-config@main`. The installer
+is idempotent and brings every component to the latest `main` HEAD,
+including the `VERSION` and `CORE_VERSION.md` copies in `~/.degacore/`.
+Inside an AI session, `/core-update` (or natural language `update dega
+core`) is the same path with a SHA short-circuit on
+`~/.degacore/state/core-sha`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,9 +19,21 @@ visualization for agent activity). Follow both phases in order.
    - Ask the user which components to install
    - Fetch all selected files from GitHub
    - Install shared artifacts to `~/.degacore/`
+   - Copy `VERSION` and `CORE_VERSION.md` from the repo root to
+     `~/.degacore/` so the install records its release version and the
+     AI has the natural-language reference (`CORE_VERSION.md`) on hand
+     when asked "what core version am I on?" — see
+     [`CORE_VERSION.md`](CORE_VERSION.md)
    - Detect installed agents (Claude, Gemini, Codex)
    - Generate per-agent config (settings, commands, rules)
    - Self-install `/apply-core` so future updates work from any directory
+
+   Manual fallback (run from the repo root if Phase 1 is performed by hand):
+
+   ```bash
+   mkdir -p ~/.degacore
+   cp VERSION CORE_VERSION.md ~/.degacore/
+   ```
 
 ### Phase 2 — Install Canon TUI
 

--- a/commands/apply-core.md
+++ b/commands/apply-core.md
@@ -51,6 +51,9 @@ Files available:
 - `settings-template.json`
 - `scripts/log-server.py`
 - `scripts/statusline.sh`
+- `scripts/core-version.sh`
+- `VERSION`
+- `CORE_VERSION.md`
 - `dega-core.yaml`
 - `scripts/ralph-check.sh`
 - `scripts/ralph-loop.sh`
@@ -766,6 +769,38 @@ cp ~/.degacore/config/rules/*.md ~/.<agent>/rules/
 ```
 
 Same skip-and-warn handling: user files with the same name take precedence.
+
+---
+
+### 5b. Record the install version
+
+Copy the repo's `VERSION` and `CORE_VERSION.md` files to `~/.degacore/` so
+the install records which release it is on and the AI has the
+natural-language reference on hand when asked "what core version am I on?".
+
+Fetch and write each file:
+
+```
+https://raw.githubusercontent.com/DEGAorg/claude-code-config/main/VERSION
+https://raw.githubusercontent.com/DEGAorg/claude-code-config/main/CORE_VERSION.md
+```
+
+Write to `~/.degacore/VERSION` and `~/.degacore/CORE_VERSION.md`. Safe to
+overwrite — both files are installer-owned.
+
+Also install `scripts/core-version.sh` to `~/.degacore/scripts/core-version.sh`
+and `chmod +x` it. The helper prints
+`installed=<x>  latest=<y>  status=<up-to-date|behind|ahead|unknown>`
+by reading `~/.degacore/VERSION` and `gh api …/contents/VERSION`.
+
+After writing, run the helper as a sanity check:
+
+```bash
+bash ~/.degacore/scripts/core-version.sh
+```
+
+It should print `status=up-to-date` (or `unknown` if `gh` is not on PATH —
+that's fine, the install still succeeded).
 
 ---
 

--- a/scripts/core-version.sh
+++ b/scripts/core-version.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Print the installed core version, the latest version on the remote,
+# and the relative status: up-to-date, behind, or ahead.
+#
+# Output format:
+#   installed=<x.y.z>  latest=<x.y.z>  status=<up-to-date|behind|ahead|unknown>
+#
+# Sources:
+#   installed → ~/.degacore/VERSION (written during /apply-core)
+#   latest    → raw VERSION file on the remote default branch
+#
+# Network or filesystem failures yield the literal "unknown" rather than
+# aborting, so the script is safe to call from status banners.
+
+INSTALLED_VERSION_FILE="${DEGACORE_VERSION_FILE:-$HOME/.degacore/VERSION}"
+REMOTE_REPO="${DEGACORE_REMOTE_REPO:-DEGAorg/claude-code-config}"
+
+read_installed() {
+  if [[ -f "$INSTALLED_VERSION_FILE" ]]; then
+    tr -d '[:space:]' <"$INSTALLED_VERSION_FILE"
+  else
+    printf 'unknown'
+  fi
+}
+
+read_latest() {
+  if ! command -v gh >/dev/null 2>&1; then
+    printf 'unknown'
+    return
+  fi
+  local body
+  if body=$(gh api -H 'Accept: application/vnd.github.raw' \
+    "repos/${REMOTE_REPO}/contents/VERSION" 2>/dev/null); then
+    printf '%s' "$body" | tr -d '[:space:]'
+  else
+    printf 'unknown'
+  fi
+}
+
+# Compare two semver-ish strings. Echoes one of: up-to-date, behind, ahead, unknown.
+compare_versions() {
+  local installed=$1 latest=$2
+  if [[ "$installed" == "unknown" ]] || [[ "$latest" == "unknown" ]]; then
+    printf 'unknown'
+    return
+  fi
+  if [[ "$installed" == "$latest" ]]; then
+    printf 'up-to-date'
+    return
+  fi
+  local re='^[0-9]+\.[0-9]+\.[0-9]+$'
+  if [[ ! "$installed" =~ $re ]] || [[ ! "$latest" =~ $re ]]; then
+    printf 'unknown'
+    return
+  fi
+  local IFS=.
+  # shellcheck disable=SC2206
+  local i=($installed) l=($latest)
+  local idx
+  for idx in 0 1 2; do
+    if ((i[idx] < l[idx])); then
+      printf 'behind'
+      return
+    fi
+    if ((i[idx] > l[idx])); then
+      printf 'ahead'
+      return
+    fi
+  done
+  printf 'up-to-date'
+}
+
+main() {
+  local installed latest status
+  installed=$(read_installed)
+  latest=$(read_latest)
+  status=$(compare_versions "$installed" "$latest")
+  printf 'installed=%s  latest=%s  status=%s\n' "$installed" "$latest" "$status"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
Salvages the intent of #276 (which conflicts because `VERSION` already
shipped independently in 0.1.0 / 0.1.1) and lands the rest of the
work that was supposed to merge with it: the helper script, the
natural-language reference, and the install wiring.

## Summary

- `scripts/core-version.sh` — prints
  `installed=<x>  latest=<y>  status=<up-to-date|behind|ahead|unknown>`
  by reading `~/.degacore/VERSION` and comparing to the remote
  `main` VERSION via `gh api`. Failures degrade to `status=unknown`
  rather than aborting.
- `CORE_VERSION.md` — natural-language reference for where the version
  lives, how to read installed vs remote, and how the AI should
  answer "what core version am I on?". `0.1.0` floor (the actual
  baseline) instead of #276's `0.6.0` placeholder.
- `INSTALL.md` Phase 1 + `commands/apply-core.md` (new Step 5b) —
  install copies `VERSION`, `CORE_VERSION.md`, and
  `scripts/core-version.sh` to `~/.degacore/`. Future `/apply-core`
  and `/core-update` runs pick this up automatically.
- `AGENTS.md` — repo-map row pointing at `VERSION` / `CORE_VERSION.md`.
- `CHANGELOG.md` `[Unreleased]` — records the additions.

Closes #275 and supersedes #276 (which can be closed once this lands).

## Test plan

- [x] `shellcheck -e SC1091 -S warning scripts/core-version.sh` exits 0
- [x] `shfmt -i 2 -d scripts/core-version.sh` exits 0
- [x] Helper runs against the live install:
      `installed=0.1.1  latest=0.1.1  status=up-to-date`
- [x] `INSTALL.md` Phase 1 / `commands/apply-core.md` Step 5b applied
      manually to confirm `~/.degacore/VERSION`,
      `~/.degacore/CORE_VERSION.md`, and
      `~/.degacore/scripts/core-version.sh` land correctly.
- [ ] Run `/core-update` from a fresh shell to confirm the helper
      installs end-to-end via the canonical update path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)