### PR TITLE
fix(runner): stamp active_since on legacy same-step update

### DIFF
--- a/canon/templates/__tests__/runner-active-since.test.ts
+++ b/canon/templates/__tests__/runner-active-since.test.ts
@@ -106,6 +106,17 @@ describe("updateFlow — active_since timestamp", () => {
       false,
     );
   });
+
+  it("stamps active_since on a same-step update when a legacy file lacks it", () => {
+    seedFlow({ active: "scan", completed: [] });
+
+    updateFlow(flowPath, "scan", []);
+
+    const flow = readFlow();
+    expect(flow.active).toBe("scan");
+    expect(flow.active_since).toBeDefined();
+    expect(flow.active_since).toMatch(ISO_8601_UTC);
+  });
 });
 
 describe("updateFlow — preserves DAG metadata", () => {

--- a/canon/templates/runner.ts
+++ b/canon/templates/runner.ts
@@ -109,8 +109,10 @@ function logEntry(
  * timestamp whenever `active` transitions to a new non-empty value.
  *
  * Idempotent: a repeat call with the same `active` preserves the existing
- * `active_since`. When `active === ""`, `active_since` is omitted entirely
- * so the TUI's `.get("active_since", "")` reader treats the field as absent.
+ * `active_since`, or stamps a fresh one if the file was already active but
+ * missing the field (legacy/upgrade recovery). When `active === ""`,
+ * `active_since` is omitted entirely so the TUI's `.get("active_since", "")`
+ * reader treats the field as absent.
  *
  * All other fields in the file are preserved verbatim — the seeds carry
  * `nodes`/`edges` DAG metadata that the canon-tui automation panel reads,
@@ -133,7 +135,7 @@ export function updateFlow(
       active === ""
         ? undefined
         : active === flow.active
-          ? flow.active_since
+          ? (flow.active_since ?? new Date().toISOString())
           : new Date().toISOString();
 
     const next: Record<string, unknown> = { ...flow, active, completed };


### PR DESCRIPTION
Follow-up from the #360 release re-review (codex P3).

When upgrading from a `flow.json` that is already `active` but lacks `active_since`, a same-step `updateFlow` call preserved `undefined` and deleted the field — the TUI had no start timestamp for the current step until the next transition. Now stamps a fresh ISO timestamp when the existing one is absent.

Regression test added (verified failing against prior logic). `npm run check` passes (847 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)