### PR TITLE
test(orch): handshake bats + repeatable live test for notification hooks

### DIFF
--- a/docs/orch-agent-notifications.md
+++ b/docs/orch-agent-notifications.md
@@ -75,3 +75,43 @@ Remove the `01-orch-notify.sh` entry from the `hooks.Stop` array in
 will keep writing files for Canon TUI to consume, but the agent will
 no longer be auto-notified at Stop time. To also stop writing files,
 remove `02-agent-notify.sh` from the orch lifecycle hooks directory.
+
+## Testing
+
+Three layers of test coverage live alongside the hooks:
+
+| Test                                       | What it covers                                                                 |
+|--------------------------------------------|-------------------------------------------------------------------------------|
+| `tests/orch/test_notify_lifecycle.bats`    | Lifecycle hook in isolation: schema, value mapping for the `ship` event.       |
+| `tests/orch/test_notify_stop_hook.bats`    | Stop hook in isolation: block-JSON output, idempotency, no-op without dir.     |
+| `tests/orch/test_notify_handshake.bats`    | Both hooks against a shared fixture: catches schema drift between the pair.    |
+
+A wrapper script bundles the bats run and provides setup/teardown for
+the live Claude Code integration check that bats cannot perform on its
+own:
+
+```bash
+bash scripts/test-orch-notify-live.sh unit       # run all three bats files
+bash scripts/test-orch-notify-live.sh setup      # wire stop hook + seed notification
+bash scripts/test-orch-notify-live.sh status     # inspect current state
+bash scripts/test-orch-notify-live.sh teardown   # restore settings + remove fixtures
+```
+
+`setup` writes its changes to this repo's `.claude/settings.local.json`
+(gitignored) and seeds a fake notification under `.orchestrator/`. After
+running `setup`:
+
+1. Exit your Claude Code session (`/exit`) and open a new one in this
+   repo so the new hook entry is loaded.
+2. Send a trivial prompt, let it answer, end the turn.
+3. The next turn should open with a system-reminder citing the seeded
+   plan slug and PR url.
+
+When the integration check is done, run `teardown` to restore
+`.claude/settings.local.json` from the backup and delete the seeded
+fixture files.
+
+This is the recommended pre-release validation any time
+`hooks/orch-lifecycle/02-agent-notify.sh` or
+`hooks/stop/01-orch-notify.sh` change, before the develop → main
+release PR.

--- a/scripts/test-orch-notify-live.sh
+++ b/scripts/test-orch-notify-live.sh
@@ -98,8 +98,8 @@ cmd_setup() {
 }
 JSON
 
-  ( cd "${REPO_ROOT}" && \
-    bash "${LIFECYCLE_HOOK}" ship "${SLUG}" --items 1 --passed 1 --elapsed 1s )
+  (cd "${REPO_ROOT}" &&
+    bash "${LIFECYCLE_HOOK}" ship "${SLUG}" --items 1 --passed 1 --elapsed 1s)
 
   cat <<EOF
 
@@ -148,7 +148,7 @@ cmd_status() {
   echo "settings:  ${SETTINGS_FILE}"
   if [[ -f "${SETTINGS_FILE}" ]] && command -v jq >/dev/null 2>&1; then
     if jq -e '.hooks.Stop // [] | map(.hooks[]?.command // "") | any(. | contains("01-orch-notify.sh"))' \
-       "${SETTINGS_FILE}" >/dev/null 2>&1; then
+      "${SETTINGS_FILE}" >/dev/null 2>&1; then
       echo "  Stop hook wired:   yes"
     else
       echo "  Stop hook wired:   no"
@@ -176,13 +176,25 @@ cmd_status() {
 }
 
 case "${1:-}" in
-  unit)     shift; cmd_unit "$@" ;;
-  setup)    shift; cmd_setup "$@" ;;
-  teardown) shift; cmd_teardown "$@" ;;
-  status)   shift; cmd_status "$@" ;;
-  -h | --help | "") usage 0 ;;
-  *)
-    echo "error: unknown subcommand '$1'" >&2
-    usage 1
-    ;;
+unit)
+  shift
+  cmd_unit "$@"
+  ;;
+setup)
+  shift
+  cmd_setup "$@"
+  ;;
+teardown)
+  shift
+  cmd_teardown "$@"
+  ;;
+status)
+  shift
+  cmd_status "$@"
+  ;;
+-h | --help | "") usage 0 ;;
+*)
+  echo "error: unknown subcommand '$1'" >&2
+  usage 1
+  ;;
 esac

