### PR TITLE
fix(canon-start): drop TUI-detection gate that blocks canon-tui sessions

### DIFF
--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -518,29 +518,24 @@ let the operator inspect and decide.
 
 ## Graceful degradation
 
-This command expects to be launched via `./canon.sh`, which uses either the
-Canon TUI (`canon run`) or tmux as a fallback.
-Dashboard state writes degrade gracefully:
+This command works regardless of how the session was launched (Canon TUI,
+tmux, plain terminal, IDE). Dashboard state writes degrade silently when
+the writer is missing — that's the only environment-dependent behavior.
 
-| Component | If missing | Behavior |
-|-----------|-----------|----------|
-| Neither Canon TUI nor tmux detected | Stop with message | User told to run `./canon.sh` first |
-| `$DEGA_CORE_HOME/scripts/terminal-ui-write.sh` | Skip state file writes | No dashboard updates, workflow still runs |
+Every `terminal-ui-write.sh` call in this command is guarded with
+`[[ -f "${TUI_WRITE}" ]] &&`. If the script does not exist, the call is
+skipped silently — no error, no repeated warnings.
 
-**Canon TUI detection:** The session is valid if ANY of these are true:
-- `$TMUX` is set (tmux fallback)
-- `$CANON_TUI` is set (Canon TUI / canon-tui)
-- `.canon/state.json` exists and was updated within the last 5 minutes (TUI wrote init state)
-
-Every `terminal-ui-write.sh` call in this command is already guarded with
-`[[ -f "${TUI_WRITE}" ]] &&`. If the script
-does not exist, the call is skipped silently — no error, no repeated warnings.
+Do **not** gate the pipeline on `$TMUX`, `$CANON_TUI`, `$TOAD_CWD`, or
+any other env-var meant to signal "running inside a TUI." Those signals
+do not propagate reliably through the canon-tui → claude-code-acp → claude
+chain, and a missing dashboard is not a failure — phases still run, state
+file still gets written when the writer is installed. Just proceed.
 
 ---
 
 ## Completion criteria
 
-- TUI environment verified at entry — stops if not inside Canon TUI or tmux
 - Phase detection correctly identifies the project's current state
 - Each phase delegates to the right sub-command logic (canon-scaffold.sh, discover, develop)
 - State file is updated at each phase transition (when terminal-ui-write.sh is available)

--- a/commands/canon-start.md
+++ b/commands/canon-start.md
@@ -518,29 +518,24 @@ let the operator inspect and decide.
 
 ## Graceful degradation
 
-This command expects to be launched via `./canon.sh`, which uses either the
-Canon TUI (`canon run`) or tmux as a fallback.
-Dashboard state writes degrade gracefully:
+This command works regardless of how the session was launched (Canon TUI,
+tmux, plain terminal, IDE). Dashboard state writes degrade silently when
+the writer is missing — that's the only environment-dependent behavior.
 
-| Component | If missing | Behavior |
-|-----------|-----------|----------|
-| Neither Canon TUI nor tmux detected | Stop with message | User told to run `./canon.sh` first |
-| `$DEGA_CORE_HOME/scripts/terminal-ui-write.sh` | Skip state file writes | No dashboard updates, workflow still runs |
+Every `terminal-ui-write.sh` call in this command is guarded with
+`[[ -f "${TUI_WRITE}" ]] &&`. If the script does not exist, the call is
+skipped silently — no error, no repeated warnings.
 
-**Canon TUI detection:** The session is valid if ANY of these are true:
-- `$TMUX` is set (tmux fallback)
-- `$CANON_TUI` is set (Canon TUI / canon-tui)
-- `.canon/state.json` exists and was updated within the last 5 minutes (TUI wrote init state)
-
-Every `terminal-ui-write.sh` call in this command is already guarded with
-`[[ -f "${TUI_WRITE}" ]] &&`. If the script
-does not exist, the call is skipped silently — no error, no repeated warnings.
+Do **not** gate the pipeline on `$TMUX`, `$CANON_TUI`, `$TOAD_CWD`, or
+any other env-var meant to signal "running inside a TUI." Those signals
+do not propagate reliably through the canon-tui → claude-code-acp → claude
+chain, and a missing dashboard is not a failure — phases still run, state
+file still gets written when the writer is installed. Just proceed.
 
 ---
 
 ## Completion criteria
 
-- TUI environment verified at entry — stops if not inside Canon TUI or tmux
 - Phase detection correctly identifies the project's current state
 - Each phase delegates to the right sub-command logic (canon-scaffold.sh, discover, develop)
 - State file is updated at each phase transition (when terminal-ui-write.sh is available)


### PR DESCRIPTION
## Symptom

Launching \`/canon-start\` inside \`canon run\` halts at:

> Status: Empty directory — no git repo, no .canon/, no TUI session detected.
> ... Neither \$TMUX nor \$CANON_TUI is set, and canon-ctl is not on PATH.
> Recommendation: Launch this session via ./canon.sh ...
> How would you like to proceed?

The pipeline never runs phase 3 — the agent waits for user input.

## Root cause

The "Canon TUI detection" block in \`canon-start.md\` requires one of \`\$TMUX\`, \`\$CANON_TUI\`, or a fresh \`.canon/state.json\`. Verified inside a live canon-tui session by asking the agent to run \`echo \"TMUX=\${TMUX:-x} CANON_TUI=\${CANON_TUI:-x} TOAD_CWD=\${TOAD_CWD:-x}\"\` — **all three were unset.**

The env contract is broken across the canon-tui → claude-code-acp → claude process chain; whatever TUI-signal env-var canon-tui sets in \`acp/agent.py\` does not survive to the agent's tool sandbox. The gate fires every time, regardless of how Canon was actually launched.

## Why this gate adds no value

State-file writes already degrade gracefully — every \`terminal-ui-write.sh\` call is wrapped in \`[[ -f \"\${TUI_WRITE}\" ]] &&\`. A missing dashboard is cosmetic, not a failure mode. There's no reason to halt the pipeline for it.

## Fix

Remove the env-based gate. Replace the "Graceful degradation" section with an explicit instruction to never gate on TUI-detection env-vars. The dashboard-write degradation guarantees the workflow still runs end-to-end without a TUI.

## Prior art

The original env check was already removed once for the same reason: \`89c9191b\` (Mar 30 2026, "fix: remove environment check from canon-start"). The May 1 \"ship globally\" commit (\`c6305531\`) reintroduced a different, equally-broken version. This PR restores the post-89c9191b behavior.

## Test plan

- [x] Reading the spec end-to-end, no remaining \`\$TMUX\` / \`\$CANON_TUI\` / \`\$TOAD_CWD\` gate
- [x] \`canon/commands/canon-start.md\` and \`commands/canon-start.md\` stay byte-identical (\`diff\` empty)
- [ ] Manual: \`canon run ~/dega/aidd/workshop/test-mintNN\` (fresh empty dir) → agent prints \`Phase: init\`, runs \`canon-scaffold.sh\`, runs \`pnpm install\`, runs \`canon-cli wallet ensure\` — no permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)