### PR TITLE
fix(orch): unjam document phase end-to-end — 6 bugs (printf, persist race, crash halts, wave-bail, parser)

### DIFF
--- a/scripts/orch-document.sh
+++ b/scripts/orch-document.sh
@@ -199,13 +199,21 @@ orch_document_parse_report() {
 
   local text
   # stream-json lines: { "type": "assistant", "message": { "content": [...] } }
-  text=$(jq -rs '
+  #
+  # The pipe-pane log includes everything the tmux pane emitted — and at
+  # close time tmux writes terminal-restore ANSI escape sequences plus our
+  # `--- documenter N exited ---` marker. Those trailing non-JSON bytes
+  # land on the log's last line and crash `jq -rs` (slurp), which then
+  # returns nothing — leaving the parser to fall back to raw bytes that
+  # awk's fence regex can't match, so even a clean PASS / NO_CHANGES_NEEDED
+  # report would be miscategorized as FAIL. Prefilter to JSON-object lines.
+  text=$(grep '^{' "${log_file}" | jq -rs '
     map(select((.type? // "") == "assistant"))
     | map(.message.content // [])
     | flatten
     | map(select((.type? // "") == "text") | .text)
     | join("\n")
-  ' "${log_file}" 2>/dev/null) || text=""
+  ' 2>/dev/null) || text=""
 
   if [[ -z "${text}" ]]; then
     text=$(cat "${log_file}" 2>/dev/null || printf '')

--- a/scripts/orch-document.sh
+++ b/scripts/orch-document.sh
@@ -387,10 +387,10 @@ spawn_documenter() {
     printf '%s\n' "${prompt_body}"
     printf '\n---\n\n'
     printf '## Your Assignment\n\n'
-    printf '- **Item ID**: %s\n' "${item_id}"
-    printf '- **Item description**: %s\n' "${item_desc}"
-    printf '- **Inputs directory**: %s/inputs\n' "${WORKTREE_DIR}"
-    printf '- **Working directory**: %s\n' "${WORKTREE_DIR}"
+    printf -- '- **Item ID**: %s\n' "${item_id}"
+    printf -- '- **Item description**: %s\n' "${item_desc}"
+    printf -- '- **Inputs directory**: %s/inputs\n' "${WORKTREE_DIR}"
+    printf -- '- **Working directory**: %s\n' "${WORKTREE_DIR}"
   } >"${prompt_file}"
 
   rm -f "${DOC_DIR}/item-${item_id}.txt"
@@ -473,7 +473,16 @@ persist_pending_reports() {
       continue
     fi
 
-    if printf '%s\n' "${live_windows}" | grep -q "^${window_name} 1$"; then
+    # Persist when the window is NOT alive — either `pane_dead=1` (exited
+    # but still listed) OR gone entirely (default tmux removes a window
+    # when its pane exits, so between two polls a window can transition
+    # alive → gone without ever being observed as pane_dead=1). The
+    # pipe-pane log is written eagerly to ${raw_log}, so it exists even
+    # when tmux has already dropped the window. Without this, a clean
+    # documenter exit between polls leaves docStatus=documenting until
+    # detect_stale_documenters marks it failed — triggering a spurious
+    # REVISE loop on items the doc-writer actually completed.
+    if ! printf '%s\n' "${live_windows}" | grep -q "^${window_name} 0$"; then
       if [[ -f "${raw_log}" ]]; then
         orch_document_persist_report "${SLUG}" "${item_id}" "${raw_log}"
       else

--- a/scripts/orch-engine.sh
+++ b/scripts/orch-engine.sh
@@ -491,11 +491,29 @@ if [[ "${review_rc}" -eq 124 ]]; then
     '.finalReview.result = "REVISE" | .updatedAt = $now' "${ORCH_STATE_FILE}")
   orch_write_state "${SLUG}" "${updated}"
 elif [[ "${review_rc}" -ne 0 ]]; then
-  echo "orch-engine: orch-review.sh exited with rc=${review_rc} — REVISE" >&2
+  # An orch-review.sh non-zero rc (script crash OR legitimate "nothing
+  # to review" error when all items are terminally failed) is a HALT
+  # condition, not a legitimate REVISE verdict. The previous behaviour
+  # set REVIEW_RESULT=REVISE and re-execed the wave — an infinite loop
+  # when the underlying cause was "all items failed", since each wave
+  # would re-enter the same state. Mirrors the document-phase fix.
+  echo "orch-engine: orch-review.sh exited with rc=${review_rc} — REVIEW_FAILED (halting plan)" >&2
+  # Mark items still in "reviewing" as failed (mirrors timeout branch).
+  reviewing_ids=$(jq -r '.items[] | select(.reviewStatus == "reviewing") | .id' \
+    "${ORCH_STATE_FILE}")
   now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  updated=$(jq --arg now "${now}" \
-    '.finalReview.result = "REVISE" | .updatedAt = $now' "${ORCH_STATE_FILE}")
-  orch_write_state "${SLUG}" "${updated}"
+  state=$(cat "${ORCH_STATE_FILE}")
+  for rid in ${reviewing_ids}; do
+    state=$(printf '%s' "${state}" | jq \
+      --argjson id "${rid}" \
+      --arg now "${now}" \
+      '(.items[] | select(.id == $id)).reviewStatus = "failed" |
+       .updatedAt = $now')
+  done
+  state=$(printf '%s' "${state}" | jq \
+    --arg now "${now}" \
+    '.finalReview.result = "REVIEW_FAILED" | .updatedAt = $now')
+  orch_write_state "${SLUG}" "${state}"
 fi
 
 write_heartbeat
@@ -1161,6 +1179,29 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
   write_heartbeat
   exit 0
 elif [[ "${REVIEW_RESULT}" == "REVISE" ]]; then
+  # Wave-bail gate: if no items are recoverable (all are in terminal
+  # done/failed/skipped state, or all hit max_iterations and were
+  # marked failed), halt instead of re-execing the wave. Otherwise the
+  # engine loops indefinitely on a state where nothing can change —
+  # observed when orch-review.sh's "nothing to review" rc=1 was misread
+  # as REVISE despite every item being terminally failed.
+  RECOVERABLE=$(jq '[.items[] | select(.status == "ready" or .status == "running" or .status == "queued" or .status == "pending")] | length' "${ORCH_STATE_FILE}")
+  if [[ "${RECOVERABLE}" -eq 0 ]]; then
+    echo ""
+    echo "orch-engine: REVISE requested but no recoverable items remain — halting plan" >&2
+    echo "  All items are in terminal state (done/failed/skipped) or exhausted max iterations." >&2
+    echo "  Inspect ${LOG_DIR}/ and the worktree at" >&2
+    echo "  ${ORCH_STATE_DIR}/worktrees/${SLUG} to triage." >&2
+    orch_master_deregister "${SLUG}" "failed"
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    updated=$(jq \
+      --arg now "${now}" \
+      '.status = "failed" | .updatedAt = $now' "${ORCH_STATE_FILE}")
+    orch_write_state "${SLUG}" "${updated}"
+    write_heartbeat
+    exit 1
+  fi
+
   echo ""
   echo "orch-engine: REVISE — some items need rework"
   echo "  Re-running wave execution for rework items..."
@@ -1189,6 +1230,19 @@ elif [[ "${REVIEW_RESULT}" == "REVISE" ]]; then
   fi
   # shellcheck disable=SC2086
   exec "${SCRIPT_DIR}/orch-engine.sh" "${SLUG}" --max-workers "${MAX_WORKERS}" --max-iterations "${MAX_ITERATIONS}" ${BACKGROUND_FLAG}
+elif [[ "${REVIEW_RESULT}" == "REVIEW_FAILED" ]]; then
+  echo ""
+  echo "orch-engine: REVIEW phase failed — halting plan" >&2
+  echo "  Inspect ${LOG_DIR}/reviewer-*.log and the worktree at" >&2
+  echo "  ${ORCH_STATE_DIR}/worktrees/${SLUG} to triage." >&2
+  orch_master_deregister "${SLUG}" "failed"
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  updated=$(jq \
+    --arg now "${now}" \
+    '.status = "failed" | .updatedAt = $now' "${ORCH_STATE_FILE}")
+  orch_write_state "${SLUG}" "${updated}"
+  write_heartbeat
+  exit 1
 elif [[ "${REVIEW_RESULT}" == "DOCUMENT_FAILED" ]]; then
   echo ""
   echo "orch-engine: DOCUMENTING phase failed — halting plan" >&2

--- a/scripts/orch-engine.sh
+++ b/scripts/orch-engine.sh
@@ -572,8 +572,27 @@ if [[ "${REVIEW_RESULT}" == "SHIP" ]]; then
       "${document_timeout_secs}" "${document_blocking}"
     REVIEW_RESULT="REVISE"
   elif [[ "${document_rc}" -ne 0 ]]; then
-    echo "orch-engine: orch-document.sh exited with rc=${document_rc} — REVISE" >&2
-    REVIEW_RESULT="REVISE"
+    # An orch-document.sh CRASH (rc != 0, != 124) is a bug, not a legitimate
+    # REVISE verdict. Halt so the crash surfaces for diagnosis instead of
+    # being papered over by a rework loop. Mark items still in `documenting`
+    # as failed so a resumed plan does not re-enter the same broken phase.
+    # Mirrors the timeout branch above.
+    echo "orch-engine: orch-document.sh exited with rc=${document_rc} — DOCUMENT_FAILED (halting plan)" >&2
+    documenting_ids=$(jq -r '.items[] | select(.docStatus == "documenting") | .id' \
+      "${ORCH_STATE_FILE}")
+    if [[ -n "${documenting_ids}" ]]; then
+      now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+      state=$(cat "${ORCH_STATE_FILE}")
+      for did in ${documenting_ids}; do
+        state=$(printf '%s' "${state}" | jq \
+          --argjson id "${did}" \
+          --arg now "${now}" \
+          '(.items[] | select(.id == $id)).docStatus = "failed" |
+           .updatedAt = $now')
+      done
+      orch_write_state "${SLUG}" "${state}"
+    fi
+    REVIEW_RESULT="DOCUMENT_FAILED"
   else
     DOC_RESULT=$(jq -r '.documentation.result // "UNKNOWN"' "${ORCH_STATE_FILE}")
     if [[ "${DOC_RESULT}" == "REVISE" ]]; then
@@ -1170,6 +1189,19 @@ elif [[ "${REVIEW_RESULT}" == "REVISE" ]]; then
   fi
   # shellcheck disable=SC2086
   exec "${SCRIPT_DIR}/orch-engine.sh" "${SLUG}" --max-workers "${MAX_WORKERS}" --max-iterations "${MAX_ITERATIONS}" ${BACKGROUND_FLAG}
+elif [[ "${REVIEW_RESULT}" == "DOCUMENT_FAILED" ]]; then
+  echo ""
+  echo "orch-engine: DOCUMENTING phase failed — halting plan" >&2
+  echo "  Inspect ${LOG_DIR}/documenter-*.log and the worktree at" >&2
+  echo "  ${ORCH_STATE_DIR}/worktrees/${SLUG} to triage." >&2
+  orch_master_deregister "${SLUG}" "failed"
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  updated=$(jq \
+    --arg now "${now}" \
+    '.status = "failed" | .updatedAt = $now' "${ORCH_STATE_FILE}")
+  orch_write_state "${SLUG}" "${updated}"
+  write_heartbeat
+  exit 1
 elif [[ "${REVIEW_RESULT}" == "FORMATTING_FAILED" ]]; then
   echo ""
   echo "orch-engine: FORMATTING phase failed — halting plan" >&2


### PR DESCRIPTION
## Summary

Six independent bugs in the orchestrator's document-phase + engine-dispatch path that together made plans either crash on every run or loop the wave indefinitely. Each fix unmasked the next; together they take an in-tree `/plan` from launch to a clean PR on `develop`.

**End-to-end smoke confirmed:** the same plan (#347) that crashed before the fixes shipped in **2 min 41 sec** on smoke #5, opened PR #349 from `orch/347-…` → `develop`, and cleaned up worktree + branch. All 9 SHIP steps passed.

Reproduced on bash 5.3.9 (`GNU bash 5.3.9, aarch64-apple-darwin24.6.0`). Most bugs surface only on bash; zsh's `printf` tolerates leading `-`, which masked bug #1 in interactive shells.

## Fixes (3 commits)

### Commit 1 — printf, persist race, document-crash halt

**`scripts/orch-document.sh`**

1. **`spawn_documenter` lines 390-393: printf-flag crash.** `printf '- **Item ID**: %s\n' ...` — bash builtin printf parses leading `-` as an option flag, raising `printf: - : invalid option` and exiting `rc=2` under `set -euo pipefail`. Guarded with `printf --`.
2. **`persist_pending_reports` line 476: window-gone race.** The previous check only matched `pane_dead=1` (window exited but still listed). tmux's default removes a window when its pane exits, so between two 10s polls a window can transition `alive → gone` without ever being seen as `pane_dead=1`. The pipe-pane log is written eagerly, so persist now fires whenever the window is **not alive** (dead OR gone). Otherwise `detect_stale_documenters` raced persist and marked completed work as failed.

**`scripts/orch-engine.sh`**

3. **Document-phase rc handler lines 574-595: halt, don't loop.** When `orch-document.sh` exited with `rc != 0, != 124`, the engine set `REVIEW_RESULT="REVISE"` and re-execed — an infinite loop, since the next wave hit the same crash. Now sets `DOCUMENT_FAILED`, marks stuck items as failed, and halts; new explicit exit branch mirrors `FORMATTING_FAILED`.

### Commit 2 — review-crash halt + wave-bail gate

**`scripts/orch-engine.sh`**

4. **Review-phase rc handler lines 493-516: halt, don't loop.** Same anti-pattern as #3 in the review phase. `orch-review.sh` exits `rc=1` with `error: no items completed — nothing to review (1 failed)` when every item has terminally failed; engine misread that as `REVISE` → wave re-exec → loop. Now sets `REVIEW_FAILED`, marks stuck `reviewing` items as failed, and halts; new explicit exit branch.
5. **Wave-bail gate before REVISE re-exec line 1181+.** Before re-execing the engine on `REVISE`, count items still in non-terminal status (`ready/running/queued/pending`). If zero, halt with `status=failed` instead of looping on terminally-failed items. Defense in depth against future REVISE-leak bugs.

### Commit 3 — parser robust to terminal escape garbage

**`scripts/orch-document.sh`**

6. **`orch_document_parse_report` lines 210+: prefilter to JSON lines.** The tmux pipe-pane log appends terminal ANSI escape sequences + the `--- documenter N exited ---` marker when the window closes. The parser's `jq -rs` (slurp) reads ALL lines and fails on the first invalid one — even though lines 1-22 are valid JSONL, line 23's terminal garbage crashed jq with `Invalid numeric literal at line 23, column 2`. The error was swallowed by `2>/dev/null`; `text` came back empty; the fallback `cat` returned raw bytes that awk's `^...$` fence regex couldn't match; and the parser wrote `FAIL` even on clean `NO_CHANGES_NEEDED` reports. Prefilter with `grep '^{'` keeps only JSON-object lines; jq slurps a clean array.

## Test plan

- `shellcheck -e SC1091 scripts/orch-document.sh scripts/orch-engine.sh` → rc=0
- `shfmt -d scripts/orch-document.sh scripts/orch-engine.sh` → rc=0
- **5 end-to-end smoke runs** on plan #347:
  - **#1:** confirmed bug #1 + the unconditional REVISE loop (infinite loop, manual kill after ~7 min).
  - **#2:** with fix #1 alone, exposed bugs #2 + #5 (loop persisted at engine level, killed at 15-min watcher cap).
  - **#3:** with fixes #1+#3 (intermediate state), exposed the cascade more clearly + bug #6 evidence — killed early to capture the doc-writer log before teardown.
  - **#4:** with fixes #1-5 — engine **halted cleanly via `DOCUMENT_FAILED`** at +120s when bug #6 caused doc-rc=2. First confirmation of the halt-not-loop fixes.
  - **#5 (this commit set):** **shipped cleanly at +161s.** Worker → review → document → format → push → PR #349 opened → worktree + branch cleaned up. All 9 SHIP steps passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
