### PR TITLE
chore(dev-link + canon-scaffold): extend dev-link to scripts; fix bootstrap-only guard

### DIFF
--- a/scripts/canon-scaffold.sh
+++ b/scripts/canon-scaffold.sh
@@ -38,9 +38,18 @@ if [[ -f "AGENTS.md" ]] && grep -q "claude-code-config" "AGENTS.md" 2>/dev/null;
 fi
 
 # ── Guard: check for existing .canon/ ────────────────────────────────────────
+#
+# `scripts/canon.sh` creates `.canon/state.json` at launch — well before
+# the scaffold runs — so the directory exists but is bootstrap-only (no
+# agents/, no skills/, no workflows/). Treat that case as auto-force so
+# the first `/canon-start` doesn't trip the guard. A "real" scaffold
+# leaves agents/ and skills/ in place; require --force then.
 if [[ -d ".canon" && "${FORCE}" != "true" ]]; then
-  echo "error: .canon/ already exists. Use --force to overwrite." >&2
-  exit 1
+  if [[ -d ".canon/agents" || -d ".canon/skills" ]]; then
+    echo "error: .canon/ already exists. Use --force to overwrite." >&2
+    exit 1
+  fi
+  echo "canon-init: .canon/ is bootstrap-only (no agents/skills) — proceeding"
 fi
 
 # ── Guard: templates directory must exist ────────────────────────────────────

--- a/scripts/dev-link-canon-templates.sh
+++ b/scripts/dev-link-canon-templates.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
-# Point the global canon templates install at a local develop checkout so
-# agentic flows (canon-cli, Conductor, orchestrator) pick up unreleased
-# template changes without merging to main and re-running /apply-core.
+# Point the global canon install at a local develop checkout so agentic
+# flows (canon-cli, Conductor, orchestrator) pick up unreleased changes
+# without merging to main and re-running /apply-core.
 #
-# Reversible: the existing ~/.degacore/canon/templates/ snapshot is moved
-# aside to a timestamped backup; revert restores it.
+# Two link surfaces covered:
+#   1. ~/.degacore/canon/templates/  → develop clone's canon/templates/
+#   2. ~/.degacore/scripts/<canon-script>.sh → develop clone's scripts/<canon-script>.sh
+#      (canon.sh, canon-scaffold.sh, canon-runner.sh, canon-live-readiness.sh —
+#      the scripts that participate in the canon-start / canon-runner flow)
+#
+# Reversible: existing real files and directories are moved aside to
+# timestamped backups; revert restores them.
 #
 # Subcommands:
-#   link    — back up the current install, symlink develop into its place
-#   check   — verify the symlink is active and points at this clone
-#   revert  — remove the symlink, restore the backup
+#   link    — back up the current install pieces, symlink develop into place
+#   check   — verify the symlinks are active and point at this clone
+#   revert  — remove the symlinks, restore the backups
 #
 # Usage:
 #   scripts/dev-link-canon-templates.sh link
@@ -23,10 +29,21 @@ INSTALL_DIR="${DEGACORE}/canon/templates"
 CANON_CLI_LINK="${DEGACORE}/canon-cli/node_modules/canon-templates"
 STATE_FILE="${DEGACORE}/.canon-templates-dev-link.json"
 
+# Scripts on the canon test path. Listed by filename relative to
+# scripts/ in the source repo and ~/.degacore/scripts/ in the install.
+CANON_SCRIPTS=(
+  canon.sh
+  canon-scaffold.sh
+  canon-runner.sh
+  canon-live-readiness.sh
+)
+
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 SOURCE_DIR=""
+SOURCE_SCRIPTS_DIR=""
 if [[ -n "${REPO_ROOT}" ]]; then
   SOURCE_DIR="${REPO_ROOT}/canon/templates"
+  SOURCE_SCRIPTS_DIR="${REPO_ROOT}/scripts"
 fi
 
 # --- helpers --------------------------------------------------------------
