### PR TITLE
chore(conductor,canon-start): cleanup — delegation primary, no Task subagent, probe env-gated

### DIFF
--- a/agents/conductor.md
+++ b/agents/conductor.md
@@ -189,35 +189,32 @@ is state gathering — that happens automatically.
 
 ## Rules
 
-- **Never block** — all long-running operations use `run_in_background`
-- **Never write code, run tests, or edit project source files** — those
-  go through delegation (subagents, orchestrator)
-- **Execute deterministic infrastructure scripts directly** — Conductor
-  MAY (and should) run:
-  - Canon scripts under `${DEGA_CORE_HOME:-$HOME/.degacore}/scripts/`
-    (`canon-scaffold.sh`, `canon-runner.sh`, `canon-live-readiness.sh`,
-    `canon.sh`)
-  - `canon-cli` with any subcommand
-  - Package-manager installs (`pnpm install`, `npm install`)
-  - Read-only state-gathering commands (`ls`, `cat`, `grep`, `git status`,
-    `gh pr list`, etc.)
-  - Bash blocks explicitly defined in slash command files under
-    `~/.claude/commands/` or `.claude/commands/`
-  These are infrastructure, not authored work — there is nothing to
-  delegate. Refusing to run them and narrating fictional completion is a
-  hallucination bug, not persona adherence.
-- **Never fabricate tool output OR narrated completion** — every shell
-  result you cite *or summarize* MUST be grounded in an actual Bash
-  tool call from this session. Forbidden summaries unless preceded by
-  a real tool call with matching output: "Init complete",
+- **Default: delegate** — code, tests, edits, feature work, and anything
+  the user wants reasoned about goes to the right subagent (Canon agents,
+  orchestrator workers, planner). You orchestrate; they do.
+- **Exception: deterministic slash commands** — `/canon-start`,
+  `/canon-init`, and similar bash-pipeline commands under
+  `~/.claude/commands/` or `.claude/commands/` are infrastructure, not
+  authored work. Their phases ARE bash blocks. Issue every bash block
+  via the **Bash tool directly**. Do NOT route through the Task tool —
+  Task subagents have been observed to fabricate completion without
+  running. There is no agent to delegate to; the bash call IS the work.
+- **State gathering: yourself, directly** — `ls`, `cat`, `grep`,
+  `git status`, `gh pr list`, `canon-cli` for state queries. Direct
+  Bash, no delegation.
+- **Defer to the panel** — Canon TUI shows state, metrics, progress,
+  logs on the right pane. Your chat output is for: phase name (one
+  line), decisions, user questions. State detail goes into
+  `.canon/state.json` via `terminal-ui-write.sh`, not into chat.
+- **Never fabricate** — every shell result you cite **or summarize**
+  must be backed by a real Bash tool call from this session.
+  Forbidden summaries without a backing call: "Init complete",
   "Scaffold created", "X packages installed", "Wallet exists at 0x…",
-  "Files fetched". These are claims of execution and need a
-  corresponding Bash tool call to substantiate. If a tool call returns
-  empty or errors, say so and stop. Do not fill in plausible output
-  from memory. If you cannot run a required command, stop and tell the
-  user. Tool calls are the work, not narration — skipping them to keep
+  "Files fetched". If a tool call returns empty or errors, say so and
+  stop. Tool calls are the work, not narration — skipping them to keep
   output terse is a hallucination, not concision.
-- **Never skip approval** — confirm with the user before spawning work
-- **State first** — gather state before recommending actions
-- **TUI via socket only** — use `canon-ctl`, never `/panel` commands
-- **Graceful degradation** — if TUI is down, proceed without it
+- **Never block** — long-running operations use `run_in_background`.
+- **Never skip approval** — confirm with the user before spawning work.
+- **State first** — gather state before recommending actions.
+- **TUI via socket only** — use `canon-ctl`, never `/panel` commands.
+- **Graceful degradation** — if TUI is down, proceed without it.

--- a/canon/commands/canon-start.md
+++ b/canon/commands/canon-start.md
@@ -5,6 +5,12 @@
 Run every step below in order. Do not stop between steps unless explicitly told to.
 
 **Output rules — STRICT:**
+- **Use the Bash tool directly, never the Task tool.** Every fenced
+  bash block here is infrastructure (scaffold, install, wallet ensure,
+  state writes), not authored work. Issue each via the Bash tool
+  yourself. Do **not** spawn Task subagents to "run the bash" — they
+  fabricate completion without executing. There is no agent to
+  delegate to; the bash call IS the work.
 - **Scope override for the Canon-TUI agent_context rule.** When this
   command runs inside Canon TUI, the canon-tui agent_context.md tells
   you "Never echo tool output" and "The panel IS the answer". Those
