### PR TITLE
fix(runner): preserve nodes/edges DAG metadata in updateFlow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Runner writes active_since timestamp on active step change (`20260515-runner-active-since`) — 2026-05-15
 
 ### Fixed
+- Runner `updateFlow` preserves `nodes`/`edges` DAG metadata when rewriting `flow.json` (was dropped on the first step transition, breaking the automation panel) — 2026-06-15
 - Fix Codex-native skill installation in CORE installer (`20260605-codex-skill-install`) — 2026-06-05
 
 ## [0.1.10] — 2026-05-27

--- a/canon/templates/__tests__/runner-active-since.test.ts
+++ b/canon/templates/__tests__/runner-active-since.test.ts
@@ -107,3 +107,53 @@ describe("updateFlow — active_since timestamp", () => {
     );
   });
 });
+
+describe("updateFlow — preserves DAG metadata", () => {
+  const NODES = [
+    { id: "scan", label: "Scan", type: "build" },
+    { id: "execute", label: "Execute", type: "deploy" },
+  ];
+  const EDGES = [{ from: "scan", to: "execute" }];
+
+  function seedWithDag(active = ""): void {
+    seedFlow({ active });
+    const flow = JSON.parse(readFileSync(flowPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    flow["nodes"] = NODES;
+    flow["edges"] = EDGES;
+    writeFileSync(flowPath, JSON.stringify(flow, null, 2) + "\n");
+  }
+
+  function readRaw(): Record<string, unknown> {
+    return JSON.parse(readFileSync(flowPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+  }
+
+  it("keeps nodes and edges when active transitions to a new value", () => {
+    seedWithDag();
+
+    updateFlow(flowPath, "scan", []);
+
+    const flow = readRaw();
+    expect(flow["nodes"]).toEqual(NODES);
+    expect(flow["edges"]).toEqual(EDGES);
+    expect(flow["active"]).toBe("scan");
+  });
+
+  it("keeps nodes and edges across a full cycle including the empty-string reset", () => {
+    seedWithDag();
+
+    updateFlow(flowPath, "scan", []);
+    updateFlow(flowPath, "execute", ["scan"]);
+    updateFlow(flowPath, "", ["scan", "execute"]);
+
+    const flow = readRaw();
+    expect(flow["nodes"]).toEqual(NODES);
+    expect(flow["edges"]).toEqual(EDGES);
+    expect(flow["active"]).toBe("");
+  });
+});

--- a/canon/templates/runner.ts
+++ b/canon/templates/runner.ts
@@ -111,6 +111,11 @@ function logEntry(
  * Idempotent: a repeat call with the same `active` preserves the existing
  * `active_since`. When `active === ""`, `active_since` is omitted entirely
  * so the TUI's `.get("active_since", "")` reader treats the field as absent.
+ *
+ * All other fields in the file are preserved verbatim — the seeds carry
+ * `nodes`/`edges` DAG metadata that the canon-tui automation panel reads,
+ * so the write spreads the existing flow rather than rebuilding it from a
+ * fixed key set.
  */
 export function updateFlow(
   flowPath: string,
@@ -119,13 +124,10 @@ export function updateFlow(
 ): void {
   if (!existsSync(flowPath)) return;
   try {
-    const flow = JSON.parse(readFileSync(flowPath, "utf-8")) as {
-      steps: string[];
-      labels: Record<string, string>;
-      active: string;
-      completed: string[];
-      active_since?: string;
-    };
+    const flow = JSON.parse(readFileSync(flowPath, "utf-8")) as Record<
+      string,
+      unknown
+    > & { active?: string; active_since?: string };
 
     const activeSince =
       active === ""
@@ -134,19 +136,12 @@ export function updateFlow(
           ? flow.active_since
           : new Date().toISOString();
 
-    const next: {
-      steps: string[];
-      labels: Record<string, string>;
-      active: string;
-      completed: string[];
-      active_since?: string;
-    } = {
-      steps: flow.steps,
-      labels: flow.labels,
-      active,
-      completed,
-      ...(activeSince !== undefined ? { active_since: activeSince } : {}),
-    };
+    const next: Record<string, unknown> = { ...flow, active, completed };
+    if (activeSince === undefined) {
+      delete next["active_since"];
+    } else {
+      next["active_since"] = activeSince;
+    }
 
     writeFileSync(flowPath, JSON.stringify(next, null, 2) + "\n");
   } catch {


### PR DESCRIPTION
The combined-release review of develop→main (#360) surfaced an integration bug between #341 and #342:

- #342 added `nodes`/`edges` DAG metadata to the strategy `flow.json` seeds.
- #341 rewrote `updateFlow()` to rebuild the flow object from a fixed key set (`steps`, `labels`, `active`, `completed`, `active_since`).

Result: the first runner cycle rewrites `flow.json` without `nodes`/`edges`, wiping the DAG metadata the canon-tui automation panel reads — so the feature this release ships breaks at runtime.

## Fix
Spread the existing flow and override only `active`/`completed`/`active_since`, preserving `nodes`/`edges` (and any other fields).

## Tests
Two regression tests assert `nodes`/`edges` survive a step transition and a full cycle (incl. the empty-string reset). Verified they fail against the prior implementation. `npm run check` (tsc + oxlint + vitest, 851 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)