--- a/scripts/test-orch-notify-live.sh
+++ b/scripts/test-orch-notify-live.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# test-orch-notify-live.sh — repeatable end-to-end test for the orch
+# agent-notification hooks.
+#
+# Subcommands:
+#   unit      Run the bats unit + handshake tests for both hooks.
+#   setup     Wire the Stop hook into THIS repo's .claude/settings.local.json
+#             (gitignored, scoped to this dir) and seed an unseen notification
+#             so the next Claude Code Stop event surfaces it as an agent-bump.
+#   teardown  Reverse `setup`: restore .claude/settings.local.json and remove
+#             the seeded plan + notification files.
+#   status    Show what the script sees: hook entry presence, notification
+#             files in flight, settings backup file.
+#
+# Designed for the manual integration test described in
+# docs/orch-agent-notifications.md ("Testing"). The unit subcommand should
+# pass on every PR; the setup/teardown pair is for human-in-loop verification
+# that Claude Code actually surfaces the Stop-hook output as a system-reminder.
+
+set -euo pipefail
+
+SLUG="20260506-orch-notify-live-test"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SETTINGS_FILE="${REPO_ROOT}/.claude/settings.local.json"
+SETTINGS_BACKUP="${SETTINGS_FILE}.test-orch-notify.bak"
+PLAN_DIR="${REPO_ROOT}/.orchestrator/plans/${SLUG}"
+NOTIF_FILE="${REPO_ROOT}/.orchestrator/notifications/${SLUG}.json"
+LIFECYCLE_HOOK="${REPO_ROOT}/hooks/orch-lifecycle/02-agent-notify.sh"
+
+usage() {
+  sed -n '2,18p' "$0" | sed 's/^# \?//'
+  exit "${1:-0}"
+}
+
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "error: jq is required" >&2
+    exit 1
+  fi
+}
+
+cmd_unit() {
+  if ! command -v bats >/dev/null 2>&1; then
+    echo "error: bats is required (brew install bats-core)" >&2
+    exit 1
+  fi
+  cd "${REPO_ROOT}"
+  bats tests/orch/test_notify_lifecycle.bats \
+    tests/orch/test_notify_stop_hook.bats \
+    tests/orch/test_notify_handshake.bats
+}
+
+cmd_setup() {
+  require_jq
+
+  if [[ -e "${SETTINGS_BACKUP}" ]]; then
+    echo "error: backup already exists at ${SETTINGS_BACKUP}" >&2
+    echo "       run '$0 teardown' first or delete the backup manually" >&2
+    exit 1
+  fi
+
+  # Backup current settings (or stub an empty {} if absent).
+  if [[ -f "${SETTINGS_FILE}" ]]; then
+    cp "${SETTINGS_FILE}" "${SETTINGS_BACKUP}"
+  else
+    mkdir -p "$(dirname "${SETTINGS_FILE}")"
+    echo '{}' >"${SETTINGS_FILE}"
+    echo '{}' >"${SETTINGS_BACKUP}"
+  fi
+
+  # Add the Stop hook entry. The full path keeps the hook runnable even if
+  # CLAUDE_PROJECT_DIR is set to something other than the repo root.
+  local hook_cmd="bash ${REPO_ROOT}/hooks/stop/01-orch-notify.sh"
+  local tmp="${SETTINGS_FILE}.tmp.$$"
+  jq --arg cmd "${hook_cmd}" '
+    .hooks //= {} |
+    .hooks.Stop //= [] |
+    .hooks.Stop += [{
+      "matcher": "",
+      "hooks": [{ "type": "command", "command": $cmd }]
+    }]
+  ' "${SETTINGS_FILE}" >"${tmp}"
+  mv "${tmp}" "${SETTINGS_FILE}"
+
+  # Seed a fake plan + notification so the next Stop event has something
+  # to surface. Use the lifecycle hook itself so the file format is real.
+  mkdir -p "${PLAN_DIR}"
+  cat >"${PLAN_DIR}/state.json" <<JSON
+{
+  "slug": "${SLUG}",
+  "issueNumber": 0,
+  "status": "completed",
+  "finalReview": {
+    "decision": "SHIP",
+    "prUrl": "https://example.invalid/test/pr/0",
+    "prNumber": 0
+  }
+}
+JSON
+
+  ( cd "${REPO_ROOT}" && \
+    bash "${LIFECYCLE_HOOK}" ship "${SLUG}" --items 1 --passed 1 --elapsed 1s )
+
+  cat <<EOF
+
+Setup complete.
+
+Wired:    Stop hook in ${SETTINGS_FILE}
+Backup:   ${SETTINGS_BACKUP}
+Seeded:   ${NOTIF_FILE}
+
+Next steps to confirm Claude Code surfaces the agent-bump:
+
+  1. Exit this Claude Code session (/exit) and open a new one in:
+     ${REPO_ROOT}
+  2. Ask anything trivial ("what's 2+2?") and let it answer.
+  3. End that turn (just send another message).
+  4. The next turn should open with a system-reminder containing
+     "${SLUG}" and "PR: https://example.invalid/test/pr/0".
+
+When done, run:
+  bash $0 teardown
+EOF
+}
+
+cmd_teardown() {
+  if [[ -f "${SETTINGS_BACKUP}" ]]; then
+    mv "${SETTINGS_BACKUP}" "${SETTINGS_FILE}"
+    echo "restored: ${SETTINGS_FILE}"
+  else
+    echo "warn: no backup found at ${SETTINGS_BACKUP} — settings.local.json left as-is" >&2
+  fi
+
+  if [[ -f "${NOTIF_FILE}" ]]; then
+    rm -f "${NOTIF_FILE}"
+    echo "removed:  ${NOTIF_FILE}"
+  fi
+
+  if [[ -d "${PLAN_DIR}" ]]; then
+    rm -rf "${PLAN_DIR}"
+    echo "removed:  ${PLAN_DIR}"
+  fi
+
+  echo "teardown complete."
+}
+
+cmd_status() {
+  echo "settings:  ${SETTINGS_FILE}"
+  if [[ -f "${SETTINGS_FILE}" ]] && command -v jq >/dev/null 2>&1; then
+    if jq -e '.hooks.Stop // [] | map(.hooks[]?.command // "") | any(. | contains("01-orch-notify.sh"))' \
+       "${SETTINGS_FILE}" >/dev/null 2>&1; then
+      echo "  Stop hook wired:   yes"
+    else
+      echo "  Stop hook wired:   no"
+    fi
+  fi
+
+  if [[ -f "${SETTINGS_BACKUP}" ]]; then
+    echo "  backup present:    yes (${SETTINGS_BACKUP})"
+  else
+    echo "  backup present:    no"
+  fi
+
+  echo
+  echo "test plan dir: ${PLAN_DIR}"
+  [[ -d "${PLAN_DIR}" ]] && echo "  exists" || echo "  absent"
+
+  echo
+  echo "notification file: ${NOTIF_FILE}"
+  if [[ -f "${NOTIF_FILE}" ]]; then
+    echo "  exists, contents:"
+    jq . "${NOTIF_FILE}" 2>/dev/null | sed 's/^/    /'
+  else
+    echo "  absent"
+  fi
+}
+
+case "${1:-}" in
+  unit)     shift; cmd_unit "$@" ;;
+  setup)    shift; cmd_setup "$@" ;;
+  teardown) shift; cmd_teardown "$@" ;;
+  status)   shift; cmd_status "$@" ;;
+  -h | --help | "") usage 0 ;;
+  *)
+    echo "error: unknown subcommand '$1'" >&2
+    usage 1
+    ;;
+esac