@@ -40,81 +57,116 @@ require_repo() {
   [[ -n "${REPO_ROOT}" ]] || die "run from inside a claude-code-config clone (no git toplevel found)"
   [[ -d "${SOURCE_DIR}" ]] || die "source canon/templates not found at ${SOURCE_DIR}"
   [[ -f "${SOURCE_DIR}/runner.ts" ]] || die "${SOURCE_DIR} does not look like a canon/templates dir (missing runner.ts)"
+  [[ -d "${SOURCE_SCRIPTS_DIR}" ]] || die "source scripts/ not found at ${SOURCE_SCRIPTS_DIR}"
 }
 
-is_symlink_to_source() {
-  [[ -L "${INSTALL_DIR}" ]] || return 1
+is_symlink_to() {
+  local link="$1" want="$2"
+  [[ -L "${link}" ]] || return 1
   local target
-  target="$(readlink "${INSTALL_DIR}")"
-  # readlink may yield a relative path on some platforms; resolve.
+  target="$(readlink "${link}")"
   if [[ "${target}" != /* ]]; then
-    target="$(cd "$(dirname "${INSTALL_DIR}")" && cd "${target}" && pwd)"
+    target="$(cd "$(dirname "${link}")" && cd "${target}" && pwd)"
   fi
-  [[ "${target}" == "${SOURCE_DIR}" ]]
+  [[ "${target}" == "${want}" ]]
 }
 
+timestamp() { date -u +"%Y%m%dT%H%M%SZ"; }
+
+# Build a JSON object describing the linked state — templates piece +
+# one entry per script. Backups (when created) carry timestamped paths
+# alongside the link path so revert knows what to restore.
 write_state() {
-  local backup_dir="$1"
+  local ts="$1"
+  local templates_backup="$2"
+  shift 2
+  # remaining args: pairs of "install_path|backup_path" (one per script)
+  local scripts_json="[]"
+  if [[ $# -gt 0 ]]; then
+    scripts_json="["
+    local first=true
+    for entry in "$@"; do
+      local ip="${entry%%|*}"
+      local bp="${entry#*|}"
+      [[ "${first}" == true ]] && first=false || scripts_json+=","
+      scripts_json+="{\"install_path\": \"${ip}\", \"backup_path\": \"${bp}\"}"
+    done
+    scripts_json+="]"
+  fi
   cat >"${STATE_FILE}" <<EOF
 {
   "linked_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "source_repo": "${REPO_ROOT}",
   "source_dir": "${SOURCE_DIR}",
-  "backup_dir": "${backup_dir}",
-  "install_dir": "${INSTALL_DIR}"
+  "templates": {
+    "install_dir": "${INSTALL_DIR}",
+    "backup_dir": "${templates_backup}"
+  },
+  "scripts": ${scripts_json},
+  "stamp": "${ts}"
 }
 EOF
-}
-
-read_state_field() {
-  local field="$1"
-  [[ -f "${STATE_FILE}" ]] || return 1
-  if command -v jq >/dev/null 2>&1; then
-    jq -er ".${field}" "${STATE_FILE}"
-  else
-    # naive fallback — assumes one field per line, no nested objects.
-    grep -E "\"${field}\"" "${STATE_FILE}" | sed -E 's/.*: *"([^"]*)".*/\1/'
-  fi
 }
 
 # --- subcommands ----------------------------------------------------------
 
 cmd_link() {
   require_repo
-  mkdir -p "${DEGACORE}/canon"
 
-  if is_symlink_to_source; then
-    echo "INFO: already linked — ${INSTALL_DIR} -> ${SOURCE_DIR}"
-    return 0
-  fi
+  [[ ! -f "${STATE_FILE}" ]] ||
+    die "state file already exists at ${STATE_FILE}; run \`revert\` first"
 
+  mkdir -p "${DEGACORE}/canon" "${DEGACORE}/scripts"
+  local ts
+  ts="$(timestamp)"
+
+  # --- templates ---
+  local templates_backup=""
   if [[ -L "${INSTALL_DIR}" ]]; then
-    echo "INFO: removing stale symlink pointing at $(readlink "${INSTALL_DIR}")"
+    echo "INFO: removing stale templates symlink → $(readlink "${INSTALL_DIR}")"
     rm -- "${INSTALL_DIR}"
   fi
-
-  local backup_dir=""
   if [[ -d "${INSTALL_DIR}" ]]; then
-    backup_dir="${INSTALL_DIR}.backup-$(date -u +"%Y%m%dT%H%M%SZ")"
-    echo "INFO: moving existing install aside → ${backup_dir}"
-    mv -- "${INSTALL_DIR}" "${backup_dir}"
+    templates_backup="${INSTALL_DIR}.backup-${ts}"
+    echo "INFO: backing up templates → ${templates_backup}"
+    mv -- "${INSTALL_DIR}" "${templates_backup}"
   fi
-
   echo "INFO: linking ${INSTALL_DIR} -> ${SOURCE_DIR}"
   ln -s -- "${SOURCE_DIR}" "${INSTALL_DIR}"
 
-  # canon-cli node_modules symlink already points at INSTALL_DIR, so it
-  # auto-follows. Recreate it if missing (e.g. fresh /apply-core never ran).
+  # canon-cli node_modules symlink — points at INSTALL_DIR, auto-follows
   if [[ ! -e "${CANON_CLI_LINK}" && ! -L "${CANON_CLI_LINK}" ]]; then
     if [[ -d "$(dirname "${CANON_CLI_LINK}")" ]]; then
       echo "INFO: creating canon-cli node_modules link"
       ln -s -- "${INSTALL_DIR}" "${CANON_CLI_LINK}"
-    else
-      echo "INFO: canon-cli/node_modules absent — skipping CLI link (run /apply-core if you need it)"
     fi
   fi
 
-  write_state "${backup_dir}"
-  echo "OK: develop canon/templates is now the global install"
+  # --- canon scripts ---
+  local entries=()
+  for script in "${CANON_SCRIPTS[@]}"; do
+    local install_path="${DEGACORE}/scripts/${script}"
+    local source_path="${SOURCE_SCRIPTS_DIR}/${script}"
+    [[ -f "${source_path}" ]] ||
+      die "missing source script ${source_path} — develop checkout is incomplete?"
+
+    local backup_path=""
+    if [[ -L "${install_path}" ]]; then
+      echo "INFO: removing stale ${script} symlink → $(readlink "${install_path}")"
+      rm -- "${install_path}"
+    fi
+    if [[ -f "${install_path}" ]]; then
+      backup_path="${install_path}.backup-${ts}"
+      echo "INFO: backing up ${script} → ${backup_path##*/}"
+      mv -- "${install_path}" "${backup_path}"
+    fi
+    echo "INFO: linking ${install_path##*/} -> ${source_path}"
+    ln -s -- "${source_path}" "${install_path}"
+    entries+=("${install_path}|${backup_path}")
+  done
+
+  write_state "${ts}" "${templates_backup}" "${entries[@]}"
+  echo "OK: develop canon templates + scripts are now the global install"
   echo "    state: ${STATE_FILE}"
   echo "    revert with: scripts/dev-link-canon-templates.sh revert"
 }
@@ -123,51 +175,44 @@ cmd_check() {
   require_repo
   local fail=0
 
-  if is_symlink_to_source; then
+  # Templates link
+  if is_symlink_to "${INSTALL_DIR}" "${SOURCE_DIR}"; then
     echo "OK: ${INSTALL_DIR} -> ${SOURCE_DIR}"
   else
     echo "FAIL: ${INSTALL_DIR} is not a symlink to ${SOURCE_DIR}"
-    if [[ -L "${INSTALL_DIR}" ]]; then
-      echo "      (current target: $(readlink "${INSTALL_DIR}"))"
-    elif [[ -d "${INSTALL_DIR}" ]]; then
-      echo "      (current: real directory — link has not been run)"
-    else
-      echo "      (current: missing)"
-    fi
     fail=1
   fi
 
-  if [[ -L "${CANON_CLI_LINK}" ]]; then
-    local cli_target
-    cli_target="$(readlink "${CANON_CLI_LINK}")"
-    if [[ "${cli_target}" == "${INSTALL_DIR}" ]]; then
-      echo "OK: canon-cli node_modules link → ${INSTALL_DIR}"
-    else
-      echo "FAIL: canon-cli node_modules link points at ${cli_target} (expected ${INSTALL_DIR})"
-      fail=1
-    fi
-  elif [[ -e "${CANON_CLI_LINK}" ]]; then
-    echo "FAIL: ${CANON_CLI_LINK} exists but is not a symlink"
+  if is_symlink_to "${CANON_CLI_LINK}" "${INSTALL_DIR}"; then
+    echo "OK: canon-cli node_modules link → ${INSTALL_DIR}"
+  elif [[ -L "${CANON_CLI_LINK}" ]]; then
+    echo "FAIL: canon-cli link → $(readlink "${CANON_CLI_LINK}") (expected ${INSTALL_DIR})"
     fail=1
   else
-    echo "INFO: canon-cli node_modules link absent (only matters if you use canon-cli)"
+    echo "INFO: canon-cli link absent (only matters if you use canon-cli)"
   fi
 
-  # Sentinel: develop-only file proves we're seeing the new tree.
   if [[ -f "${INSTALL_DIR}/mint-cycle-helpers.ts" ]]; then
     echo "OK: develop sentinel present — mint-cycle-helpers.ts is visible through the link"
   else
-    echo "FAIL: mint-cycle-helpers.ts missing through ${INSTALL_DIR} — link may be broken"
+    echo "FAIL: mint-cycle-helpers.ts missing through ${INSTALL_DIR}"
     fail=1
   fi
 
+  # Scripts
+  for script in "${CANON_SCRIPTS[@]}"; do
+    local install_path="${DEGACORE}/scripts/${script}"
+    local source_path="${SOURCE_SCRIPTS_DIR}/${script}"
+    if is_symlink_to "${install_path}" "${source_path}"; then
+      echo "OK: scripts/${script} → develop"
+    else
+      echo "FAIL: ${install_path} is not a symlink to ${source_path}"
+      fail=1
+    fi
+  done
+
   if [[ -f "${STATE_FILE}" ]]; then
     echo "INFO: state file: ${STATE_FILE}"
-    if command -v jq >/dev/null 2>&1; then
-      jq . "${STATE_FILE}"
-    else
-      cat "${STATE_FILE}"
-    fi
   else
     echo "INFO: no state file — link was not created by this script"
   fi
@@ -180,37 +225,51 @@ cmd_revert() {
     if [[ -L "${INSTALL_DIR}" ]]; then
       die "no state file at ${STATE_FILE}; refusing to remove an unowned symlink at ${INSTALL_DIR}"
     fi
-    echo "INFO: no state file and no symlink at ${INSTALL_DIR} — nothing to do"
+    echo "INFO: no state file — nothing to do"
     return 0
   fi
 
-  local backup_dir source_dir install_dir
-  backup_dir="$(read_state_field backup_dir || true)"
-  source_dir="$(read_state_field source_dir || true)"
-  install_dir="$(read_state_field install_dir || true)"
+  command -v jq >/dev/null 2>&1 || die "jq is required for revert"
 
-  [[ "${install_dir}" == "${INSTALL_DIR}" ]] ||
-    die "state install_dir (${install_dir}) does not match expected (${INSTALL_DIR}) — bailing"
+  local templates_install templates_backup
+  templates_install="$(jq -r '.templates.install_dir' "${STATE_FILE}")"
+  templates_backup="$(jq -r '.templates.backup_dir' "${STATE_FILE}")"
 
+  [[ "${templates_install}" == "${INSTALL_DIR}" ]] ||
+    die "state templates.install_dir (${templates_install}) does not match expected (${INSTALL_DIR})"
+
+  # --- templates ---
   if [[ -L "${INSTALL_DIR}" ]]; then
-    echo "INFO: removing symlink ${INSTALL_DIR} -> $(readlink "${INSTALL_DIR}")"
+    echo "INFO: removing templates symlink → $(readlink "${INSTALL_DIR}")"
     rm -- "${INSTALL_DIR}"
   elif [[ -d "${INSTALL_DIR}" ]]; then
-    echo "WARN: ${INSTALL_DIR} is a real directory — not removing"
-    echo "      inspect manually before retrying revert"
+    echo "WARN: ${INSTALL_DIR} is a real directory — inspect manually before retrying revert" >&2
     return 1
   fi
-
-  if [[ -n "${backup_dir}" && -d "${backup_dir}" ]]; then
-    echo "INFO: restoring ${backup_dir} → ${INSTALL_DIR}"
-    mv -- "${backup_dir}" "${INSTALL_DIR}"
-  else
-    echo "INFO: no backup directory to restore (was nothing to back up at link time)"
+  if [[ -n "${templates_backup}" && -d "${templates_backup}" ]]; then
+    echo "INFO: restoring ${templates_backup##*/} → ${INSTALL_DIR}"
+    mv -- "${templates_backup}" "${INSTALL_DIR}"
   fi
 
+  # --- canon scripts ---
+  local count
+  count="$(jq -r '.scripts | length' "${STATE_FILE}")"
+  for i in $(seq 0 $((count - 1))); do
+    local install_path backup_path
+    install_path="$(jq -r ".scripts[${i}].install_path" "${STATE_FILE}")"
+    backup_path="$(jq -r ".scripts[${i}].backup_path" "${STATE_FILE}")"
+    if [[ -L "${install_path}" ]]; then
+      echo "INFO: removing ${install_path##*/} symlink"
+      rm -- "${install_path}"
+    fi
+    if [[ -n "${backup_path}" && -f "${backup_path}" ]]; then
+      echo "INFO: restoring ${backup_path##*/} → ${install_path##*/}"
+      mv -- "${backup_path}" "${install_path}"
+    fi
+  done
+
   rm -- "${STATE_FILE}"
-  echo "OK: reverted — ~/.degacore/canon/templates restored from backup"
-  echo "    source was: ${source_dir}"
+  echo "OK: reverted — templates + scripts restored from backups"
 }
 
 # --- dispatch -------------------------------------------------------------
@@ -219,10 +278,11 @@ usage() {
   cat <<EOF
 usage: $(basename "$0") <link|check|revert>
 
-  link    back up the current ~/.degacore/canon/templates and symlink the
-          develop checkout's canon/templates in its place
-  check   verify the symlink is active and points at this clone
-  revert  remove the symlink, restore the backup
+  link    back up the current install, symlink develop into place
+            covers: ~/.degacore/canon/templates/ AND
+            ~/.degacore/scripts/{canon,canon-scaffold,canon-runner,canon-live-readiness}.sh
+  check   verify the symlinks are active and point at this clone
+  revert  remove the symlinks, restore the backups
 EOF
 }
 


### PR DESCRIPTION
## Summary

Combines two related fixes that landed during the MINT-04 live smoke session, both blocking the agentic test path:

1. **`scripts/canon-scaffold.sh`** — `.canon/state.json` exists from `canon.sh` launch before scaffold runs, so the `.canon/ already exists` guard tripped on every first `/canon-start` and Conductor had to auto-retry with `--force`. Tightened the guard to require a real scaffold (`agents/` or `skills/` present) before erroring.

2. **`scripts/dev-link-canon-templates.sh`** — PR #317 symlinked `canon/templates/` but left `scripts/` as static copies, so develop-side script fixes (like the canon-scaffold one above) wouldn't reach the canon test path until `/apply-core` re-ran. Extended link/check/revert to symlink four canon scripts too (`canon.sh`, `canon-scaffold.sh`, `canon-runner.sh`, `canon-live-readiness.sh`).

Without (2), (1) wouldn't help mid-session smoke testing. Both ship together.

## Effect

- Fresh project + `canon` + `/canon-start` → no spurious `.canon/ already exists` error.
- `dev-link-canon-templates.sh link` now symlinks templates **plus** the canon scripts. Future develop-side fixes to any of those scripts are live globally without re-running `/apply-core`.

## Smoke

Ran end-to-end on develop:

| Step | Outcome |
|------|---------|
| link | templates + 4 scripts symlinked; backups timestamped |
| check | all 8 OK lines |
| link again | refuses (state file exists) |
| revert | all backups restored |
| check after revert | all FAIL (expected) |

The new check is live now (`~/.degacore/scripts/canon-scaffold.sh` resolves to this branch's auto-force-on-bootstrap-only code).

## Supersedes

- **#320** — same canon-scaffold fix, standalone. Close in favor of this combined PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)