@@ -52,37 +58,34 @@ Run every step below in order. Do not stop between steps unless explicitly told 
 
 ---
 
-## 0. Pre-flight — diagnostic probe + open the State panel
+## 0. Pre-flight — open the State panel (and optional diagnostic probe)
 
 **ALWAYS run this bash block first**, before any phase detection, before
-the live-mode short-circuit, before anything else. It writes a host-
-visible probe file proving the Bash tool reached a real shell with a
-real filesystem, then opens the TUI's State panel. This step is
-unconditional — it runs on every invocation, including `--live` reruns
-that jump straight to Phase 8.
+the live-mode short-circuit, before anything else. It opens the TUI's
+State panel. If `CANON_DEBUG_PROBE=1` is set in the environment, it
+also writes a host-visible probe file to `~/Desktop/canon-canary/` so
+you can verify the Bash tool is reaching the real filesystem (used
+when diagnosing canon-tui agent issues; default off).
 
 ```bash
-mkdir -p ~/Desktop/canon-canary
-PROBE=~/Desktop/canon-canary/canon-start-$(date -u +%Y%m%dT%H%M%SZ)-$$.md
-{
-  echo "# canon-start probe"
-  echo "pid: $$"
-  echo "pwd: $(pwd)"
-  echo "host: $(hostname)"
-  echo "user: $USER"
-  echo "date_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  echo "home: $HOME"
-  echo "degacore_scaffold_exists: $([[ -x ~/.degacore/scripts/canon-scaffold.sh ]] && echo yes || echo no)"
-  echo "cwd_entry_count: $(ls -la | wc -l | tr -d ' ')"
-} >"$PROBE"
-echo "probe written: $PROBE"
 command -v canon-ctl >/dev/null && canon-ctl action "screen.show_state" || true
+if [[ -n "${CANON_DEBUG_PROBE:-}" ]]; then
+  mkdir -p ~/Desktop/canon-canary
+  PROBE=~/Desktop/canon-canary/canon-start-$(date -u +%Y%m%dT%H%M%SZ)-$$.md
+  {
+    echo "# canon-start probe"
+    echo "pid: $$"
+    echo "pwd: $(pwd)"
+    echo "host: $(hostname)"
+    echo "user: $USER"
+    echo "date_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "home: $HOME"
+    echo "degacore_scaffold_exists: $([[ -x ~/.degacore/scripts/canon-scaffold.sh ]] && echo yes || echo no)"
+    echo "cwd_entry_count: $(ls -la | wc -l | tr -d ' ')"
+  } >"$PROBE"
+  echo "probe written: $PROBE"
+fi
 ```
-
-The probe file lands at `~/Desktop/canon-canary/`. After this command's
-output appears in chat, the file MUST exist on disk — if it doesn't, the
-Bash tool isn't reaching the host filesystem and the rest of the
-pipeline cannot work.
 
 ---
 

--- a/commands/canon-start.md
+++ b/commands/canon-start.md
@@ -5,6 +5,12 @@
 Run every step below in order. Do not stop between steps unless explicitly told to.
 
 **Output rules — STRICT:**
+- **Use the Bash tool directly, never the Task tool.** Every fenced
+  bash block here is infrastructure (scaffold, install, wallet ensure,
+  state writes), not authored work. Issue each via the Bash tool
+  yourself. Do **not** spawn Task subagents to "run the bash" — they
+  fabricate completion without executing. There is no agent to
+  delegate to; the bash call IS the work.
 - **Scope override for the Canon-TUI agent_context rule.** When this
   command runs inside Canon TUI, the canon-tui agent_context.md tells
   you "Never echo tool output" and "The panel IS the answer". Those
@@ -52,37 +58,34 @@ Run every step below in order. Do not stop between steps unless explicitly told 
 
 ---
 
-## 0. Pre-flight — diagnostic probe + open the State panel
+## 0. Pre-flight — open the State panel (and optional diagnostic probe)
 
 **ALWAYS run this bash block first**, before any phase detection, before
