### PR TITLE
fix(mm-premium): drop default hurdleRate to 0 (match $5 smoke cycleCapital)

### DIFF
--- a/canon/templates/strategies/mm-premium/__tests__/risk.test.ts
+++ b/canon/templates/strategies/mm-premium/__tests__/risk.test.ts
@@ -100,7 +100,9 @@ describe("createRiskChecker (mm-premium)", () => {
     });
 
     it("rejects when projected net / capital falls below hurdle", () => {
-      const risk = createRiskChecker(makeConfig());
+      // Override hurdleRate back to the C2-spec value: the shipped
+      // default is 0 (smoke-friendly) and would never reject anything.
+      const risk = createRiskChecker(makeConfig({ hurdleRate: 0.0133 }));
       const signal = makeSignal({
         metadata: {
           offsetC: 0.005,

--- a/canon/templates/strategies/mm-premium/config.ts
+++ b/canon/templates/strategies/mm-premium/config.ts
@@ -71,7 +71,12 @@ export interface MintPremiumConfig {
 export const DEFAULT_MM_PREMIUM_CONFIG: MintPremiumConfig = {
   kellyFraction: 1.0,
   maxExposure: 0.25,
-  hurdleRate: 0.0133,
+  // hurdleRate ships at 0 so the $5 smoke default actually finds a
+  // viable market. The C2 spec gate is 0.0133 (1.33% net/capital) — at
+  // that level the strategy needs ≥~$154 cycleCapital to clear gas. Raise
+  // this when you raise cycleCapital for production. Setting it >0 with
+  // a small cycleCapital will reject every market.
+  hurdleRate: 0,
   feeRate: 0.0017,
   gasCost: 0.05,
   lpRebate: 0.325,


### PR DESCRIPTION
## Summary

Inconsistency in #319: I dropped `cycleCapital` default to $5 (smoke-friendly) but left `hurdleRate: 0.0133` from the C2 production spec. At $5 cycle the strategy nets ~$0.018 — gas eats the spread — so `net/capital` ≈ 0.36%, which fails the 1.33% hurdle. **Every market gets rejected.**

First live smoke confirmed exactly this:
```json
{"type":"error","reason":"NO_EDGE","snapshotsConsidered":83482}
```
83k markets scanned, none viable, cycle exited NO_EDGE without firing.

This PR drops the default `hurdleRate` to 0 so the $5 smoke default actually finds viable markets and exercises the rest of the cycle path (splitPosition → dual leg → fill-poll → reconcile).

## Docs at the call site

Inline comment in `DEFAULT_MM_PREMIUM_CONFIG` documents:
- 0 is for smoke; 0.0133 is the C2-spec gate
- Hurdle clears naturally at `cycleCapital ≥ ~$154`
- Operators raising `cycleCapital` to $200+ should raise `hurdleRate` back to the spec to re-enable the production profitability gate

## Test fixture override

`risk.test.ts` 'rejects when below hurdle' test now explicitly passes `hurdleRate: 0.0133` because the shipped default would never reject. Other tests already overrode `cycleCapital: 1_000` which independently keeps them above the spec hurdle.

774 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)