### PR TITLE
fix(canon-start): override canon-tui "never echo tool output" rule + host probe

### DIFF
--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -5,6 +5,17 @@
 Run every step below in order. Do not stop between steps unless explicitly told to.
 
 **Output rules — STRICT:**
+- **Scope override for the Canon-TUI agent_context rule.** When this
+  command runs inside Canon TUI, the canon-tui agent_context.md tells
+  you "Never echo tool output" and "The panel IS the answer". Those
+  rules apply **only to `canon-ctl` panel-control commands** (e.g.
+  `canon-ctl action "screen.show_state"`) — not to anything else in
+  this file. For `canon-scaffold.sh`, `pnpm install`, `canon-cli`,
+  `terminal-ui-write.sh`, and every other bash block in `/canon-start`,
+  you MUST issue the Bash tool call and report the actual outcome from
+  its stdout/stderr. The panel only shows what `state.json` writes
+  produce, and those writes are themselves bash blocks here — if you
+  skip the calls, the panel never moves and the work never happens.
 - **Every fenced ` ```bash ` block in this file is a Bash tool call
   contract.** You MUST issue the actual Bash tool call for each one —
   the scaffold script, `pnpm install`, `canon-cli wallet ensure`, state
@@ -41,18 +52,37 @@ Run every step below in order. Do not stop between steps unless explicitly told 
 
 ---
 
-## 0. Pre-flight — open the State panel
+## 0. Pre-flight — diagnostic probe + open the State panel
 
 **ALWAYS run this bash block first**, before any phase detection, before
-the live-mode short-circuit, before anything else. It opens the TUI's
-State panel so the user can watch `.canon/state.json` updates land while
-phases run. Silent no-op if `canon-ctl` is not on PATH. This step is
+the live-mode short-circuit, before anything else. It writes a host-
+visible probe file proving the Bash tool reached a real shell with a
+real filesystem, then opens the TUI's State panel. This step is
 unconditional — it runs on every invocation, including `--live` reruns
 that jump straight to Phase 8.
 
 ```bash
+mkdir -p ~/Desktop/canon-canary
+PROBE=~/Desktop/canon-canary/canon-start-$(date -u +%Y%m%dT%H%M%SZ)-$$.md
+{
+  echo "# canon-start probe"
+  echo "pid: $$"
+  echo "pwd: $(pwd)"
+  echo "host: $(hostname)"
+  echo "user: $USER"
+  echo "date_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "home: $HOME"
+  echo "degacore_scaffold_exists: $([[ -x ~/.degacore/scripts/canon-scaffold.sh ]] && echo yes || echo no)"
+  echo "cwd_entry_count: $(ls -la | wc -l | tr -d ' ')"
+} >"$PROBE"
+echo "probe written: $PROBE"
 command -v canon-ctl >/dev/null && canon-ctl action "screen.show_state" || true
 ```
+
+The probe file lands at `~/Desktop/canon-canary/`. After this command's
+output appears in chat, the file MUST exist on disk — if it doesn't, the
+Bash tool isn't reaching the host filesystem and the rest of the
+pipeline cannot work.
 
 ---
 

--- a/commands/canon-start.md
+++ b/commands/canon-start.md
@@ -5,6 +5,17 @@
 Run every step below in order. Do not stop between steps unless explicitly told to.
 
 **Output rules — STRICT:**
+- **Scope override for the Canon-TUI agent_context rule.** When this
+  command runs inside Canon TUI, the canon-tui agent_context.md tells
+  you "Never echo tool output" and "The panel IS the answer". Those
+  rules apply **only to `canon-ctl` panel-control commands** (e.g.
+  `canon-ctl action "screen.show_state"`) — not to anything else in
+  this file. For `canon-scaffold.sh`, `pnpm install`, `canon-cli`,
+  `terminal-ui-write.sh`, and every other bash block in `/canon-start`,
+  you MUST issue the Bash tool call and report the actual outcome from
+  its stdout/stderr. The panel only shows what `state.json` writes
+  produce, and those writes are themselves bash blocks here — if you
+  skip the calls, the panel never moves and the work never happens.
 - **Every fenced ` ```bash ` block in this file is a Bash tool call
   contract.** You MUST issue the actual Bash tool call for each one —
   the scaffold script, `pnpm install`, `canon-cli wallet ensure`, state
@@ -41,18 +52,37 @@ Run every step below in order. Do not stop between steps unless explicitly told 
 
 ---
 
-## 0. Pre-flight — open the State panel
+## 0. Pre-flight — diagnostic probe + open the State panel
 
 **ALWAYS run this bash block first**, before any phase detection, before
