### PR TITLE
fix(orch): don't commit inputs/ + formatting/ scratch dirs (was orphaned from PR #348)

### DIFF
--- a/scripts/orch-state.sh
+++ b/scripts/orch-state.sh
@@ -311,7 +311,7 @@ orch_sync_done_files() {
         local wt_changes
         wt_changes=$(git -C "${worktree_dir}" status --porcelain 2>/dev/null || true)
         if [[ -n "${wt_changes}" ]]; then
-          git -C "${worktree_dir}" add -A
+          git -C "${worktree_dir}" add -A -- '.' ':(exclude)inputs' ':(exclude)formatting'
           if git -C "${worktree_dir}" commit --no-verify \
             -m "orch: item ${item_id} — ${item_desc}"; then
             echo "orch-state: committed item ${item_id} changes in worktree"
@@ -1008,7 +1008,7 @@ orch_commit_worktree() {
   fi
 
   # Stage and commit all changes in the worktree
-  git -C "${worktree_dir}" add -A
+  git -C "${worktree_dir}" add -A -- '.' ':(exclude)inputs' ':(exclude)formatting'
   if git -C "${worktree_dir}" commit --no-verify -m "orch: ${slug} — worker changes
 
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"; then


### PR DESCRIPTION
Cherry-picks commit `4713fe86` from the original fix branch, which was orphaned when PR [#348](https://github.com/DEGAorg/claude-code-config/pull/348) merged at `05:08 UTC` with only 3 of 4 commits.

## Why this matters

`orch_commit_worktree` and the per-item progress commit in `orch-state.sh` both used `git -C "${worktree_dir}" add -A` to stage worker output. That sweeps in two orch-internal scratch directories that `stage_inputs` functions write at the **worktree root**, not under `.orchestrator/`:

- `inputs/` — written by `orch_document_stage_inputs` (`item-description.txt`, `item-id.txt`, `diff.patch`, `changed-files.txt`, `done-summary.txt`, `plan.md`)
- `formatting/` — written by `orch_format_stage_inputs` (`result.txt`)

Neither path is in the repo `.gitignore` (only `/.orchestrator/` is). The result: the orch's own auto-PR landed with ~87 lines of agent scratch alongside the actual work change — observed on PR [#349](https://github.com/DEGAorg/claude-code-config/pull/349), which was closed in favor of the manually-recreated [#351](https://github.com/DEGAorg/claude-code-config/pull/351).

## The fix

Add explicit pathspec excludes to both `add -A` sites in `orch-state.sh` (lines 314 + 1011):

```bash
git add -A -- '.' ':(exclude)inputs' ':(exclude)formatting'
```

A cleaner long-term fix is to move `stage_inputs` writes under `.orchestrator/` (already gitignored). That's a multi-script refactor; this surgical fix unblocks clean orch PRs today.

## Diff scope

1 file changed, 2 insertions(+), 2 deletions(-). Two lines patched in `scripts/orch-state.sh`.
