### PR TITLE
fix(canon-scaffold): fail loud on partial copy + skip node_modules

### DIFF
--- a/scripts/canon-scaffold.sh
+++ b/scripts/canon-scaffold.sh
@@ -31,6 +31,29 @@ state() {
   fi
 }
 
+# ── Trap: fail loud on early exit ────────────────────────────────────────────
+#
+# Previous behavior: if the template copy was interrupted (Ctrl-C, parent
+# process kill, system signal), the script died under set -e but left a
+# partial scaffold behind. The next /canon-start run would then either
+# fail late (the verify step caught it) or silently proceed against a
+# half-populated dir. Trap EXIT so any abort before SCAFFOLD_COMPLETE
+# prints a clear diagnostic and tells the user how to recover.
+SCAFFOLD_COMPLETE=0
+abort_partial() {
+  local rc=$?
+  if [[ ${SCAFFOLD_COMPLETE} -eq 1 ]]; then
+    return 0
+  fi
+  echo "" >&2
+  echo "error: canon-scaffold aborted before completion (exit ${rc})" >&2
+  echo "  partial state may have been written to ${PROJECT_DIR}" >&2
+  echo "  to retry: empty the directory and re-run canon-scaffold" >&2
+  state status=error error="aborted before completion (exit ${rc})" \
+    log.error="canon-scaffold aborted before completion"
+}
+trap abort_partial EXIT
+
 # ── Guard: don't run inside claude-code-config itself ────────────────────────
 if [[ -f "AGENTS.md" ]] && grep -q "claude-code-config" "AGENTS.md" 2>/dev/null; then
   echo "error: run canon-init from your strategy project, not from claude-code-config" >&2
@@ -94,14 +117,63 @@ if [[ ! -d ".git" ]]; then
 fi
 
 # ── 1. Copy templates as project root ────────────────────────────────────────
+#
+# Skip `node_modules/` (and the dev-only npm `package-lock.json` that
+# coexists with our pnpm lock): both are heavy, contain thousands of
+# symlinks from pnpm's content-addressed store, and have been the
+# observed source of mid-copy hangs/aborts on macOS. `pnpm install`
+# recreates `node_modules/` deterministically from `pnpm-lock.yaml`, so
+# nothing of value is lost.
 echo "→ copying project templates..."
