### PR TITLE
fix(orch): inject Homebrew/local paths into verify subshell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Install copies `VERSION` and `CORE_VERSION.md` to `~/.degacore/` and installs `scripts/core-version.sh` to `~/.degacore/scripts/`, so the running install records its release and the AI has the natural-language reference on hand — 2026-05-05
 
+### Fixed
+- `scripts/orch-verify.sh` now prepends `/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin` to the `bash -c` subshell's PATH so `rg`, `yq`, `fd` resolve under tmux/launchd subshells where Homebrew is otherwise stripped from `$PATH`. Override the prefix via `ORCH_VERIFY_PATH_PREFIX` (used by tests). Adds `tests/orch/test_verify_path.bats` regression coverage — 2026-05-05
+
 ## [0.1.1] — 2026-05-04
 
 Live-mode template fixes uncovered during test-live-4. Strategies now

--- a/scripts/orch-verify.sh
+++ b/scripts/orch-verify.sh
@@ -172,8 +172,13 @@ for line in "${UNCHECKED_LINES[@]}"; do
 
   log "RUN: ${cmd}"
 
+  # Prepend Homebrew/local paths so rg, yq, fd, etc. resolve in the
+  # bash -c subshell even when the inherited PATH is stripped (e.g. tmux
+  # subshells under launchd lose Homebrew). Override via
+  # ORCH_VERIFY_PATH_PREFIX in tests.
+  VERIFY_PATH_PREFIX="${ORCH_VERIFY_PATH_PREFIX:-/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin}"
   set +e
-  output=$(cd "${VERIFY_CWD}" && timeout "${CRITERION_TIMEOUT}" bash -c "${cmd}" 2>&1)
+  output=$(cd "${VERIFY_CWD}" && PATH="${VERIFY_PATH_PREFIX}:${PATH}" timeout "${CRITERION_TIMEOUT}" bash -c "${cmd}" 2>&1)
   rc=$?
   set -e
 