-the live-mode short-circuit, before anything else. It opens the TUI's
-State panel so the user can watch `.canon/state.json` updates land while
-phases run. Silent no-op if `canon-ctl` is not on PATH. This step is
+the live-mode short-circuit, before anything else. It writes a host-
+visible probe file proving the Bash tool reached a real shell with a
+real filesystem, then opens the TUI's State panel. This step is
 unconditional — it runs on every invocation, including `--live` reruns
 that jump straight to Phase 8.
 
 ```bash
+mkdir -p ~/Desktop/canon-canary
+PROBE=~/Desktop/canon-canary/canon-start-$(date -u +%Y%m%dT%H%M%SZ)-$$.md
+{
+  echo "# canon-start probe"
+  echo "pid: $$"
+  echo "pwd: $(pwd)"
+  echo "host: $(hostname)"
+  echo "user: $USER"
+  echo "date_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "home: $HOME"
+  echo "degacore_scaffold_exists: $([[ -x ~/.degacore/scripts/canon-scaffold.sh ]] && echo yes || echo no)"
+  echo "cwd_entry_count: $(ls -la | wc -l | tr -d ' ')"
+} >"$PROBE"
+echo "probe written: $PROBE"
 command -v canon-ctl >/dev/null && canon-ctl action "screen.show_state" || true
 ```
+
+The probe file lands at `~/Desktop/canon-canary/`. After this command's
+output appears in chat, the file MUST exist on disk — if it doesn't, the
+Bash tool isn't reaching the host filesystem and the rest of the
+pipeline cannot work.
 
 ---
 


### PR DESCRIPTION
## Root cause found

Reading canon-tui's `src/toad/data/agent_context.md` revealed the real conflict. Canon-tui injects this as a content block on the first prompt of every session (via `Agent._load_agent_context()` in `src/toad/acp/agent.py:686-715`):

```
## Response style
- **Never echo tool output** — do not include raw JSON, PIDs, return
  codes, or other technical details from canon-ctl responses in your
  messages to the user.
- **The panel IS the answer** — when you open a panel, do NOT summarize
  its contents in chat. […]
- Keep responses short. One sentence is enough for a successful action.
```

That rule was written for `canon-ctl` panel-control commands (suppressing raw socket JSON), but it's phrased generically as "Never echo tool output." When applied to `/canon-start` — dozens of bash blocks that DO need to run and DO need to report real outcomes — the agent reads it as license to **skip execution entirely**. That's why #329 and #330 didn't help: a competing instruction in the injected context said the opposite.

Every observed symptom now fits:
- Empty cwd after \"Phase: init\" → agent didn't issue the scaffold call
- Unmoving state panel → agent didn't issue the `terminal-ui-write.sh` calls
- Plausible-sounding completion summaries → agent obeyed \"Keep it to one sentence\" + filled detail from memory
- Canary worked → user explicitly asked for one specific call; no scope conflict

## This PR

Two related changes, both in the same three files as #329/#330:

### 1. Scope override (top of Output rules — STRICT)

Adds at the top of canon-start.md's strict rules:

> Scope override for the Canon-TUI agent_context rule. \"Never echo tool output\" and \"The panel IS the answer\" apply ONLY to `canon-ctl` panel-control commands — not to `canon-scaffold.sh`, `pnpm install`, `canon-cli`, `terminal-ui-write.sh`, or any other bash block in this file. The panel only shows what `state.json` writes produce, and those writes are themselves bash blocks here — if you skip the calls, the panel never moves and the work never happens.

### 2. Diagnostic probe (top of phase 0)

Adds an unconditional bash block at the start of phase 0 that writes a timestamped marker file to `~/Desktop/canon-canary/`. After running `/canon-start`, we can check the desktop from a normal terminal:
- **File present** → agent IS issuing real Bash calls; override worked
- **File absent** → override didn't take; the proper fix is in canon-tui

## Test plan

- [ ] Merge to develop (symlinks already point at working tree — auto-picks up)
- [ ] Restart canon-tui session, run `/canon-start` in fresh empty dir
- [ ] Check `~/Desktop/canon-canary/canon-start-*.md` exists with correct pwd
- [ ] Verify scaffold lands: `ls ~/dega/aidd/workshop/test-mintXX | wc -l` ≈ 40
- [ ] Verify state panel moves in canon-tui as phases run
- [ ] Cross-check wallet: chat-reported address == `.canon/wallet.env` on disk == `canon-cli wallet info --pretty`

## Follow-up

The proper fix is on the canon-tui side — narrow `agent_context.md` from \"Never echo tool output\" to \"Never echo `canon-ctl` output.\" Same intent without suppressing every other tool's output. Will file against `DEGAorg/canon-tui` after this lands and we confirm the override unblocks testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)