-cp -a "${TEMPLATE_DIR}/." "${PROJECT_DIR}/"
+SCAFFOLD_SKIP=(node_modules package-lock.json)
+
+# Returns 0 if $1 is in SCAFFOLD_SKIP, 1 otherwise.
+should_skip() {
+  local name="$1"
+  for s in "${SCAFFOLD_SKIP[@]}"; do
+    [[ "${name}" == "${s}" ]] && return 0
+  done
+  return 1
+}
+
+shopt -s dotglob nullglob
+expected_entries=()
+for entry in "${TEMPLATE_DIR}"/*; do
+  name="$(basename "${entry}")"
+  should_skip "${name}" && continue
+  expected_entries+=("${name}")
+  cp -a "${entry}" "${PROJECT_DIR}/"
+done
+shopt -u dotglob nullglob
+
+# Post-copy verification: every expected top-level entry must actually
+# exist at the destination. The previous single `cp -a TEMPLATE_DIR/.`
+# could be interrupted mid-traversal (Ctrl-C, parent-process kill,
+# filesystem stall on node_modules' 2k+ symlinks) and leave a partial
+# scaffold whose state.json never advanced past "Git repo initialized."
+# Per-entry copy plus this explicit existence check turns any partial
+# copy into a loud, actionable failure instead of a silent half-success.
+missing_entries=()
+for name in "${expected_entries[@]}"; do
+  if [[ ! -e "${PROJECT_DIR}/${name}" ]]; then
+    missing_entries+=("${name}")
+  fi
+done
+if [[ ${#missing_entries[@]} -gt 0 ]]; then
+  echo "error: template copy incomplete — missing ${#missing_entries[@]} of ${#expected_entries[@]} top-level entries:" >&2
+  for name in "${missing_entries[@]}"; do
+    echo "  - ${name}" >&2
+  done
+  state status=error error="template copy incomplete (${#missing_entries[@]} missing)" \
+    log.error="Template copy incomplete"
+  exit 1
+fi
 
 # Stamp the actual project name into package.json and dega-core.yaml
 sed_inplace "s/\"name\": \"canon-templates\"/\"name\": \"${PROJECT_NAME}\"/" package.json
 sed_inplace "s/strategy: canon-templates/strategy: ${PROJECT_NAME}/" dega-core.yaml
 
-state log.info="Project templates copied"
+state log.info="Project templates copied (${#expected_entries[@]} top-level entries)"
 
 # ── 2. Create runtime directories ────────────────────────────────────────────
 mkdir -p .canon/execution .canon/workflows
@@ -221,3 +293,5 @@ echo "  2. Start claude and run /canon-start"
 
 state phase=init status=running \
   log.info="Canon framework initialized — ready for next phase"
+
+SCAFFOLD_COMPLETE=1

--- a/tests/test_canon_scaffold.bats
+++ b/tests/test_canon_scaffold.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/canon-scaffold.sh.
+#
+# Regression for the partial-scaffold bug observed during the MINT-04
+# live smoke: cp -a was interrupted mid-copy, leaving the project dir
+# half-populated (no AGENTS.md / package.json / runner.ts / .cursorrules)
+# while the script appeared to "succeed" on the surface. These tests
+# assert the script either copies every expected entry or aborts loudly.
+
+setup() {
+  TEST_TMP=$(mktemp -d)
+  export TEST_TMP
+
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+  SCRIPT="${REPO_ROOT}/scripts/canon-scaffold.sh"
+  SOURCE_TEMPLATES="${REPO_ROOT}/canon/templates"
+
+  # Point DEGA_CORE_HOME at the repo so TEMPLATE_DIR resolves locally
+  # (no GitHub fetch). The fetch helpers fall back to network for
+  # agents/skills/commands; we mirror those under TEST_TMP/dega-core.
+  DEGA_HOME="${TEST_TMP}/dega-core"
+  mkdir -p "${DEGA_HOME}/canon"
+  ln -s "${REPO_ROOT}/canon/templates" "${DEGA_HOME}/canon/templates"
+  ln -s "${REPO_ROOT}/canon/agents" "${DEGA_HOME}/canon/agents"
+  ln -s "${REPO_ROOT}/canon/skills" "${DEGA_HOME}/canon/skills"
+  ln -s "${REPO_ROOT}/canon/commands" "${DEGA_HOME}/canon/commands"
+  export DEGA_CORE_HOME="${DEGA_HOME}"
+
+  # git config for the scaffold's `git commit` step (CI envs lack it)
+  export GIT_AUTHOR_NAME="canon-scaffold-test"
+  export GIT_AUTHOR_EMAIL="test@example.com"
+  export GIT_COMMITTER_NAME="canon-scaffold-test"
+  export GIT_COMMITTER_EMAIL="test@example.com"
+}
+
+teardown() {
+  cd /
+  rm -rf "${TEST_TMP}"
+}
+
+# ─── happy path ──────────────────────────────────────────────────────────────
+
+@test "scaffold lands every expected file in an empty dir" {
+  PROJECT="${TEST_TMP}/proj-happy"
+  mkdir -p "${PROJECT}"
+  cd "${PROJECT}"
+
+  run bash "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+
+  # Every path the in-script verify block checks must be present.
+  for f in \
+    AGENTS.md \
+    CLAUDE.md \
+    GEMINI.md \
+    .cursorrules \
+    package.json \
+    tsconfig.json \
+    vitest.config.ts \
+    runner.ts \
+    client-polymarket.ts \
+    client-sportsbook.ts \
+    dega-core.yaml \
+    types/TradeSignal.ts \
+    types/RiskInterface.ts \
+    nba-momentum/strategy.md \
+    nba-momentum/plan.md \
+    strategies/arb-binary/signal.ts \
+    strategies/arb-binary/main.ts \
+    strategies/arb-binary/entry.ts \
+    .canon/agents/dev.md \
+    .canon/agents/strategy-architect.md \
+    .canon/skills/prediction-markets.md \
+    .canon/skills/canon-conventions.md \
+    .canon/config.yaml \
+    .claude/commands/canon-start.md \
+    .claude/commands/develop.md; do
+    [ -f "${PROJECT}/${f}" ] || {
+      echo "missing: ${f}" >&2
+      false
+    }
+  done
+
+  # node_modules is intentionally skipped — pnpm install recreates it.
+  [ ! -e "${PROJECT}/node_modules" ]
+}
+
+@test "scaffold copies the same number of top-level entries as templates (minus skips)" {
+  PROJECT="${TEST_TMP}/proj-count"
+  mkdir -p "${PROJECT}"
+  cd "${PROJECT}"
+
+  run bash "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+
+  # Source minus node_modules and package-lock.json (the documented skips)
+  expected=$(find "${SOURCE_TEMPLATES}" -mindepth 1 -maxdepth 1 \
+    ! -name node_modules ! -name package-lock.json | wc -l | tr -d ' ')
+  # Project minus things the scaffold creates itself (.git, .claude)
+  actual=$(find "${PROJECT}" -mindepth 1 -maxdepth 1 \
+    ! -name .git ! -name .claude | wc -l | tr -d ' ')
+  [ "${expected}" -eq "${actual}" ]
+}
+
+# ─── failure / partial-state paths ───────────────────────────────────────────
+
+@test "scaffold aborts loudly when template dir is missing" {
+  PROJECT="${TEST_TMP}/proj-no-templates"
+  mkdir -p "${PROJECT}"
+  cd "${PROJECT}"
+
+  rm "${DEGA_HOME}/canon/templates"
+  mkdir "${DEGA_HOME}/canon/templates-stash"
+  # canon-scaffold treats missing templates as a hard guard error
+  DEGA_CORE_HOME="${TEST_TMP}/does-not-exist" run bash "${SCRIPT}"
+  [ "${status}" -ne 0 ]
+  echo "${output}" | grep -q "templates not found"
+}
+
+@test "scaffold's partial-copy guard fires when copy is incomplete" {
+  # Simulate a silent partial copy by intercepting cp with a stub that
+  # only copies the first two top-level entries. The script's post-copy
+  # entry-count check must catch the shortfall and exit non-zero with a
+  # clear error.
+  PROJECT="${TEST_TMP}/proj-partial"
+  mkdir -p "${PROJECT}"
+  cd "${PROJECT}"
+
+  STUB_BIN="${TEST_TMP}/stub-bin"
+  mkdir -p "${STUB_BIN}"
+  cat >"${STUB_BIN}/cp" <<STUB
+#!/usr/bin/env bash
+# Pass through sed-related calls; sabotage template-copy calls after
+# the third entry by silently succeeding without copying.
+COUNT_FILE="${TEST_TMP}/cp-count"
+n=\$(cat "\${COUNT_FILE}" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\${n}" >"\${COUNT_FILE}"
+if [[ \${n} -gt 3 ]]; then
+  exit 0
+fi
+exec /bin/cp "\$@"
+STUB
+  chmod +x "${STUB_BIN}/cp"
+
+  PATH="${STUB_BIN}:${PATH}" run bash "${SCRIPT}"
+  [ "${status}" -ne 0 ]
+  echo "${output}" | grep -q "template copy incomplete"
+}
+
+@test "scaffold's EXIT trap reports partial state when interrupted before completion" {
+  # Force an early abort by making one of the fetch sources unreachable.
+  # The script should exit non-zero AND the trap should write the
+  # "aborted before completion" message.
+  PROJECT="${TEST_TMP}/proj-trap"
+  mkdir -p "${PROJECT}"
+  cd "${PROJECT}"
+
+  # Break the agents symlink so the local-first fetch falls through to
+  # curl, then point BASE_URL at an unroutable host so curl fails fast.
+  rm "${DEGA_HOME}/canon/agents"
+
+  # The script hardcodes BASE_URL, so we exercise the fetch failure via
+  # the `exit 1` in fetch(). That hits the trap before completion.
+  run bash -c "
+    set +e
+    cd '${PROJECT}'
+    # Make curl always fail by pointing at an invalid resolver
+    curl() { return 1; }
+    export -f curl
+    bash '${SCRIPT}' 2>&1
+  "
+  [ "${status}" -ne 0 ]
+  echo "${output}" | grep -q "aborted before completion"
+}


### PR DESCRIPTION
## Summary

`canon-scaffold.sh` could leave the user with a half-populated project dir and appear to succeed. Three changes turn that into a loud, recoverable failure:

- **EXIT trap** prints an actionable diagnostic if the script aborts before `SCAFFOLD_COMPLETE=1` at the tail. Covers signal-based interrupts (Ctrl-C, parent-process kill) that previously left no on-disk evidence past `Git repo initialized`.
- **Skip `node_modules/` and `package-lock.json`** during the template copy. `pnpm install` rebuilds `node_modules/` from `pnpm-lock.yaml` deterministically; the original `cp -a TEMPLATE_DIR/.` had to traverse 2k+ pnpm symlinks first, which is where the observed mid-copy stalls originated.
- **Post-copy existence check** asserts every expected top-level entry actually landed on disk, then names the missing ones if not. Catches silent-partial-copy modes the previous `set -e + single cp -a` missed.

Adds `tests/test_canon_scaffold.bats` with five scenarios:
- happy-path file-by-file landing check
- entry-count invariant (source minus skips equals dest minus scaffold-created dirs)
- missing-template-dir guard
- partial-copy guard (cp stub returning 0 without writing)
- EXIT trap fires with the right diagnostic when fetch fails

## Context

Caught during the MINT-04 live smoke handoff. The failing run wrote `.canon/state.json` only through `Git repo initialized` then silently stopped — the user inspected the dir manually and reported ~15 of ~38 template entries present, with no AGENTS.md / package.json / runner.ts. Background and reproduction trail in `docs/reviews/canon-mm-premium-smoke-handoff.md` (not in this PR; kept local while #321/#322 are open).

## Test plan

- [x] `shellcheck scripts/canon-scaffold.sh` exits 0
- [x] `shfmt -d scripts/canon-scaffold.sh` empty diff
- [x] `bats tests/test_canon_scaffold.bats` — 5/5 pass
- [x] All existing `tests/**/*.bats` still pass
- [x] Manual smoke: `bash ~/.degacore/scripts/canon-scaffold.sh` in a fresh `/tmp` dir produces complete output, exits 0, verify block green

🤖 Generated with [Claude Code](https://claude.com/claude-code)