### PR TITLE
chore: remove deprecated planner from install + docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,7 +92,7 @@ uv tool install "canon-tui @ git+https://github.com/DEGAorg/canon-tui.git@main" 
 | **Commands** | `config/commands/` | `/plan`, `/fix-issue`, `/review-pr`, `/cleanup`, `/doc-garden`, `/core-init` |
 | **Rules** | `config/rules/` | Language standards (Python, TypeScript, Rust, Bash, GitHub Actions) |
 | **Skills** | `config/skills/` | App legibility, custom linters, sound notifications |
-| **Agents** | `config/agents/` | Worker, verifier, and planner agent prompts |
+| **Agents** | `config/agents/` | Worker and verifier agent prompts |
 | **Hooks** | `scripts/hooks/` | Guardrails: block `rm -rf`, enforce package manager, play sounds |
 | **Orchestrator** | `scripts/orch-*.sh` | Parallel plan execution engine (needs `tmux`, `jq`) |
 | **Terminal UI** | `scripts/terminal-ui/` | Ink dashboard for monitoring runs (needs `node`, `pnpm`) |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ That's it. The agent fetches the install instructions and runs the full setup au
 
 ### Multi-agent support
 
-The orchestrator, planner, and all hooks run identically under any supported agent. An abstraction layer ([`scripts/agent-shim.sh`](scripts/agent-shim.sh)) detects the provider at runtime and adapts CLI flags, config paths, and invocation patterns automatically. Settings are generated per-agent from a single [`settings-template.json`](settings-template.json) via adapters in [`scripts/adapters/`](scripts/adapters/). See **[Agent-Agnostic Architecture](docs/agent-agnostic-architecture.md)** for the full design.
+The orchestrator and all hooks run identically under any supported agent. An abstraction layer ([`scripts/agent-shim.sh`](scripts/agent-shim.sh)) detects the provider at runtime and adapts CLI flags, config paths, and invocation patterns automatically. Settings are generated per-agent from a single [`settings-template.json`](settings-template.json) via adapters in [`scripts/adapters/`](scripts/adapters/). See **[Agent-Agnostic Architecture](docs/agent-agnostic-architecture.md)** for the full design.
 
 ## Contents
 

--- a/agents/conductor.md
+++ b/agents/conductor.md
@@ -10,9 +10,9 @@ Defer state detail to the Canon TUI panel via `terminal-ui-write.sh`;
 chat is for phase names, decisions, and user questions.
 
 For code, tests, edits, and feature work, delegate to the appropriate
-subagent (Canon agents, orchestrator workers, planner). For state
-queries and the bash blocks inside slash commands like `/canon-start`,
-run them yourself.
+subagent (Canon agents, orchestrator workers). For state queries and
+the bash blocks inside slash commands like `/canon-start`, run them
+yourself.
 
 ## Persona
 

--- a/commands/apply-core.md
+++ b/commands/apply-core.md
@@ -90,9 +90,6 @@ Files available:
 - `agents/orch-worker.md`
 - `agents/orch-verifier.md`
 - `hooks/orch-done-sync.sh`
-- `scripts/planner-loop.sh`
-- `agents/planner-assess.md`
-- `agents/planner-writer.md`
 - `sounds/unstoppable.mp3`
 - `sounds/super-mario-bros.mp3`
 - `sounds/yeahoo.mp3`
@@ -238,7 +235,6 @@ Read and note which of these already exist under `~/.degacore/`:
 - `~/.degacore/scripts/orch-review.sh`
 - `~/.degacore/scripts/orch-verify.sh`
 - `~/.degacore/scripts/ralph-item-reviewer-prompt.md`
-- `~/.degacore/scripts/planner-loop.sh`
 - `~/.degacore/scripts/canon-scaffold.sh`
 - `~/.degacore/scripts/canon.sh`
 - `~/.degacore/scripts/canon-runner.sh`
@@ -252,7 +248,6 @@ Read and note which of these already exist under `~/.degacore/`:
 - `~/.degacore/scripts/create-exec-plan.sh`
 - `~/.degacore/sounds/` (any files)
 - `~/.degacore/state/logs/`
-- `~/.degacore/state/planner/`
 - `~/.degacore/bin/canon-cli`
 - `~/.degacore/canon-cli/` (any files)
 
@@ -340,13 +335,6 @@ Components:
   `dega-core.yaml` (default 30). Requires Terminal UI and tmux. Invoke
   via `~/.degacore/scripts/orch-run.sh <slug>`.
   (opt-in; recommended when `~/.degacore/scripts/orch-run.sh` is missing)
-- **Planner** — autonomous planner loop that reads `focus.yaml`, assesses the
-  project, writes execution plans, and launches the orchestrator. Installs
-  `planner-loop.sh` to `~/.degacore/scripts/` and agent prompts
-  (`planner-assess.md`, `planner-writer.md`) to `~/.degacore/config/agents/`.
-  Requires Orchestrator. Invoke via
-  `~/.degacore/scripts/planner-loop.sh`.
-  (opt-in; recommended when `~/.degacore/scripts/planner-loop.sh` is missing)
 - **Canon Bootstrap** — launcher, scaffold scripts, project templates, and CLI
   for Canon prediction market projects. Installs `canon-scaffold.sh`
   (deterministic project scaffolder called by `/canon-start`), `canon.sh`