--- a/tests/orch/test_notify_handshake.bats
+++ b/tests/orch/test_notify_handshake.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+#
+# End-to-end handshake test for the orch agent-notification hooks.
+#
+# The unit tests for the lifecycle hook (test_notify_lifecycle.bats) and the
+# Stop hook (test_notify_stop_hook.bats) each use their own isolated fixture.
+# That leaves a gap: a schema drift between what the lifecycle hook writes
+# and what the Stop hook expects to read would not be caught.
+#
+# This test runs both hooks against a single shared fixture in sequence:
+#   1. Lifecycle hook writes the notification (`ship` event).
+#   2. Stop hook reads it, emits block JSON, marks it seen.
+#   3. Stop hook re-runs and produces no output (idempotency end-to-end).
+#
+# If the file format ever drifts between the two scripts, this test fails.
+
+REPO_ROOT_REAL="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+LIFECYCLE_HOOK="${REPO_ROOT_REAL}/hooks/orch-lifecycle/02-agent-notify.sh"
+STOP_HOOK="${REPO_ROOT_REAL}/hooks/stop/01-orch-notify.sh"
+
+setup() {
+  TEST_TMP="$(mktemp -d -t orch-notify-handshake-XXXXXX)"
+  export TEST_TMP
+  export CLAUDE_PROJECT_DIR="${TEST_TMP}"
+
+  SLUG="handshake-plan"
+  export SLUG
+
+  PLAN_DIR="${TEST_TMP}/.orchestrator/plans/${SLUG}"
+  NOTIF_DIR="${TEST_TMP}/.orchestrator/notifications"
+  mkdir -p "${PLAN_DIR}"
+  export PLAN_DIR
+  export NOTIF_DIR
+
+  cat >"${PLAN_DIR}/state.json" <<'JSON'
+{
+  "slug": "handshake-plan",
+  "issueNumber": 777,
+  "status": "completed",
+  "finalReview": {
+    "decision": "SHIP",
+    "prUrl": "https://github.com/DEGAorg/claude-code-config/pull/777",
+    "prNumber": 777
+  }
+}
+JSON
+}
+
+teardown() {
+  if [[ -n "${TEST_TMP:-}" && -d "${TEST_TMP}" ]]; then
+    rm -rf "${TEST_TMP}"
+  fi
+}
+
+@test "lifecycle ship → stop hook surfaces the notification end-to-end" {
+  cd "${TEST_TMP}"
+
+  # 1. Lifecycle hook produces the notification.
+  run bash "${LIFECYCLE_HOOK}" ship "${SLUG}" --items 6 --passed 6 --elapsed 8m
+  [ "${status}" -eq 0 ]
+  [ -f "${NOTIF_DIR}/${SLUG}.json" ]
+
+  # 2. Stop hook consumes the file and emits valid block JSON.
+  run bash "${STOP_HOOK}" </dev/null
+  [ "${status}" -eq 0 ]
+  [ -n "${output}" ]
+
+  printf '%s' "${output}" | jq -e '.decision == "block"' >/dev/null
+  printf '%s' "${output}" | jq -e '.reason | type == "string" and length > 0' >/dev/null
+
+  # The reason must reference the slug AND the PR url that the lifecycle
+  # hook persisted from state.json — proving the schema contract holds.
+  printf '%s' "${output}" | jq -e --arg slug "${SLUG}" '.reason | contains($slug)' >/dev/null
+  printf '%s' "${output}" | jq -e '.reason | contains("pull/777")' >/dev/null
+
+  # 3. Notification is now marked seen.
+  run jq -e '.seen == true' "${NOTIF_DIR}/${SLUG}.json"
+  [ "${status}" -eq 0 ]
+
+  # 4. Second Stop hook run is silent (no double-injection).
+  run bash "${STOP_HOOK}" </dev/null
+  [ "${status}" -eq 0 ]
+  [ -z "${output}" ]
+}
+
+@test "lifecycle verify-failed → stop hook surfaces the failure" {
+  cd "${TEST_TMP}"
+
+  # Replace state.json with a verify-failed fixture.
+  cat >"${PLAN_DIR}/state.json" <<'JSON'
+{
+  "slug": "handshake-plan",
+  "issueNumber": 777,
+  "status": "in_progress",
+  "verification": {
+    "status": "failed",
+    "uncheckedCount": 3
+  }
+}
+JSON
+
+  run bash "${LIFECYCLE_HOOK}" verify "${SLUG}"
+  [ "${status}" -eq 0 ]
+  [ -f "${NOTIF_DIR}/${SLUG}.json" ]
+
+  run jq -e '.status == "failed"' "${NOTIF_DIR}/${SLUG}.json"
+  [ "${status}" -eq 0 ]
+
+  run bash "${STOP_HOOK}" </dev/null
+  [ "${status}" -eq 0 ]
+  printf '%s' "${output}" | jq -e '.decision == "block"' >/dev/null
+  printf '%s' "${output}" | jq -e '.reason | contains("failed")' >/dev/null
+}