--- a/tests/orch/test_verify_path.bats
+++ b/tests/orch/test_verify_path.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+#
+# Regression test for orch-verify.sh PATH injection.
+#
+# Forensics: when orch-verify runs criterion commands via `bash -c`,
+# the subshell inherits whatever PATH the parent has. Under tmux/launchd
+# the parent PATH may lack Homebrew dirs, so commands like `rg`, `yq`,
+# `fd` fail to resolve and the criterion is incorrectly marked failed.
+# Fix: prepend `/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin:` to
+# PATH inside the `bash -c` subshell. The prefix is overridable via
+# ORCH_VERIFY_PATH_PREFIX so this test can point it at a tmpdir
+# fixture binary instead of mutating the host's /opt/homebrew/bin.
+
+setup() {
+  TEST_TMP="$(mktemp -d -t orch-verify-path-XXXXXX)"
+  export TEST_TMP
+  REPO_ROOT_REAL="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  export REPO_ROOT_REAL
+
+  # Fixture: a binary under a /opt/homebrew/bin-shaped tmpdir. The
+  # fixture dir is NOT in the parent PATH, so the criterion can only
+  # resolve when orch-verify.sh injects it via ORCH_VERIFY_PATH_PREFIX.
+  FIXTURE_BIN_DIR="${TEST_TMP}/opt/homebrew/bin"
+  mkdir -p "${FIXTURE_BIN_DIR}"
+  cat >"${FIXTURE_BIN_DIR}/fixture-tool" <<'SH'
+#!/bin/sh
+echo fixture-ok
+exit 0
+SH
+  chmod +x "${FIXTURE_BIN_DIR}/fixture-tool"
+  export FIXTURE_BIN_DIR
+
+  SLUG="path-test"
+  export SLUG
+  STATE_DIR="${TEST_TMP}/.orchestrator"
+  PLAN_DIR="${STATE_DIR}/worktrees/${SLUG}/.orchestrator/plans/${SLUG}"
+  STATE_PLAN_DIR="${STATE_DIR}/plans/${SLUG}"
+  mkdir -p "${PLAN_DIR}" "${STATE_PLAN_DIR}/logs"
+  export PLAN_DIR
+
+  cat >"${PLAN_DIR}/plan.md" <<'MD'
+# Synthetic plan
+
+## Completion criteria
+
+- [ ] `fixture-tool` exits 0
+MD
+
+  cat >"${STATE_PLAN_DIR}/state.json" <<'JSON'
+{
+  "verification": {"status": "pending", "uncheckedCount": 0, "iteration": 0},
+  "updatedAt": ""
+}
+JSON
+}
+
+teardown() {
+  if [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]]; then
+    rm -rf "${TEST_TMP}"
+  fi
+}
+
+@test "orch-verify resolves criterion via injected PATH prefix and marks [x]" {
+  run env \
+    ORCH_VERIFY_PATH_PREFIX="${FIXTURE_BIN_DIR}" \
+    ORCH_STATE_DIR="${TEST_TMP}/.orchestrator" \
+    ORCH_REPO_ROOT="${TEST_TMP}" \
+    GH_SYNC=true \
+    bash "${REPO_ROOT_REAL}/scripts/orch-verify.sh" "${SLUG}"
+  [ "${status}" -eq 0 ]
+
+  # Criterion must be flipped to [x] in the plan
+  run grep -F -- '- [x] `fixture-tool` exits 0' "${PLAN_DIR}/plan.md"
+  [ "${status}" -eq 0 ]
+}
+
+@test "orch-verify fails when prefix does not contain the fixture" {
+  # No prefix override → defaults to /opt/homebrew/bin etc., which does
+  # not contain fixture-tool. Criterion stays unchecked, exit 1.
+  run env \
+    ORCH_VERIFY_PATH_PREFIX="/nonexistent-prefix-dir" \
+    ORCH_STATE_DIR="${TEST_TMP}/.orchestrator" \
+    ORCH_REPO_ROOT="${TEST_TMP}" \
+    GH_SYNC=true \
+    bash "${REPO_ROOT_REAL}/scripts/orch-verify.sh" "${SLUG}"
+  [ "${status}" -ne 0 ]
+
+  run grep -F -- '- [ ] `fixture-tool` exits 0' "${PLAN_DIR}/plan.md"
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
Salvages the only landable code change from #257 — the PATH fix +
bats test. The cleanup-report docs in #257 (`docs/cleanup-reports/*`)
are stale 2026-04-28 release artifacts that 0.1.0 shipped without,
so they're dropped.

## Summary

`scripts/orch-verify.sh` runs each criterion command via `bash -c`,
which inherits the parent's PATH. Under tmux subshells launched
from launchd (the orchestrator's normal runtime), Homebrew dirs
are stripped from PATH, so `rg`, `yq`, `fd`, etc. fail to resolve
and verify marks otherwise-passing criteria as failed.

- Prepend `/opt/homebrew/bin:/usr/local/bin:/usr/local/sbin` to the
  subshell PATH. Override via `ORCH_VERIFY_PATH_PREFIX` (tests use
  this).
- Add `tests/orch/test_verify_path.bats` — fixture binary outside
  the parent PATH; asserts the criterion resolves only when the
  prefix is injected, and that pointing the prefix elsewhere
  correctly fails.

Memory note: this resolves the "subshell PATH still lacks rg/yq/fd,
but advisory default makes it not gate" caveat from the 0.1.0
release record. Verify is no longer a noisy gate even when operators
flip `verify.mode=enforce`.

## Test plan

- [x] `shellcheck -e SC1091 -S warning scripts/orch-verify.sh` exits 0
- [x] `shfmt -i 2 -d scripts/orch-verify.sh` exits 0
- [x] `bats tests/orch/*.bats` — 57/57 pass (55 pre-existing + 2 new)
- [ ] Run a real plan through the orchestrator with
      `verify.mode=enforce` and confirm criteria using `rg`/`yq`/`fd`
      pass instead of being marked failed-by-resolve.

Closes #252 and supersedes #257 (which can be closed once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)