@@ -372,7 +360,7 @@ the GitHub URLs above. Extract the raw file content from each response.
 Create the `~/.degacore/` directory tree if it doesn't exist:
 
 ```bash
-mkdir -p ~/.degacore/{bin,config/{commands,skills,rules,agents},scripts/{adapters,hooks/{orch-lifecycle,stop},terminal-ui/src},state/{logs,planner},sounds,canon-cli/commands}
+mkdir -p ~/.degacore/{bin,config/{commands,skills,rules,agents},scripts/{adapters,hooks/{orch-lifecycle,stop},terminal-ui/src},state/logs,sounds,canon-cli/commands}
 ```
 
 Also install the agent-shim and adapter scripts (always, regardless of
@@ -587,20 +575,6 @@ rebuild it:
 ```bash
 cd ~/.degacore/scripts/terminal-ui && pnpm install && pnpm run build
 ```
-
-#### Planner
-
-Write the planner loop script:
-- `scripts/planner-loop.sh` -> `~/.degacore/scripts/planner-loop.sh`
-
-Run `chmod +x ~/.degacore/scripts/planner-loop.sh` after writing.
-
-Write the agent prompts:
-- `agents/planner-assess.md` -> `~/.degacore/config/agents/planner-assess.md`
-- `agents/planner-writer.md` -> `~/.degacore/config/agents/planner-writer.md`
-
-Safe to overwrite — these are engine scripts and agent definitions with no
-user customization.
 
 #### Canon Bootstrap
 
@@ -942,7 +916,6 @@ Installed to ~/.degacore/:
   Sounds -> sounds/ (MP3 + OGG) + scripts/hooks/play-sound.sh
   Terminal UI -> scripts/terminal-ui/ (built with pnpm)
   Orchestrator -> scripts/orch-*.sh + config/agents/ + scripts/hooks/
-  Planner -> scripts/planner-loop.sh + config/agents/
   Canon Bootstrap -> scripts/canon-scaffold.sh + scripts/canon.sh
   Canon CLI -> canon-cli/ (built) + bin/canon-cli (linked)
 

--- a/docs/agent-agnostic-architecture.md
+++ b/docs/agent-agnostic-architecture.md
@@ -94,7 +94,7 @@ to stay in sync.
 │   ├── commands/                     # apply-core, plan, fix-issue, etc.
 │   ├── rules/                        # python, node-typescript, rust, bash
 │   ├── skills/                       # app-legibility, custom-linter-authoring
-│   └── agents/                       # orch-worker, orch-verifier, planner-*
+│   └── agents/                       # orch-worker, orch-verifier, conductor
 ├── scripts/
 │   ├── agent-shim.sh                 # Provider abstraction layer
 │   ├── adapters/                     # claude-settings.sh, gemini-settings.sh, codex-settings.sh
@@ -123,5 +123,5 @@ Automatic — the shim detects the parent process. To override:
 export DEGA_PROVIDER=gemini
 ```
 
-Or simply run your scripts under the target agent's CLI. The orchestrator,
-planner, and all hooks adapt automatically.
+Or simply run your scripts under the target agent's CLI. The orchestrator
+and all hooks adapt automatically.

--- a/docs/self-development.md
+++ b/docs/self-development.md
@@ -1,7 +1,7 @@
 # Self-Development Guide
 
 How to apply fixes and new features to this repo. Covers the full lifecycle
-from plan to ship, using manual workflows, the orchestrator, or the planner loop.
+from plan to ship, using manual workflows or the orchestrator.
 
 ---
 
@@ -10,7 +10,7 @@ from plan to ship, using manual workflows, the orchestrator, or the planner loop
 Every change follows three steps:
 
 1. **Plan** — create an exec-plan with `/plan`
-2. **Implement** — work the plan (manually, orchestrator, or planner loop)
+2. **Implement** — work the plan (manually or via the orchestrator)
 3. **Ship** — review passes, plan archives to `completed/`, commit lands
 
 ```bash


### PR DESCRIPTION
The planner-loop component (`planner-loop.sh`, `planner-assess.md`, `planner-writer.md`) was removed from the repo, but the install surface and several user-facing docs still described it as a live, installable component. Re-running `/core-update` against an existing install would print three orphan-file warnings; new installs would never have these files but the install picker still offered a "Planner" component.

## What's changed

- `commands/apply-core.md` — drop the Planner component section, the fetch list entries, the inventory checks, the `state/planner` mkdir, and the post-install summary line
- `INSTALL.md` — remove planner from the agent-prompts cell
- `README.md` — drop planner from the multi-agent support sentence
- `agents/conductor.md` — drop planner from the delegation subagent list
- `docs/agent-agnostic-architecture.md` — drop `planner-*` from the layout diagram and the adapt-automatically sentence
- `docs/self-development.md` — drop the planner loop as a workflow option

Net: 6 files, +11 / −38, deletion-only.

## What's untouched

- `docs/agnostic-gem-recommendations.md` still references planner as part of an aspirational provider-shim design. That doc is forward-looking recommendations rather than current state, so left as-is.

## Verification

```bash
rg -i 'planner' INSTALL.md README.md agents/conductor.md commands/apply-core.md \
  docs/agent-agnostic-architecture.md docs/self-development.md
# → no output
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)