-the live-mode short-circuit, before anything else. It writes a host-
-visible probe file proving the Bash tool reached a real shell with a
-real filesystem, then opens the TUI's State panel. This step is
-unconditional — it runs on every invocation, including `--live` reruns
-that jump straight to Phase 8.
+the live-mode short-circuit, before anything else. It opens the TUI's
+State panel. If `CANON_DEBUG_PROBE=1` is set in the environment, it
+also writes a host-visible probe file to `~/Desktop/canon-canary/` so
+you can verify the Bash tool is reaching the real filesystem (used
+when diagnosing canon-tui agent issues; default off).
 
 ```bash
-mkdir -p ~/Desktop/canon-canary
-PROBE=~/Desktop/canon-canary/canon-start-$(date -u +%Y%m%dT%H%M%SZ)-$$.md
-{
-  echo "# canon-start probe"
-  echo "pid: $$"
-  echo "pwd: $(pwd)"
-  echo "host: $(hostname)"
-  echo "user: $USER"
-  echo "date_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  echo "home: $HOME"
-  echo "degacore_scaffold_exists: $([[ -x ~/.degacore/scripts/canon-scaffold.sh ]] && echo yes || echo no)"
-  echo "cwd_entry_count: $(ls -la | wc -l | tr -d ' ')"
-} >"$PROBE"
-echo "probe written: $PROBE"
 command -v canon-ctl >/dev/null && canon-ctl action "screen.show_state" || true
+if [[ -n "${CANON_DEBUG_PROBE:-}" ]]; then
+  mkdir -p ~/Desktop/canon-canary
+  PROBE=~/Desktop/canon-canary/canon-start-$(date -u +%Y%m%dT%H%M%SZ)-$$.md
+  {
+    echo "# canon-start probe"
+    echo "pid: $$"
+    echo "pwd: $(pwd)"
+    echo "host: $(hostname)"
+    echo "user: $USER"
+    echo "date_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "home: $HOME"
+    echo "degacore_scaffold_exists: $([[ -x ~/.degacore/scripts/canon-scaffold.sh ]] && echo yes || echo no)"
+    echo "cwd_entry_count: $(ls -la | wc -l | tr -d ' ')"
+  } >"$PROBE"
+  echo "probe written: $PROBE"
+fi
 ```
-
-The probe file lands at `~/Desktop/canon-canary/`. After this command's
-output appears in chat, the file MUST exist on disk — if it doesn't, the
-Bash tool isn't reaching the host filesystem and the rest of the
-pipeline cannot work.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 1 cleanup after the canon-tui hallucination postmortem (#329, #330, #331). Live session reached green: scaffold landed, wallet agreed three ways (chat / `.canon/wallet.env` / `canon-cli wallet info`). This PR consolidates what worked, restores the Conductor's original delegation framing, and removes a piece of diagnostic plumbing from the hot path.

## What this changes

### `agents/conductor.md` — delegation primary, execution exceptional

The session showed that direct execution **is** needed for `/canon-start` (the slash command IS a bash pipeline), but the previous rewrite over-rotated and made execution feel co-equal with delegation. This restores delegation as the default and reframes execution as an explicit narrow exception:

```
- Default: delegate — code, tests, edits, feature work go to subagents.
- Exception: deterministic slash commands — /canon-start, /canon-init.
  Issue every bash block via the Bash tool directly. Do NOT route
  through the Task tool — Task subagents fabricate. There is no agent
  to delegate to; the bash call IS the work.
- State gathering: yourself, directly.
- Defer to the panel — chat is phase name + decisions; detail goes to
  state.json via terminal-ui-write.sh, not chat.
- Never fabricate — every cited/summarized shell result backed by a
  real Bash call this session.
```

### `commands/canon-start.md` + `canon/commands/canon-start.md`

Adds at the top of the STRICT output rules:

```
Use the Bash tool directly, never the Task tool. Every fenced bash
block here is infrastructure, not authored work. Do not spawn Task
subagents to "run the bash" — they fabricate completion without
executing. There is no agent to delegate to; the bash call IS the work.
```

This was the unwritten 4th fix that finally unblocked the live test. With the canon-tui-injected `agent_context.md` advising "the panel IS the answer" + the default Claude instinct to delegate, the agent kept routing bash through Task subagents, which fabricated. Telling it explicitly per-turn worked; this codifies it so we don't have to.

### Probe → env-gated

The host-visible probe at phase 0 served its diagnostic purpose. Default-off now, fires only when `CANON_DEBUG_PROBE=1` is set in the environment when launching canon-tui. Deterministic shell check, not an agentic decision. Keeps the diagnostic available without adding chat noise on every run.

## Test plan

- [ ] Merge to develop (symlinks already point at working tree)
- [ ] Restart canon-tui in a fresh empty dir; run `/canon-start`
- [ ] Chat should be quiet (phase names + decisions only)
- [ ] Probe should NOT write unless `CANON_DEBUG_PROBE=1`
- [ ] Scaffold lands ~40 entries; wallet agrees three ways
- [ ] Panel moves as phases run

## Follow-ups (banked, not in this PR)

On `DEGAorg/canon-tui`:
1. Spawn claude with conductor as the actual **system prompt** (currently injected as user content via `_load_agent_context`). Until this lands, every behavioral rule here is advisory rather than binding.
2. Narrow `src/toad/data/agent_context.md`'s "Never echo tool output" → "Never echo `canon-ctl` output". Makes #331's scope override obsolete on this side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)