### PR DESCRIPTION
## Summary

Adds a third bats file plus a wrapper script so the orch agent-notification
hooks (lifecycle + Stop) can be validated end-to-end without cutting a
release. Closes a coverage gap and turns Phase 4 (live Claude Code
integration check) into two scripted commands.

### What's new

| File | Role |
|------|------|
| `tests/orch/test_notify_handshake.bats` | Two new tests that run the lifecycle hook **and** the Stop hook against a single shared fixture (ship + verify-failed). Catches schema drift between the two scripts that the per-hook tests would miss. |
| `scripts/test-orch-notify-live.sh` | Wrapper with `unit` / `setup` / `status` / `teardown` subcommands. `setup` writes the Stop hook entry into this repo's `.claude/settings.local.json` (gitignored), seeds an unseen notification via the real lifecycle hook, and prints next steps. `teardown` restores from a backup and removes the seeded fixtures. |
| `docs/orch-agent-notifications.md` | New **Testing** section: 3-test taxonomy table + the live-test workflow. |

### Why a wrapper script

The two existing bats files (#260) cover each hook in isolation with its own
fixture. That leaves a schema-drift gap between what the lifecycle hook
**writes** and what the Stop hook **reads**. The new handshake bats catches
that. The wrapper script automates the rest of the manual flow that bats
cannot exercise on its own — wiring `.claude/settings.local.json`, seeding a
realistic notification, and cleaning up.

## Test plan

- [x] `bats tests/orch/test_notify_*.bats` → 6/6 pass (4 existing + 2 new handshake)
- [x] `shellcheck scripts/test-orch-notify-live.sh` → 0 warnings
- [x] `setup` → backs up settings, adds Stop hook entry, seeds notification via the real lifecycle hook
- [x] `status` → reports Stop-hook-wired, backup-present, notification contents accurately before and after
- [x] `teardown` → restores settings from backup, removes seeded fixtures
- [x] **Live integration**: `claude -p "..."` invocation in the worktree triggered the Stop hook, marked the notification `seen: true`, and Claude's response quoted the slug, status, summary, PR url, and issue number verbatim

## Notes

- Scoped to `.claude/settings.local.json` (gitignored, per-project) so the
  setup never touches `~/.claude/settings.json`.
- Uses absolute paths in the hook command so the integration works
  regardless of `CLAUDE_PROJECT_DIR`.
- No runtime impact: nothing in this PR runs unless the user invokes the
  bats files or the wrapper script.

## Recommended next test cycle

Any time `hooks/orch-lifecycle/02-agent-notify.sh` or
`hooks/stop/01-orch-notify.sh` change:

\`\`\`bash
bash scripts/test-orch-notify-live.sh unit
bash scripts/test-orch-notify-live.sh setup
# observe in a fresh Claude Code session
bash scripts/test-orch-notify-live.sh teardown
\`\`\`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>