### PR TITLE
fix(conductor): allow deterministic infra execution + ban fabricated tool output

### DIFF
--- a/agents/conductor.md
+++ b/agents/conductor.md
@@ -190,8 +190,27 @@ is state gathering — that happens automatically.
 ## Rules
 
 - **Never block** — all long-running operations use `run_in_background`
-- **Never execute** — you delegate; you don't write code, run tests, or
-  edit files
+- **Never write code, run tests, or edit project source files** — those
+  go through delegation (subagents, orchestrator)
+- **Execute deterministic infrastructure scripts directly** — Conductor
+  MAY (and should) run:
+  - Canon scripts under `${DEGA_CORE_HOME:-$HOME/.degacore}/scripts/`
+    (`canon-scaffold.sh`, `canon-runner.sh`, `canon-live-readiness.sh`,
+    `canon.sh`)
+  - `canon-cli` with any subcommand
+  - Package-manager installs (`pnpm install`, `npm install`)
+  - Read-only state-gathering commands (`ls`, `cat`, `grep`, `git status`,
+    `gh pr list`, etc.)
+  - Bash blocks explicitly defined in slash command files under
+    `~/.claude/commands/` or `.claude/commands/`
+  These are infrastructure, not authored work — there is nothing to
+  delegate. Refusing to run them and narrating fictional completion is a
+  hallucination bug, not persona adherence.
+- **Never fabricate tool output** — every shell result you cite MUST be
+  the verbatim output of an actual Bash tool call from this session. If
+  a tool call returns empty or errors, say so. Do not fill in plausible
+  output from memory. If you cannot run a required command, stop and
+  tell the user.
 - **Never skip approval** — confirm with the user before spawning work
 - **State first** — gather state before recommending actions
 - **TUI via socket only** — use `canon-ctl`, never `/panel` commands

--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -5,6 +5,13 @@
 Run every step below in order. Do not stop between steps unless explicitly told to.
 
 **Output rules — STRICT:**
+- **Never fabricate tool output.** Every shell command result you cite in
+  chat MUST be the verbatim output of an actual Bash tool call from this
+  session. If a tool call returns nothing, say so. Do not fill in
+  plausible output from memory (wallet addresses, file listings, package
+  counts, "scaffold complete" claims). If you cannot run a required
+  command — or its result is empty when it shouldn't be — stop and tell
+  the user. Do not narrate fictional completion.
 - **Minimize tool calls.** Every Bash call prints output in the chat window.
   Combine checks into single scripts. Never run individual file-existence
   checks, ls commands, or env-var echoes as separate tool calls.

--- a/commands/canon-start.md
+++ b/commands/canon-start.md
@@ -5,6 +5,13 @@
 Run every step below in order. Do not stop between steps unless explicitly told to.
 
 **Output rules — STRICT:**
+- **Never fabricate tool output.** Every shell command result you cite in
+  chat MUST be the verbatim output of an actual Bash tool call from this
+  session. If a tool call returns nothing, say so. Do not fill in
+  plausible output from memory (wallet addresses, file listings, package
+  counts, "scaffold complete" claims). If you cannot run a required
+  command — or its result is empty when it shouldn't be — stop and tell
+  the user. Do not narrate fictional completion.
 - **Minimize tool calls.** Every Bash call prints output in the chat window.
   Combine checks into single scripts. Never run individual file-existence
   checks, ls commands, or env-var echoes as separate tool calls.


### PR DESCRIPTION
## Summary

Fixes the canon-tui agent hallucination bug
([handoff doc](../blob/fix/conductor-execution-and-verbatim-output/docs/reviews/canon-tui-agent-hallucination-handoff.md)),
specifically the two **claude-code-config** tasks (A1 + A2). Task A3 is
already covered by #328.

When `/canon-start` ran inside `canon run <PATH>`, the Conductor agent
fabricated tool output (Solana-shaped wallet addresses, fake
`.canon/wallet.env` contents pulled from training data, made-up file
listings) instead of executing the deterministic bash blocks. Root
cause: the persona said *Never execute*, the slash command said *Run
this bash block and print the output*, and the agent resolved the
contradiction by pretending to run the command.

### A1 — Conductor persona

`agents/conductor.md`: replace the blanket *Never execute* rule with:

- **Never write code, run tests, or edit project source files** — still
  delegated.
- **Execute deterministic infrastructure scripts directly** — Canon
  scripts under `${DEGA_CORE_HOME}/scripts/`, `canon-cli`, package
  installs, read-only state gathering, bash blocks from slash command
  files. These are infrastructure, not authored work.
- **Never fabricate tool output** — shell results cited in chat must be
  verbatim output of an actual Bash tool call. Empty/error results must
  be surfaced, not invented.

### A2 — canon-start.md verbatim-output rule

`commands/canon-start.md` and `canon/commands/canon-start.md` (identical;
former is the apply-core source, latter is what `canon-scaffold.sh`
fetches into per-project `.claude/commands/`): prepend a *Never fabricate
tool output* bullet to the **Output rules — STRICT** section. Calls out
the specific failure modes seen in the field — wallet addresses, file
listings, package counts, "scaffold complete" claims.

### A3 — already in #328

The TUI-detection gate removal is unchanged here — #328 only touches the
*Graceful degradation* section (line ~518) and is non-overlapping with
these edits at the top of the file. Both PRs can land independently.

## Test plan

- [ ] Merge this PR + #328 to develop
- [ ] In a fresh empty dir, run `/canon-start` via plain `claudep`:
      scaffold + install + `canon-cli wallet ensure` all execute, on-disk
      state matches the chat.
- [ ] In a fresh empty dir inside `canon run <PATH>` (after the canon-tui
      Bash-tool fix lands — Task B1/B2 in the handoff doc), the wallet
      address in chat matches `.canon/wallet.env` on disk and the output
      of `canon-cli wallet info --pretty` from outside the TUI.
- [ ] Confirm conductor.md change doesn't regress orchestrator runs (it
      still bans writing code, running tests, or editing project source
      — only infra scripts are allowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)