### PR TITLE
fix(canon-start): mandate Bash execution, ban narrated completion

### DIFF
--- a/agents/conductor.md
+++ b/agents/conductor.md
@@ -206,11 +206,17 @@ is state gathering — that happens automatically.
   These are infrastructure, not authored work — there is nothing to
   delegate. Refusing to run them and narrating fictional completion is a
   hallucination bug, not persona adherence.
-- **Never fabricate tool output** — every shell result you cite MUST be
-  the verbatim output of an actual Bash tool call from this session. If
-  a tool call returns empty or errors, say so. Do not fill in plausible
-  output from memory. If you cannot run a required command, stop and
-  tell the user.
+- **Never fabricate tool output OR narrated completion** — every shell
+  result you cite *or summarize* MUST be grounded in an actual Bash
+  tool call from this session. Forbidden summaries unless preceded by
+  a real tool call with matching output: "Init complete",
+  "Scaffold created", "X packages installed", "Wallet exists at 0x…",
+  "Files fetched". These are claims of execution and need a
+  corresponding Bash tool call to substantiate. If a tool call returns
+  empty or errors, say so and stop. Do not fill in plausible output
+  from memory. If you cannot run a required command, stop and tell the
+  user. Tool calls are the work, not narration — skipping them to keep
+  output terse is a hallucination, not concision.
 - **Never skip approval** — confirm with the user before spawning work
 - **State first** — gather state before recommending actions
 - **TUI via socket only** — use `canon-ctl`, never `/panel` commands

--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -5,13 +5,29 @@
 Run every step below in order. Do not stop between steps unless explicitly told to.
 
 **Output rules — STRICT:**
-- **Never fabricate tool output.** Every shell command result you cite in
-  chat MUST be the verbatim output of an actual Bash tool call from this
-  session. If a tool call returns nothing, say so. Do not fill in
-  plausible output from memory (wallet addresses, file listings, package
-  counts, "scaffold complete" claims). If you cannot run a required
-  command — or its result is empty when it shouldn't be — stop and tell
-  the user. Do not narrate fictional completion.
+- **Every fenced ` ```bash ` block in this file is a Bash tool call
+  contract.** You MUST issue the actual Bash tool call for each one —
+  the scaffold script, `pnpm install`, `canon-cli wallet ensure`, state
+  writes, all of them. Reading the block is not running it. The tool
+  call itself is the work; the phase-name line is the summary. The
+  "minimize tool calls" and "no narration" rules below mean *combine
+  related checks into one bash block* and *don't add explanatory prose*
+   — they do NOT mean *skip the bash block and narrate completion*.
+   Skipping a required bash block to keep output terse is a
+   hallucination, not concision.
+- **Never fabricate tool output OR narrated completion.** Every shell
+  result you cite OR summarize MUST be grounded in an actual Bash tool
+  call from this session. Forbidden summaries unless preceded by a
+  real tool call with matching output: "Init complete", "Scaffold
+  created", "X packages installed", "Wallet exists at 0x…",
+  "Files fetched", "Agents installed". These are CLAIMS OF EXECUTION
+  and need a corresponding Bash tool call in this session to
+  substantiate. If a tool call returns nothing, say "Bash returned
+  empty" and stop. If you cannot run a required command — or its
+  result is empty when it shouldn't be — stop and tell the user. Do
+  not fill in plausible output from memory (wallet addresses, file
+  listings, package counts, "scaffold complete" claims). Do not
+  narrate fictional completion.
 - **Minimize tool calls.** Every Bash call prints output in the chat window.
   Combine checks into single scripts. Never run individual file-existence
   checks, ls commands, or env-var echoes as separate tool calls.

--- a/commands/canon-start.md
+++ b/commands/canon-start.md
@@ -5,13 +5,29 @@
 Run every step below in order. Do not stop between steps unless explicitly told to.
 
 **Output rules — STRICT:**
-- **Never fabricate tool output.** Every shell command result you cite in
-  chat MUST be the verbatim output of an actual Bash tool call from this
-  session. If a tool call returns nothing, say so. Do not fill in
-  plausible output from memory (wallet addresses, file listings, package
-  counts, "scaffold complete" claims). If you cannot run a required
-  command — or its result is empty when it shouldn't be — stop and tell
-  the user. Do not narrate fictional completion.
+- **Every fenced ` ```bash ` block in this file is a Bash tool call
+  contract.** You MUST issue the actual Bash tool call for each one —
+  the scaffold script, `pnpm install`, `canon-cli wallet ensure`, state
+  writes, all of them. Reading the block is not running it. The tool
+  call itself is the work; the phase-name line is the summary. The
+  "minimize tool calls" and "no narration" rules below mean *combine
+  related checks into one bash block* and *don't add explanatory prose*
+   — they do NOT mean *skip the bash block and narrate completion*.
+   Skipping a required bash block to keep output terse is a
+   hallucination, not concision.
+- **Never fabricate tool output OR narrated completion.** Every shell
+  result you cite OR summarize MUST be grounded in an actual Bash tool
+  call from this session. Forbidden summaries unless preceded by a
+  real tool call with matching output: "Init complete", "Scaffold
+  created", "X packages installed", "Wallet exists at 0x…",
+  "Files fetched", "Agents installed". These are CLAIMS OF EXECUTION
+  and need a corresponding Bash tool call in this session to
+  substantiate. If a tool call returns nothing, say "Bash returned
+  empty" and stop. If you cannot run a required command — or its
+  result is empty when it shouldn't be — stop and tell the user. Do
+  not fill in plausible output from memory (wallet addresses, file
+  listings, package counts, "scaffold complete" claims). Do not
+  narrate fictional completion.
 - **Minimize tool calls.** Every Bash call prints output in the chat window.
   Combine checks into single scripts. Never run individual file-existence
   checks, ls commands, or env-var echoes as separate tool calls.


