### PR TITLE
chore(mint): bump fill-poll default 60s → 300s (Q1 review)

### DIFF
--- a/canon/templates/strategies/mint-01/cycle.ts
+++ b/canon/templates/strategies/mint-01/cycle.ts
@@ -165,8 +165,17 @@ export function shouldStopLoss(
 
 /** USDC.e has 6 decimals; `splitPosition` consumes raw token units. */
 const USDC_E_DECIMALS_SCALE = 1_000_000n;
-/** Default time between fill-poll iterations. */
-const DEFAULT_FILL_POLL_INTERVAL_MS = 60_000;
+/**
+ * Default time between fill-poll iterations.
+ *
+ * Bumped from 60s to 300s (5 min) per the open-questions review (Q1):
+ * a 24h mint cycle doesn't need second-level fill latency, and a slower
+ * cadence keeps total CLOB call count well under any rate-limit ceiling
+ * even when multiple cycles run concurrently. Operators can override
+ * via `deps.fillPollIntervalMs` for tighter detection on volatile
+ * markets.
+ */
+const DEFAULT_FILL_POLL_INTERVAL_MS = 300_000;
 
 const TERMINAL_ORDER_STATUSES: ReadonlySet<string> = new Set([
   "filled",

--- a/canon/templates/strategies/mm-premium/config.ts
+++ b/canon/templates/strategies/mm-premium/config.ts
@@ -87,7 +87,7 @@ export const DEFAULT_MM_PREMIUM_CONFIG: MintPremiumConfig = {
   signalTtlMs: 6 * 60 * 60 * 1000,
   bankroll: 10_000,
   stopLossDrift: 0.05,
-  fillPollIntervalMs: 60_000,
+  fillPollIntervalMs: 300_000,
   maxCycleDurationMs: 24 * 60 * 60 * 1000,
 };
 


### PR DESCRIPTION
## Summary

Per the open-questions review (`docs/reviews/mint-cycle-open-questions.md` Q1), bumps the fill-poll cadence default from 60s to 300s (5 min) for both MINT-01 and MINT-04 cycle loops.

For a 24h cycle, second-level fill latency was never needed; the conservative cadence keeps total CLOB call count well under any rate-limit ceiling even when multiple cycles run concurrently. Goes from ~1440 ticks/day per cycle down to ~288.

Operators can still override:
- `mint-01`: `deps.fillPollIntervalMs` in `runCycle(deps)`
- `mm-premium`: `MintPremiumConfig.fillPollIntervalMs`

## Q2 — note (not in this PR)

Polymarket CLOB `getOrder` doesn't return midpoint, so true piggybacking on order-response payloads isn't possible. With the 5-min cadence here, the midpoint fetch piggybacks on the same tick at negligible cost (~288 orderbook fetches per 24h per cycle). Decoupling cadences (e.g. `stopLossCheckEveryNTicks`) stays as an open follow-up if needed.

## Test plan

- [x] `pnpm -C canon/templates exec tsc --noEmit` exits 0
- [x] `pnpm -C canon/templates test` 774 pass / 11 skipped
- [ ] CI green
- [ ] Live amoy smoke (separate, ahead of the release PR)

Holding the release PR (#315) closed-but-staged until live verification on develop completes. This bump rolls into #315 automatically once it goes back through CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)