### PR DESCRIPTION
## Summary

Follow-up to #329. Canary test inside canon-tui confirms the Bash relay
**is fine** — `echo CANARY-\$\$; pwd; date +%s%N; ls -la | wc -l` returns
a real PID, real cwd, real shell. The hallucination bug is **on this
repo's side**, not canon-tui's.

What's actually happening: the agent **skips the scaffold tool call
entirely** and narrates "Init complete, 230 packages installed, wallet
exists at 0x3fEe…cAde" to satisfy the existing **\"minimize tool calls\"
+ \"no narration\"** rules. The previous verbatim-output rule banned
fake **quoted** blocks but not fake **summary lines**, so the agent
slipped through with prose claims.

## Fix

Two-pronged tighten in the same three files as #329:

1. **Bash-block contract** — explicit new rule: every fenced
   ` ```bash ``` ` block in `canon-start.md` MUST be issued as a real
   Bash tool call. Reading is not running. Tool calls are the work, not
   narration. Skipping a block to stay terse is a hallucination, not
   concision.
2. **Ban narrated completion** — extend the \"Never fabricate tool
   output\" rule to also forbid summary phrases unless preceded by a
   real Bash call with matching output. Enumerated the specific
   phrases seen in the wild:
   - \"Init complete\"
   - \"Scaffold created\"
   - \"X packages installed\"
   - \"Wallet exists at 0x…\"
   - \"Files fetched\"
   - \"Agents installed\"

Applied to all three files (same surface as #329):
- `agents/conductor.md` — Rules section
- `commands/canon-start.md` — apply-core source
- `canon/commands/canon-start.md` — canon-scaffold source

## Test plan

- [ ] Merge to develop, refresh dev symlinks (already point at the
      working tree — no action needed once merged)
- [ ] Start fresh canon-tui session in an empty dir, run `/canon-start`
- [ ] Verify: agent issues actual Bash tool calls for scaffold + pnpm
      install + wallet ensure (visible in transcript)
- [ ] Verify: `ls -la` from a normal shell shows the scaffold landed
      (~40 entries, `.canon/wallet.env` exists, real Polygon address)
- [ ] Cross-check: chat-reported wallet matches `.canon/wallet.env` on
      disk and `canon-cli wallet info --pretty` from outside the TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)